### PR TITLE
Fix build on MacOS

### DIFF
--- a/src/audio_renderer_spectrum.cpp
+++ b/src/audio_renderer_spectrum.cpp
@@ -215,7 +215,7 @@ void AudioSpectrumRenderer::Render(wxBitmap &bmp, int start, AudioRenderingStyle
 		return;
 
 	assert(bmp.IsOk());
-	assert(bmp.GetDepth() == 24);
+	assert(bmp.GetDepth() == 24 || bmp.GetDepth() == 32);
 
 	int end = start + bmp.GetWidth();
 

--- a/subprojects/luajit/meson.build
+++ b/subprojects/luajit/meson.build
@@ -37,5 +37,11 @@ incdir = include_directories('include')
 
 subdir('src')
 
+luajit_link_args = []
+if host_machine.system() == 'darwin'
+	luajit_link_args = ['pagezero_size', '10000', '-image_base', '100000000']
+endif
+
 luajit_dep = declare_dependency(link_with: luajit_lib,
+                                link_args: luajit_link_args,
                                 include_directories: incdir)

--- a/subprojects/packagefiles/boost/libs/locale/meson.build
+++ b/subprojects/packagefiles/boost/libs/locale/meson.build
@@ -64,6 +64,10 @@ endif
 if not cpp.check_header('iconv.h')
     locale_deps += dependency('iconv')
 endif
+iconv_dep = cpp.find_library('iconv', required: false)
+if iconv_dep.found()
+    locale_deps += iconv_dep
+endif
 locale_args += '-DBOOST_LOCALE_WITH_ICONV=1'
 
 locale_deps += icu_deps


### PR DESCRIPTION
Fix boost_locale build with host iconv.

Add needed link arguments for 64-bit luajit build.

Fix the spectrum audio renderer. wxBitmap is forced to 32-bits on OSX. wxImage doesn't have an alpha channel by default, so the rest of the operations don't need to be adjusted.

Built Aegisub.app with:
```
meson build -Dbuild_osx_bundle=true -Dffmpeg:gpl=enabled -Dffmpeg:version3=enabled -Ddefault_library=static
# create build/osx-bundle.sed out of packages/osx_bundle/osx-bundle.sed.in
ninja -C buld osx-bundle
```