### PR TITLE
meson: set _DEBUG on all platforms for debug builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -45,6 +45,10 @@ if host_machine.system() == 'windows'
     add_project_arguments('-DNOMINMAX', '-D_WIN32_WINNT=0x0602', language: 'cpp')
 endif
 
+if get_option('debug')
+    add_project_arguments('-D_DEBUG', language: 'cpp')
+endif
+
 conf = configuration_data()
 conf.set_quoted('P_DATA', dataroot)
 if get_option('credit') != ''


### PR DESCRIPTION
Mostly just enables logging to stdout and what appears to be some sanity checking of the Lua stack, as well as adds `[DEBUG]` to the window title.