### PR TITLE
meson: Apply Lua 5.2 compat flags to both native and non-native builds

### DIFF
--- a/subprojects/luajit/meson.build
+++ b/subprojects/luajit/meson.build
@@ -7,21 +7,23 @@ system_deps = [
     cc.find_library('m', required: false)
 ]
 
-add_project_arguments('-DLUAJIT_ENABLE_LUA52COMPAT', language: 'c')
+# compat flag is needed for both the buildvm code generator (compiled natively) and luajit itself
+add_project_arguments('-DLUAJIT_ENABLE_LUA52COMPAT', language: 'c', native: true)
+add_project_arguments('-DLUAJIT_ENABLE_LUA52COMPAT', language: 'c', native: false)
 if host_machine.system() == 'linux'
-    add_project_arguments('-DLUAJIT_OS=LUAJIT_OS_LINUX', language: 'c')
+    add_project_arguments('-DLUAJIT_OS=LUAJIT_OS_LINUX', language: 'c', native: true)
     readline_dep = cc.find_library('readline')
     ljvm_mode = 'elfasm'
     ljvm_bout = 'lj_vm.s'
 elif host_machine.system() == 'darwin'
-    add_project_arguments(['-DLUAJIT_OS=LUAJIT_OS_OSX'], language: 'c')
+    add_project_arguments(['-DLUAJIT_OS=LUAJIT_OS_OSX'], language: 'c', native: true)
     readline_dep = cc.find_library('readline')
     ljvm_mode = 'machasm'
     ljvm_bout = 'lj_vm.s'
 elif host_machine.system() == 'windows'
-    add_project_arguments('-DLUAJIT_OS=LUAJIT_OS_WINDOWS', language: 'c')
+    add_project_arguments('-DLUAJIT_OS=LUAJIT_OS_WINDOWS', language: 'c', native: true)
     if cc.get_id() != 'msvc'
-        add_project_arguments('-malign-double', language: 'c')
+        add_project_arguments('-malign-double', language: 'c', native: true)
     endif
     readline_dep = []
     ljvm_mode = 'peobj'


### PR DESCRIPTION
This pull request intentionally solves this in the dumbest and ugliest way possible in order to force Ryan to come up with something better (or alternatively conclude that this is actually the way to do it).