### PR TITLE
meson: luajit: allow to build in ARM64

### DIFF
--- a/subprojects/packagefiles/luajit/src/host/meson.build
+++ b/subprojects/packagefiles/luajit/src/host/meson.build
@@ -2,10 +2,13 @@ minilua = executable('minilua', 'minilua.c',
                      dependencies: system_deps,
                      native: true)
 
-if host_machine.cpu_family() == 'x86_64'
+cpu_family = host_machine.cpu_family()
+if cpu_family == 'x86_64'
     dynasm_arch = 'x64'
+elif cpu_family == 'aarch64'
+    dynasm_arch = 'arm64'
 else
-    dynasm_arch = host_machine.cpu_family()
+    dynasm_arch = cpu_family
 endif
 
 dynasm_dasc = files('../vm_@0@.dasc'.format(dynasm_arch))


### PR DESCRIPTION
Meson thought that a ARM64 cpu is aarch64, while
LuaJIT only provided a file for "arm64". Since there is
no difference but the name between aarch64 and arm64, I
choose to bind aarch64 -> arm64.

Signed-off-by: Yi-Jyun Pan <pan93412@gmail.com>