### PR TITLE
Fix negative margin handling (closes #104)

### DIFF
--- a/src/ass_dialogue.cpp
+++ b/src/ass_dialogue.cpp
@@ -118,7 +118,7 @@ void AssDialogue::Parse(std::string const& raw) {
 	Style = tkn.next_str_trim();
 	Actor = tkn.next_str_trim();
 	for (int& margin : Margin)
-		margin = mid(0, boost::lexical_cast<int>(tkn.next_str()), 9999);
+		margin = mid(-9999, boost::lexical_cast<int>(tkn.next_str()), 99999);
 	Effect = tkn.next_str_trim();
 
 	std::string text{tkn.next_tok().begin(), str.end()};

--- a/src/ass_style.cpp
+++ b/src/ass_style.cpp
@@ -158,9 +158,9 @@ AssStyle::AssStyle(std::string const& str, int version) {
 	if (version == 0)
 		alignment = SsaToAss(alignment);
 
-	Margin[0] = mid(0, p.next_int(), 9999);
-	Margin[1] = mid(0, p.next_int(), 9999);
-	Margin[2] = mid(0, p.next_int(), 9999);
+	Margin[0] = mid(-9999, p.next_int(), 99999);
+	Margin[1] = mid(-9999, p.next_int(), 99999);
+	Margin[2] = mid(-9999, p.next_int(), 99999);
 
 	// Skip alpha level
 	if (version == 0)

--- a/src/dialog_style_editor.cpp
+++ b/src/dialog_style_editor.cpp
@@ -200,7 +200,7 @@ DialogStyleEditor::DialogStyleEditor(wxWindow *parent, AssStyle *style, agi::Con
 	for (int i = 0; i < 3; i++)
 		margin[i] = new wxSpinCtrl(this, -1, std::to_wstring(style->Margin[i]),
 		                           wxDefaultPosition, wxSize(60, -1),
-		                           wxSP_ARROW_KEYS, 0, 9999, style->Margin[i]);
+		                           wxSP_ARROW_KEYS, -9999, 99999, style->Margin[i]);
 
 	Alignment = new wxRadioBox(this, -1, _("Alignment"), wxDefaultPosition, wxDefaultSize, 9, alignValues, 3, wxRA_SPECIFY_COLS);
 	auto Outline = num_text_ctrl(&work->outline_w, 0.0, 1000.0, 0.1);

--- a/src/subs_edit_box.cpp
+++ b/src/subs_edit_box.cpp
@@ -250,13 +250,13 @@ SubsEditBox::~SubsEditBox() {
 }
 
 wxTextCtrl *SubsEditBox::MakeMarginCtrl(wxString const& tooltip, int margin, wxString const& commit_msg) {
-	wxTextCtrl *ctrl = new wxTextCtrl(this, -1, "", wxDefaultPosition, wxSize(40,-1), wxTE_CENTRE | wxTE_PROCESS_ENTER, IntValidator());
-	ctrl->SetMaxLength(4);
+	wxTextCtrl *ctrl = new wxTextCtrl(this, -1, "", wxDefaultPosition, wxSize(40,-1), wxTE_CENTRE | wxTE_PROCESS_ENTER, IntValidator(0, true));
+	ctrl->SetMaxLength(5);
 	ctrl->SetToolTip(tooltip);
 	middle_left_sizer->Add(ctrl, wxSizerFlags().Center());
 
 	Bind(wxEVT_TEXT, [=](wxCommandEvent&) {
-		int value = agi::util::mid(0, atoi(ctrl->GetValue().utf8_str()), 9999);
+		int value = agi::util::mid(-9999, atoi(ctrl->GetValue().utf8_str()), 99999);
 		SetSelectedRows([&](AssDialogue *d) { d->Margin[margin] = value; },
 			commit_msg, AssFile::COMMIT_DIAG_META);
 	}, ctrl->GetId());


### PR DESCRIPTION
Previously, margins were clamped to 0..9999, but negative margins are well supported by most renderers. In addition, previously lua automations automations were able to produce these negative margin values, and they would be saved correctly. However, re-opening the file would clamp the values, and they could not be edited in the edit box.

This changes the clamping to be -9999..99999, and allows entering (and editing) negative values in all relevant fields. In addition, this makes the subtitle edit box margin fields take 5 characters instead of 4 to accommodate negative numbers up to 9999 (also the reason for raising the upper bound).