### PR TITLE
Fix git_version.h generation

### DIFF
--- a/tools/version.sh
+++ b/tools/version.sh
@@ -1,8 +1,8 @@
 srcdir="$1"
 
 # If no git repo try to read from the existing git_version.h, for building from tarballs
+version_h_path="${srcdir}/git_version.h"
 if ! test -d "${srcdir}/.git"; then
-  version_h_path="${srcdir}/build/git_version.h"
   if test -f "${version_h_path}"; then
     while read line; do
       set -- $line
@@ -52,9 +52,6 @@ new_version_h="\
 #define INSTALLER_VERSION \"${installer_version}\"
 #define RESOURCE_BASE_VERSION ${resource_version}"
 
-# may not exist yet for out of tree builds
-mkdir -p build
-version_h_path="build/git_version.h"
 
 # Write it only if it's changed to avoid spurious rebuilds
 # This bizzare comparison method is due to that newlines in shell variables are very exciting
@@ -68,7 +65,7 @@ export BUILD_GIT_VERSION_NUMBER="${git_revision}"
 export BUILD_GIT_VERSION_STRING="${git_version_str}"
 export VERSION_SOURCE="from git"
 
-cat << EOF > build/git_version.xml
+cat << EOF > "${srcdir}/git_version.xml"
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>

--- a/tools/version.sh
+++ b/tools/version.sh
@@ -24,7 +24,7 @@ fi
 last_svn_revision=6962
 last_svn_hash="16cd907fe7482cb54a7374cd28b8501f138116be"
 
-git_revision=$(expr $last_svn_revision + $(git log --pretty=oneline $last_svn_hash..HEAD 2>/dev/null | wc -l))
+git_revision=$(expr $last_svn_revision + $(git rev-list --count $last_svn_hash..HEAD))
 git_version_str=$(git describe --exact-match 2> /dev/null)
 installer_version='0.0.0'
 resource_version='0, 0, 0'


### PR DESCRIPTION
It was generated in the `build` directory and not in the root where the include points to. I don't know if this is the "intended" target directory, but it kind of makes sense. I also don't know where or how the xml file is used, but I "fixed" its path as well.

I also added a commit I did long ago to use the proper git command for the revision number.