### PR TITLE
meson: add option to specify wxWidgets version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -111,7 +111,7 @@ endif
 
 deps += dependency('zlib')
 
-wx_minver = '>=3.0.0'
+wx_minver = '>=' + get_option('wx_version')
 if host_machine.system() == 'darwin'
     wx_minver = '>=3.1.0'
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -16,6 +16,8 @@ option('csri', type: 'feature', description: 'CSRI support')
 option('system_luajit', type: 'boolean', value: false, description: 'Force using system luajit')
 option('local_boost', type: 'boolean', value: false, description: 'Force using locally compiled Boost')
 
+option('wx_version', type: 'string', value: '3.0.0', description: 'The minimum wxWidgets version to use')
+
 option('credit', type: 'string', value: '', description: 'Build credit shown in program title')
 
 option('enable_update_checker', type: 'boolean', value: false, description: 'Enable the update checker')


### PR DESCRIPTION
Because I got tired of manually editing the meson.build file whenever I wanted to test something with wx 3.1 on Linux.