### PR TITLE
meson: Fix Windows artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
             os: windows-latest,
             msvc: true,
             buildtype: release,
-            args: '-Ddefault_library=static --force-fallback-for=zlib,harfbuzz'
+            args: '-Ddefault_library=static --force-fallback-for=zlib,harfbuzz,freetype2,fribidi,libpng -Dfreetype2:harfbuzz=disabled -Dharfbuzz:freetype=disabled -Dharfbuzz:cairo=disabled -Dharfbuzz:glib=disabled -Dharfbuzz:gobject=disabled'
           }
           #- {
           #  name: Windows MinGW,

--- a/subprojects/freetype2.wrap
+++ b/subprojects/freetype2.wrap
@@ -1,8 +1,0 @@
-[wrap-git]
-directory = freetype2
-url = https://git.savannah.gnu.org/git/freetype/freetype2.git
-revision = master
-
-[provide]
-freetype = freetype2_dep
-freetype2 = freetype2_dep


### PR DESCRIPTION
Tested installer on Windows, no more missing dlls. Depends on TypesettingTools/libass#10.