### PR TITLE
Correct unused parameter in wxStyledTextCtrl::StartStyling

### DIFF
--- a/src/dialog_fonts_collector.cpp
+++ b/src/dialog_fonts_collector.cpp
@@ -400,7 +400,7 @@ void DialogFontsCollector::OnAddText(ValueEvent<color_str_pair> &event) {
 	auto const& utf8 = str.second.utf8_str();
 	collection_log->AppendTextRaw(utf8.data(), utf8.length());
 	if (str.first) {
-		collection_log->StartStyling(pos, 31);
+		collection_log->StartStyling(pos, 0);
 		collection_log->SetStyling(utf8.length(), str.first);
 	}
 	collection_log->GotoPos(pos + utf8.length());

--- a/src/dialog_translation.cpp
+++ b/src/dialog_translation.cpp
@@ -246,7 +246,7 @@ void DialogTranslation::UpdateDisplay() {
 			int initial_pos = original_text->GetLength();
 			original_text->AppendTextRaw(block->GetText().c_str());
 			if (i == cur_block) {
-				original_text->StartStyling(initial_pos, 31);
+				original_text->StartStyling(initial_pos, 0);
 				original_text->SetStyling(block->GetText().size(), 1);
 			}
 		}

--- a/src/subs_edit_ctrl.cpp
+++ b/src/subs_edit_ctrl.cpp
@@ -261,7 +261,7 @@ void SubsTextEditCtrl::UpdateStyle() {
 	cursor_pos = -1;
 	UpdateCallTip();
 
-	StartStyling(0,255);
+	StartStyling(0, 0);
 
 	if (!OPT_GET("Subtitle/Highlight/Syntax")->GetBool()) {
 		SetStyling(line_text.size(), 0);


### PR DESCRIPTION
In wxWidgets >= 3.1, this trips an assertion when it's not zero.
Removing it would break compatibility with 3.0.