### PR TITLE
Adjust boost gil header paths for boost 1.69

### DIFF
--- a/src/colour_button.cpp
+++ b/src/colour_button.cpp
@@ -18,7 +18,11 @@
 
 #include "dialogs.h"
 
+#if (BOOST_VERSION / 100000) <= 1 && ((BOOST_VERSION / 100) % 1000) <= 67
 #include <boost/gil/gil_all.hpp>
+#else
+#include <boost/gil.hpp>
+#endif
 
 AGI_DEFINE_EVENT(EVT_COLOR, agi::Color);
 

--- a/src/subtitles_provider_libass.cpp
+++ b/src/subtitles_provider_libass.cpp
@@ -46,7 +46,11 @@
 #include <libaegisub/util.h>
 
 #include <atomic>
+#if (BOOST_VERSION / 100000) <= 1 && ((BOOST_VERSION / 100) % 1000) <= 67
 #include <boost/gil/gil_all.hpp>
+#else
+#include <boost/gil.hpp>
+#endif
 #include <memory>
 #include <mutex>
 

--- a/src/video_frame.cpp
+++ b/src/video_frame.cpp
@@ -16,7 +16,11 @@
 
 #include "video_frame.h"
 
+#if (BOOST_VERSION / 100000) <= 1 && ((BOOST_VERSION / 100) % 1000) <= 67
 #include <boost/gil/gil_all.hpp>
+#else
+#include <boost/gil.hpp>
+#endif
 #include <wx/image.h>
 
 namespace {

--- a/src/video_provider_dummy.cpp
+++ b/src/video_provider_dummy.cpp
@@ -45,7 +45,11 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/filesystem/path.hpp>
 #include <libaegisub/format.h>
+#if (BOOST_VERSION / 100000) <= 1 && ((BOOST_VERSION / 100) % 1000) <= 67
 #include <boost/gil/gil_all.hpp>
+#else
+#include <boost/gil.hpp>
+#endif
 
 DummyVideoProvider::DummyVideoProvider(double fps, int frames, int width, int height, agi::Color colour, bool pattern)
 : framecount(frames)


### PR DESCRIPTION
boost/gil.hpp was added in 1.68 and boost/gil/gil_all.hpp removed in 1.69.

Builds for me on 1.69.

1.68 was released in August 2018, which was 5 months ago. It's not been long enough to skip the `#if` check.