### PR TITLE
meson: improve iconv detection

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -77,10 +77,13 @@ cxx = meson.get_compiler('cpp')
 cc = meson.get_compiler('c')
 deps += cc.find_library('m', required: false)
 deps += cc.find_library('dl', required: false)
-if not cxx.check_header('iconv.h')
+
+iconv_dep = cc.find_library('iconv', required: false)
+if not (iconv_dep.found() or cc.has_function('iconv_open'))
     iconv_sp = subproject('iconv') # this really needs to be replaced with a proper port
-    deps += iconv_sp.get_variable('libiconv_dep')
+    iconv_dep = iconv_sp.get_variable('libiconv_dep')
 endif
+deps += iconv_dep
 
 deps += dependency('libass', version: '>=0.9.7',
                    fallback: ['libass', 'libass_dep'])

--- a/subprojects/packagefiles/boost/libs/locale/meson.build
+++ b/subprojects/packagefiles/boost/libs/locale/meson.build
@@ -61,9 +61,12 @@ else
     locale_args += '-DBOOST_LOCALE_NO_WINAPI_BACKEND=1'
 endif
 
-if not cpp.check_header('iconv.h')
-    locale_deps += dependency('iconv')
+cxx = meson.get_compiler('cpp')
+iconv_dep = cxx.find_library('iconv', required: false)
+if not (iconv_dep.found() or cxx.has_function('iconv_open'))
+    iconv_dep = dependency('iconv')
 endif
+locale_deps += iconv_dep
 locale_args += '-DBOOST_LOCALE_WITH_ICONV=1'
 
 locale_deps += icu_deps


### PR DESCRIPTION
Inspired by #105, but with more robust logic and applied across the build. Should match what the libass port is doing as well.