### PR TITLE
fix configure: dont find_library iconv on linux

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -78,8 +78,15 @@ cc = meson.get_compiler('c')
 deps += cc.find_library('m', required: false)
 deps += cc.find_library('dl', required: false)
 
-iconv_dep = cc.find_library('iconv', required: false)
-if not (iconv_dep.found() or cc.has_function('iconv_open'))
+iconv_found = false
+iconv_dep = []
+if host_machine.system() == 'linux'
+    iconv_found = cc.has_function('iconv_open')
+else
+    iconv_dep = cc.find_library('iconv', required: false)
+    iconv_found = iconv_dep.found()
+endif
+if not iconv_found
     iconv_sp = subproject('iconv') # this really needs to be replaced with a proper port
     iconv_dep = iconv_sp.get_variable('libiconv_dep')
 endif


### PR DESCRIPTION
in configure phase, avoid the false negative

```
Library iconv found: NO
```

instead, on linux

```
Checking for function "iconv_open" : YES 
```
