### PR TITLE
Fix errors when automation scripts being loaded and os.execute not working

### DIFF
--- a/automation/include/unicode-monkeypatch.lua
+++ b/automation/include/unicode-monkeypatch.lua
@@ -69,7 +69,7 @@ local function fileresult(stat, fname)
 	local msg = ffi.C.strerror(errno)
 
 	if fname then
-		return nil, fname .. ": " .. tostring(msg), errno
+		return nil, fname .. ": " .. ffi.string(msg), errno
 	end
 	return nil, msg, errno
 end
@@ -125,7 +125,7 @@ function os.execute(command)
 	local wcommand = command
 	if command then
 		wcommand = widen(command)
-    local stat = ffi.C._wsystem(wcommand)
+    		local stat = ffi.C._wsystem(wcommand)
 		return execresult(stat)
 	end
 

--- a/automation/include/unicode-monkeypatch.lua
+++ b/automation/include/unicode-monkeypatch.lua
@@ -65,11 +65,11 @@ local function fileresult(stat, fname)
 		return true
 	end
 
-	local errno = ffi.errno
+	local errno = ffi.errno()
 	local msg = ffi.C.strerror(errno)
 
 	if fname then
-		return nil, fname .. ": " .. msg, errno
+		return nil, fname .. ": " .. tostring(msg), errno
 	end
 	return nil, msg, errno
 end
@@ -125,7 +125,8 @@ function os.execute(command)
 	local wcommand = command
 	if command then
 		wcommand = widen(command)
-		return execresult(wcommand)
+    local stat = ffi.C._wsystem(wcommand)
+		return execresult(stat)
 	end
 
 	return true


### PR DESCRIPTION
Line 68: Syntax error -> without the parentheses, some automation scripts will raise the error "cannot convert 'function' to 'int'" when being loaded

![Aegisub 9262 error 1](https://user-images.githubusercontent.com/98341055/164414238-3238d1e8-2dcc-45d4-a4a6-8d949cb7867c.png)

Line 72: Will raise the error "attempt to concatenate 'string' and 'char *'

![Aegisub 9262 error 2](https://user-images.githubusercontent.com/98341055/164414706-3f459395-3364-4705-b5b5-5c06bbff144d.png)

Line 128-129: code is changed so the command can be executed
