### PR TITLE
Fix two wx assertions

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -120,17 +120,21 @@ else
     wx = cmake.subproject('wxWidgets', cmake_options: ['-DwxBUILD_INSTALL=OFF',
                                                        '-DwxBUILD_PRECOMP=OFF', # otherwise breaks project generation w/ meson
                                                        '-DwxBUILD_SHARED=@0@'.format(build_shared),
+                                                       '-DwxUSE_WEBVIEW=OFF', # breaks build on linux
                                                        '-DwxBUILD_MONOLITHIC=ON']) # otherwise breaks project generation w/ meson
     deps += [
         wx.dependency('wxmono'),
-        wx.dependency('wxzlib'),
-        wx.dependency('wxpng'),
-        wx.dependency('wxexpat'),
         wx.dependency('wxregex'),
         wx.dependency('wxscintilla')
     ]
 
     if host_machine.system() == 'windows'
+        deps += [
+            wx.dependency('wxzlib'),
+            wx.dependency('wxpng'),
+            wx.dependency('wxexpat')
+        ]
+
         if cc.has_header('rpc.h')
             deps += cc.find_library('rpcrt4', required: true)
         else

--- a/src/dialog_fonts_collector.cpp
+++ b/src/dialog_fonts_collector.cpp
@@ -400,7 +400,11 @@ void DialogFontsCollector::OnAddText(ValueEvent<color_str_pair> &event) {
 	auto const& utf8 = str.second.utf8_str();
 	collection_log->AppendTextRaw(utf8.data(), utf8.length());
 	if (str.first) {
-		collection_log->StartStyling(pos, 31);
+#if wxVERSION_NUMBER >= 3100
+		collection_log->StartStyling(pos);
+#else
+		collection_log->StartStyling(pos, 255);
+#endif
 		collection_log->SetStyling(utf8.length(), str.first);
 	}
 	collection_log->GotoPos(pos + utf8.length());

--- a/src/dialog_translation.cpp
+++ b/src/dialog_translation.cpp
@@ -246,7 +246,11 @@ void DialogTranslation::UpdateDisplay() {
 			int initial_pos = original_text->GetLength();
 			original_text->AppendTextRaw(block->GetText().c_str());
 			if (i == cur_block) {
-				original_text->StartStyling(initial_pos, 31);
+#if wxVERSION_NUMBER >= 3100
+				original_text->StartStyling(initial_pos);
+#else
+				original_text->StartStyling(initial_pos, 255);
+#endif
 				original_text->SetStyling(block->GetText().size(), 1);
 			}
 		}

--- a/src/frame_main.cpp
+++ b/src/frame_main.cpp
@@ -240,8 +240,12 @@ void FrameMain::SetDisplayMode(int video, int audio) {
 	TopSizer->Show(videoBox, showVideo, true);
 	ToolsSizer->Show(audioBox, showAudio, true);
 
-	MainSizer->CalcMin();
+	auto min_size = MainSizer->CalcMin();
+#if wxVERSION_NUMBER >= 3103
+	MainSizer->RepositionChildren(min_size);
+#else
 	MainSizer->RecalcSizes();
+#endif
 	MainSizer->Layout();
 	Layout();
 

--- a/src/subs_edit_ctrl.cpp
+++ b/src/subs_edit_ctrl.cpp
@@ -261,7 +261,11 @@ void SubsTextEditCtrl::UpdateStyle() {
 	cursor_pos = -1;
 	UpdateCallTip();
 
-	StartStyling(0,255);
+#if wxVERSION_NUMBER >= 3100
+	StartStyling(0);
+#else
+	StartStyling(0, 255);
+#endif
 
 	if (!OPT_GET("Subtitle/Highlight/Syntax")->GetBool()) {
 		SetStyling(line_text.size(), 0);


### PR DESCRIPTION
On Linux a bunch of GTK errors/warnings are still printed to the console but I'm not particularly worried about them at the moment. The application itself seems to work.

I tested building on Windows too, and the assertions are gone, though it crashed for me whenever I tried to load a video. I don't think that's related to this, though.