### PR TITLE
Add option to customize the Play selection commands

### DIFF
--- a/src/command/audio.cpp
+++ b/src/command/audio.cpp
@@ -266,9 +266,6 @@ struct audio_stop final : public Command {
 struct audio_play_before final : public validate_audio_open {
 	CMD_NAME("audio/play/selection/before")
 	CMD_ICON(button_playfivehbefore)
-	/*STR_MENU("Play 500 ms before selection")
-	STR_DISP("Play 500 ms before selection")
-	STR_HELP("Play 500 ms before selection")*/
 	CMD_TYPE(COMMAND_VALIDATE | COMMAND_DYNAMIC_NAME | COMMAND_DYNAMIC_HELP)
 	
 	wxString StrMenu(const agi::Context* c) const override {
@@ -291,9 +288,6 @@ struct audio_play_before final : public validate_audio_open {
 struct audio_play_after final : public validate_audio_open {
 	CMD_NAME("audio/play/selection/after")
 	CMD_ICON(button_playfivehafter)
-	//STR_MENU("Play 500 ms after selection")
-	//STR_DISP("Play 500 ms after selection")
-	//STR_HELP("Play 500 ms after selection")
 	CMD_TYPE(COMMAND_VALIDATE | COMMAND_DYNAMIC_NAME | COMMAND_DYNAMIC_HELP)
 
 	wxString StrMenu(const agi::Context* c) const override {
@@ -316,9 +310,6 @@ struct audio_play_after final : public validate_audio_open {
 struct audio_play_end final : public validate_audio_open {
 	CMD_NAME("audio/play/selection/end")
 	CMD_ICON(button_playlastfiveh)
-	//STR_MENU("Play last 500 ms of selection")
-	//STR_DISP("Play last 500 ms of selection")
-	//STR_HELP("Play last 500 ms of selection")
 	CMD_TYPE(COMMAND_VALIDATE | COMMAND_DYNAMIC_NAME | COMMAND_DYNAMIC_HELP)
 
 	wxString StrMenu(const agi::Context* c) const override {
@@ -341,10 +332,6 @@ struct audio_play_end final : public validate_audio_open {
 struct audio_play_begin final : public validate_audio_open {
 	CMD_NAME("audio/play/selection/begin")
 	CMD_ICON(button_playfirstfiveh)
-	//STR_MENU("Play first 500 ms of selection")
-	//STR_DISP("Play first 500 ms of selection")
-	//STR_HELP("Play first 500 ms of selection")
-
 	CMD_TYPE(COMMAND_VALIDATE | COMMAND_DYNAMIC_NAME | COMMAND_DYNAMIC_HELP)
 
 	wxString StrMenu(const agi::Context* c) const override {

--- a/src/command/audio.cpp
+++ b/src/command/audio.cpp
@@ -49,6 +49,7 @@
 #include <libaegisub/audio/provider.h>
 #include <libaegisub/make_unique.h>
 #include <libaegisub/io.h>
+#include <format.h>
 
 namespace {
 	using cmd::Command;
@@ -265,58 +266,101 @@ struct audio_stop final : public Command {
 struct audio_play_before final : public validate_audio_open {
 	CMD_NAME("audio/play/selection/before")
 	CMD_ICON(button_playfivehbefore)
-	STR_MENU("Play 500 ms before selection")
+	/*STR_MENU("Play 500 ms before selection")
 	STR_DISP("Play 500 ms before selection")
-	STR_HELP("Play 500 ms before selection")
+	STR_HELP("Play 500 ms before selection")*/
+	CMD_TYPE(COMMAND_VALIDATE | COMMAND_DYNAMIC_NAME | COMMAND_DYNAMIC_HELP)
+	
+	wxString StrMenu(const agi::Context* c) const override {
+		return fmt_tl("Play %d ms before selection", OPT_GET("Audio/Play Selection Duration/Before")->GetInt());
+	}
+	wxString StrDisplay(const agi::Context* c) const override {
+		return fmt_tl("Play %d ms before selection", OPT_GET("Audio/Play Selection Duration/Before")->GetInt());
+	}
+	wxString StrHelp() const override {
+		return fmt_tl("Play %d ms before selection", OPT_GET("Audio/Play Selection Duration/Before")->GetInt());
+	}
 
 	void operator()(agi::Context *c) override {
 		c->videoController->Stop();
 		int begin = c->audioController->GetPrimaryPlaybackRange().begin();
-		c->audioController->PlayRange(TimeRange(begin - 500, begin));
+		c->audioController->PlayRange(TimeRange(begin - OPT_GET("Audio/Play Selection Duration/Before")->GetInt(), begin));
 	}
 };
 
 struct audio_play_after final : public validate_audio_open {
 	CMD_NAME("audio/play/selection/after")
 	CMD_ICON(button_playfivehafter)
-	STR_MENU("Play 500 ms after selection")
-	STR_DISP("Play 500 ms after selection")
-	STR_HELP("Play 500 ms after selection")
+	//STR_MENU("Play 500 ms after selection")
+	//STR_DISP("Play 500 ms after selection")
+	//STR_HELP("Play 500 ms after selection")
+	CMD_TYPE(COMMAND_VALIDATE | COMMAND_DYNAMIC_NAME | COMMAND_DYNAMIC_HELP)
+
+	wxString StrMenu(const agi::Context* c) const override {
+		return fmt_tl("Play %d ms after selection", OPT_GET("Audio/Play Selection Duration/After")->GetInt());
+	}
+	wxString StrDisplay(const agi::Context* c) const override {
+		return fmt_tl("Play %d ms after selection", OPT_GET("Audio/Play Selection Duration/Before")->GetInt());
+	}
+	wxString StrHelp() const override {
+		return fmt_tl("Play %d ms after selection", OPT_GET("Audio/Play Selection Duration/After")->GetInt());
+	}
 
 	void operator()(agi::Context *c) override {
 		c->videoController->Stop();
 		int end = c->audioController->GetPrimaryPlaybackRange().end();
-		c->audioController->PlayRange(TimeRange(end, end + 500));
+		c->audioController->PlayRange(TimeRange(end, end + OPT_GET("Audio/Play Selection Duration/After")->GetInt()));
 	}
 };
 
 struct audio_play_end final : public validate_audio_open {
 	CMD_NAME("audio/play/selection/end")
 	CMD_ICON(button_playlastfiveh)
-	STR_MENU("Play last 500 ms of selection")
-	STR_DISP("Play last 500 ms of selection")
-	STR_HELP("Play last 500 ms of selection")
+	//STR_MENU("Play last 500 ms of selection")
+	//STR_DISP("Play last 500 ms of selection")
+	//STR_HELP("Play last 500 ms of selection")
+	CMD_TYPE(COMMAND_VALIDATE | COMMAND_DYNAMIC_NAME | COMMAND_DYNAMIC_HELP)
+
+	wxString StrMenu(const agi::Context* c) const override {
+		return fmt_tl("Play last %d ms of selection", OPT_GET("Audio/Play Selection Duration/End")->GetInt());
+	}
+	wxString StrDisplay(const agi::Context* c) const override {
+		return fmt_tl("Play last %d ms of selection", OPT_GET("Audio/Play Selection Duration/End")->GetInt());
+	}
+	wxString StrHelp() const override {
+		return fmt_tl("Play last %d ms of selection", OPT_GET("Audio/Play Selection Duration/End")->GetInt());
+	}
 
 	void operator()(agi::Context *c) override {
 		c->videoController->Stop();
 		TimeRange times(c->audioController->GetPrimaryPlaybackRange());
-		c->audioController->PlayToEndOfPrimary(times.end() - std::min(500, times.length()));
+		c->audioController->PlayToEndOfPrimary(times.end() - std::min((int)OPT_GET("Audio/Play Selection Duration/End")->GetInt(), times.length()));
 	}
 };
 
 struct audio_play_begin final : public validate_audio_open {
 	CMD_NAME("audio/play/selection/begin")
 	CMD_ICON(button_playfirstfiveh)
-	STR_MENU("Play first 500 ms of selection")
-	STR_DISP("Play first 500 ms of selection")
-	STR_HELP("Play first 500 ms of selection")
+	//STR_MENU("Play first 500 ms of selection")
+	//STR_DISP("Play first 500 ms of selection")
+	//STR_HELP("Play first 500 ms of selection")
+
+	CMD_TYPE(COMMAND_VALIDATE | COMMAND_DYNAMIC_NAME | COMMAND_DYNAMIC_HELP)
+
+	wxString StrMenu(const agi::Context* c) const override {
+		return fmt_tl("Play first %d ms of selection", OPT_GET("Audio/Play Selection Duration/Begin")->GetInt());
+	}
+	wxString StrDisplay(const agi::Context* c) const override {
+		return fmt_tl("Play first %d ms of selection", OPT_GET("Audio/Play Selection Duration/Begin")->GetInt());
+	}
+	wxString StrHelp() const override {
+		return fmt_tl("Play first %d ms of selection", OPT_GET("Audio/Play Selection Duration/Begin")->GetInt());
+	}
 
 	void operator()(agi::Context *c) override {
 		c->videoController->Stop();
 		TimeRange times(c->audioController->GetPrimaryPlaybackRange());
-		c->audioController->PlayRange(TimeRange(
-			times.begin(),
-			times.begin() + std::min(500, times.length())));
+		c->audioController->PlayRange(TimeRange(times.begin(), times.begin() + std::min((int)OPT_GET("Audio/Play Selection Duration/Begin")->GetInt(), times.length())));
 	}
 };
 

--- a/src/libresrc/default_config.json
+++ b/src/libresrc/default_config.json
@@ -64,6 +64,12 @@
 		"Lock Scroll on Cursor" : false,
 		"Medusa Timing Hotkeys" : false,
 		"Next Line on Commit" : true,
+		"Play Selection Duration" : {
+			"After" : 500,
+			"Before" : 500,
+			"Begin" : 500,
+			"End" : 500
+		},
 		"Player" : "",
 		"Plays When Stepping Video" : false,
 		"Provider" : "ffmpegsource",

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -135,6 +135,10 @@ void Audio(wxTreebook *book, Preferences *parent) {
 	p->OptionAdd(general, _("Default timing length (ms)"), "Timing/Default Duration", 0, 36000);
 	p->OptionAdd(general, _("Default lead-in length (ms)"), "Audio/Lead/IN", 0, 36000);
 	p->OptionAdd(general, _("Default lead-out length (ms)"), "Audio/Lead/OUT", 0, 36000);
+	p->OptionAdd(general, _("Play after length (ms)"), "Audio/Play Selection Duration/After", 0, 36000);
+	p->OptionAdd(general, _("Play before length (ms)"), "Audio/Play Selection Duration/Before", 0, 36000);
+	p->OptionAdd(general, _("Play from beginning length (ms)"), "Audio/Play Selection Duration/Begin", 0, 36000);
+	p->OptionAdd(general, _("Play before end length (ms)"), "Audio/Play Selection Duration/End", 0, 36000);
 
 	p->OptionAdd(general, _("Marker drag-start sensitivity (px)"), "Audio/Start Drag Sensitivity", 1, 15);
 	p->OptionAdd(general, _("Line boundary thickness (px)"), "Audio/Line Boundaries Thickness", 1, 5);

--- a/src/toolbar.cpp
+++ b/src/toolbar.cpp
@@ -71,6 +71,12 @@ namespace {
 		/// Listener for hotkey change signal
 		agi::signal::Connection hotkeys_changed_slot;
 
+		/// Listeners for duration changed for the 4 play options
+		agi::signal::Connection audio_play_before_changed_duration;
+		agi::signal::Connection audio_play_after_changed_duration;
+		agi::signal::Connection audio_play_begin_changed_duration;
+		agi::signal::Connection audio_play_end_changed_duration;
+
 		/// Enable/disable the toolbar buttons
 		void OnIdle(wxIdleEvent &) {
 			for (size_t i = 0; i < commands.size(); ++i) {
@@ -174,6 +180,10 @@ namespace {
 		, icon_size(OPT_GET("App/Toolbar Icon Size")->GetInt())
 		, icon_size_slot(OPT_SUB("App/Toolbar Icon Size", &Toolbar::OnIconSizeChange, this))
 		, hotkeys_changed_slot(hotkey::inst->AddHotkeyChangeListener(&Toolbar::RegenerateToolbar, this))
+		, audio_play_before_changed_duration(OPT_SUB("Audio/Play Selection Duration/Before", &Toolbar::RegenerateToolbar, this))
+		, audio_play_after_changed_duration(OPT_SUB("Audio/Play Selection Duration/After", &Toolbar::RegenerateToolbar, this))
+		, audio_play_begin_changed_duration(OPT_SUB("Audio/Play Selection Duration/Begin", &Toolbar::RegenerateToolbar, this))
+		, audio_play_end_changed_duration(OPT_SUB("Audio/Play Selection Duration/End", &Toolbar::RegenerateToolbar, this))
 		{
 			Populate();
 			Bind(wxEVT_TOOL, &Toolbar::OnClick, this);
@@ -196,6 +206,10 @@ namespace {
 		}))
 #endif
 		, hotkeys_changed_slot(hotkey::inst->AddHotkeyChangeListener(&Toolbar::RegenerateToolbar, this))
+		, audio_play_before_changed_duration(OPT_SUB("Audio/Play Selection Duration/Before", &Toolbar::RegenerateToolbar, this))
+		, audio_play_after_changed_duration(OPT_SUB("Audio/Play Selection Duration/After", &Toolbar::RegenerateToolbar, this))
+		, audio_play_begin_changed_duration(OPT_SUB("Audio/Play Selection Duration/Begin", &Toolbar::RegenerateToolbar, this))
+		, audio_play_end_changed_duration(OPT_SUB("Audio/Play Selection Duration/End", &Toolbar::RegenerateToolbar, this))
 		{
 			parent->SetToolBar(this);
 			Populate();


### PR DESCRIPTION
Add the possibility to configure the duration of the following commands:
- audio/play/selection/before
- audio/play/selection/after
- audio/play/selection/end
- audio/play/selection/begin

Those were hardcoded to 500ms and there might be use cases where a different duration might be useful