### PR TITLE
Fix mutation while iterating corrupting linked list in block_cache.h

### DIFF
--- a/src/block_cache.h
+++ b/src/block_cache.h
@@ -91,7 +91,6 @@ class DataBlockCache {
 		size -= (ba.size() - std::count(ba.begin(), ba.end(), nullptr)) * factory.GetBlockSize();
 
 		ba.clear();
-		age.erase(mb.position);
 	}
 
 public:
@@ -150,8 +149,16 @@ public:
 		}
 
 		// Remove old entries until we're under the max size
-		for (auto it = age.rbegin(); size > max_size && it != age.rend(); it++)
+		auto it = age.end();
+		while (size > max_size) {
+			if (it == age.begin())
+				break;
+			it--;
 			KillMacroBlock(**it);
+		}
+
+		while (it != age.end())
+			it = age.erase(it);
 	}
 
 	/// @brief Obtain a data block from the cache


### PR DESCRIPTION
This fixes a segmentation fault that can be reliably reproduced on my Arch installation by loading a decently long audio clip in Aegisub and then quickly scrolling in the audio view. Though I'm not sure on the details myself, I can only assume that the issue stems from the call to `list::erase` in an unsafe way while iterating over a linked list.

To illustrate the issue, consider the following code, which first prints out the whole list, and then prints out each element as it is processed by `KillMacroBlock`:

```cpp
for (auto it = age.rbegin(); it != age.rend(); it++) {
    std::cout << *it << std::endl;
}

std::cout << "=======" << std::endl;

for (auto it = age.rbegin(); size > max_size && it != age.rend(); ) {
    MacroBlock *elem = *it;
    std::cout << elem << std::endl;
    it++;
    KillMacroBlock(*elem);
}
```

One example output of this for me is

```
0x555835f17d10
0x555835f17d30
0x555835f17d50
0x555835f17d70
[...]
=======
0x555835f17d10
0x7000700070007
```

illustrating that either the list or the iterator is getting corrupted somehow by the call to `KillMacroBlock`.

My solution to safely deleting the affected elements is to use a standard forward iterator rather than a reverse iterator, work backwards from the end to free each element in turn without deleting them from the list, and then afterwards loop forwards, deleting the elements using the standard `list::erase(iterator)` method.

There are [other, less verbose approaches to deleting elements with a reverse iterator](https://stackoverflow.com/questions/1830158/how-to-call-erase-with-a-reverse-iterator), but the solutions given here range from black magic, to unclear whether they are safe in a `for` loop, to apparently broken. Though it may be worth looking into these in more detail and finding an approach that would work in this case.

**Note**: Moving the `list::erase` call to outside `KillMacroBlock` slightly changes the behaviour in that empty `MacroBlock`s will be removed as well. It is unclear to me whether this makes any practical difference.

**Note 2**: Only tested against the `meson` branch.