### PR TITLE
meson: fix linux build and windows installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ${{ matrix.config.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         config:
           - name: Windows MSVC Release

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ build*/
 subprojects/boost*/
 subprojects/cairo*
 subprojects/ffmpeg
-subprojects/ffms2-*
+subprojects/ffms2
 subprojects/fontconfig*
 subprojects/freetype2
 subprojects/fribidi

--- a/libaegisub/include/libaegisub/audio/provider.h
+++ b/libaegisub/include/libaegisub/audio/provider.h
@@ -20,6 +20,7 @@
 #include <libaegisub/fs_fwd.h>
 
 #include <atomic>
+#include <memory>
 #include <vector>
 
 namespace agi {

--- a/packages/win_installer/fragment_codecs.iss
+++ b/packages/win_installer/fragment_codecs.iss
@@ -1,7 +1,7 @@
 [Files]
 ; Avisynth
-DestDir: {app}; Source: {#DEPS_DIR}\AvisynthPlus64\x86-64\DevIL.dll; Flags: ignoreversion; Components: main
-DestDir: {app}; Source: {#DEPS_DIR}\AvisynthPlus64\x86-64\AviSynth.dll; Flags: ignoreversion; Components: main
-DestDir: {app}; Source: {#DEPS_DIR}\AvisynthPlus64\x86-64\plugins\DirectShowSource.dll; Flags: ignoreversion; Components: main
+DestDir: {app}; Source: {#DEPS_DIR}\AvisynthPlus64\x64\system\DevIL.dll; Flags: ignoreversion; Components: main
+DestDir: {app}; Source: {#DEPS_DIR}\AvisynthPlus64\x64\AviSynth.dll; Flags: ignoreversion; Components: main
+DestDir: {app}; Source: {#DEPS_DIR}\AvisynthPlus64\x64\plugins\DirectShowSource.dll; Flags: ignoreversion; Components: main
 ; VSFilter
 DestDir: {app}\csri; Source: {#DEPS_DIR}\VSFilter\x64\VSFilter.dll; Flags: ignoreversion; Components: main

--- a/packages/win_installer/fragment_translations.iss
+++ b/packages/win_installer/fragment_translations.iss
@@ -3,34 +3,34 @@
 [Files]
 ; Aegisub localization
 #ifdef ENABLE_AEG_TRANSLATIONS
-Source: {#BUILD_ROOT}\po\ar.gmo;          DestDir: {app}\locale\ar;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
-Source: {#BUILD_ROOT}\po\bg.gmo;          DestDir: {app}\locale\bg;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
-Source: {#BUILD_ROOT}\po\ca.gmo;          DestDir: {app}\locale\ca;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
-Source: {#BUILD_ROOT}\po\cs.gmo;          DestDir: {app}\locale\cs;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
-Source: {#BUILD_ROOT}\po\da.gmo;          DestDir: {app}\locale\da;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
-Source: {#BUILD_ROOT}\po\de.gmo;          DestDir: {app}\locale\de;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
-Source: {#BUILD_ROOT}\po\el.gmo;          DestDir: {app}\locale\el;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
-Source: {#BUILD_ROOT}\po\es.gmo;          DestDir: {app}\locale\es;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
-Source: {#BUILD_ROOT}\po\eu.gmo;          DestDir: {app}\locale\eu;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
-Source: {#BUILD_ROOT}\po\fa.gmo;          DestDir: {app}\locale\fa;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
-Source: {#BUILD_ROOT}\po\fr_FR.gmo;       DestDir: {app}\locale\fr_FR; DestName: aegisub.mo; Flags: ignoreversion; Components: translations
-Source: {#BUILD_ROOT}\po\gl.gmo;          DestDir: {app}\locale\gl;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
-Source: {#BUILD_ROOT}\po\hu.gmo;          DestDir: {app}\locale\hu;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
-Source: {#BUILD_ROOT}\po\id.gmo;          DestDir: {app}\locale\id;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
-Source: {#BUILD_ROOT}\po\it.gmo;          DestDir: {app}\locale\it;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
-Source: {#BUILD_ROOT}\po\ja.gmo;          DestDir: {app}\locale\ja;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
-Source: {#BUILD_ROOT}\po\ko.gmo;          DestDir: {app}\locale\ko;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
-Source: {#BUILD_ROOT}\po\nl.gmo;          DestDir: {app}\locale\nl;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
-Source: {#BUILD_ROOT}\po\pl.gmo;          DestDir: {app}\locale\pl;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
-Source: {#BUILD_ROOT}\po\pt_BR.gmo;       DestDir: {app}\locale\pt_BR; DestName: aegisub.mo; Flags: ignoreversion; Components: translations
-Source: {#BUILD_ROOT}\po\pt_PT.gmo;       DestDir: {app}\locale\pt_PT; DestName: aegisub.mo; Flags: ignoreversion; Components: translations
-Source: {#BUILD_ROOT}\po\ru.gmo;          DestDir: {app}\locale\ru;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
-Source: {#BUILD_ROOT}\po\sr_RS.gmo;       DestDir: {app}\locale\sr_RS; DestName: aegisub.mo; Flags: ignoreversion; Components: translations
-Source: {#BUILD_ROOT}\po\sr_RS@latin.gmo; DestDir: {app}\locale\sr_RS@latin; DestName: aegisub.mo; Flags: ignoreversion; Components: translations
-Source: {#BUILD_ROOT}\po\uk_UA.gmo;       DestDir: {app}\locale\uk_UA; DestName: aegisub.mo; Flags: ignoreversion; Components: translations
-Source: {#BUILD_ROOT}\po\vi.gmo;          DestDir: {app}\locale\vi;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
-Source: {#BUILD_ROOT}\po\zh_CN.gmo;       DestDir: {app}\locale\zh_CN; DestName: aegisub.mo; Flags: ignoreversion; Components: translations
-Source: {#BUILD_ROOT}\po\zh_TW.gmo;       DestDir: {app}\locale\zh_TW; DestName: aegisub.mo; Flags: ignoreversion; Components: translations
+Source: {#BUILD_ROOT}\po\ar\LC_MESSAGES\aegisub.mo;          DestDir: {app}\locale\ar;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
+Source: {#BUILD_ROOT}\po\bg\LC_MESSAGES\aegisub.mo;          DestDir: {app}\locale\bg;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
+Source: {#BUILD_ROOT}\po\ca\LC_MESSAGES\aegisub.mo;          DestDir: {app}\locale\ca;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
+Source: {#BUILD_ROOT}\po\cs\LC_MESSAGES\aegisub.mo;          DestDir: {app}\locale\cs;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
+Source: {#BUILD_ROOT}\po\da\LC_MESSAGES\aegisub.mo;          DestDir: {app}\locale\da;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
+Source: {#BUILD_ROOT}\po\de\LC_MESSAGES\aegisub.mo;          DestDir: {app}\locale\de;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
+Source: {#BUILD_ROOT}\po\el\LC_MESSAGES\aegisub.mo;          DestDir: {app}\locale\el;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
+Source: {#BUILD_ROOT}\po\es\LC_MESSAGES\aegisub.mo;          DestDir: {app}\locale\es;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
+Source: {#BUILD_ROOT}\po\eu\LC_MESSAGES\aegisub.mo;          DestDir: {app}\locale\eu;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
+Source: {#BUILD_ROOT}\po\fa\LC_MESSAGES\aegisub.mo;          DestDir: {app}\locale\fa;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
+Source: {#BUILD_ROOT}\po\fr_FR\LC_MESSAGES\aegisub.mo;       DestDir: {app}\locale\fr_FR; DestName: aegisub.mo; Flags: ignoreversion; Components: translations
+Source: {#BUILD_ROOT}\po\gl\LC_MESSAGES\aegisub.mo;          DestDir: {app}\locale\gl;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
+Source: {#BUILD_ROOT}\po\hu\LC_MESSAGES\aegisub.mo;          DestDir: {app}\locale\hu;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
+Source: {#BUILD_ROOT}\po\id\LC_MESSAGES\aegisub.mo;          DestDir: {app}\locale\id;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
+Source: {#BUILD_ROOT}\po\it\LC_MESSAGES\aegisub.mo;          DestDir: {app}\locale\it;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
+Source: {#BUILD_ROOT}\po\ja\LC_MESSAGES\aegisub.mo;          DestDir: {app}\locale\ja;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
+Source: {#BUILD_ROOT}\po\ko\LC_MESSAGES\aegisub.mo;          DestDir: {app}\locale\ko;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
+Source: {#BUILD_ROOT}\po\nl\LC_MESSAGES\aegisub.mo;          DestDir: {app}\locale\nl;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
+Source: {#BUILD_ROOT}\po\pl\LC_MESSAGES\aegisub.mo;          DestDir: {app}\locale\pl;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
+Source: {#BUILD_ROOT}\po\pt_BR\LC_MESSAGES\aegisub.mo;       DestDir: {app}\locale\pt_BR; DestName: aegisub.mo; Flags: ignoreversion; Components: translations
+Source: {#BUILD_ROOT}\po\pt_PT\LC_MESSAGES\aegisub.mo;       DestDir: {app}\locale\pt_PT; DestName: aegisub.mo; Flags: ignoreversion; Components: translations
+Source: {#BUILD_ROOT}\po\ru\LC_MESSAGES\aegisub.mo;          DestDir: {app}\locale\ru;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
+Source: {#BUILD_ROOT}\po\sr_RS\LC_MESSAGES\aegisub.mo;       DestDir: {app}\locale\sr_RS; DestName: aegisub.mo; Flags: ignoreversion; Components: translations
+Source: {#BUILD_ROOT}\po\sr_RS@latin\LC_MESSAGES\aegisub.mo; DestDir: {app}\locale\sr_RS@latin; DestName: aegisub.mo; Flags: ignoreversion; Components: translations
+Source: {#BUILD_ROOT}\po\uk_UA\LC_MESSAGES\aegisub.mo;       DestDir: {app}\locale\uk_UA; DestName: aegisub.mo; Flags: ignoreversion; Components: translations
+Source: {#BUILD_ROOT}\po\vi\LC_MESSAGES\aegisub.mo;          DestDir: {app}\locale\vi;    DestName: aegisub.mo; Flags: ignoreversion; Components: translations
+Source: {#BUILD_ROOT}\po\zh_CN\LC_MESSAGES\aegisub.mo;       DestDir: {app}\locale\zh_CN; DestName: aegisub.mo; Flags: ignoreversion; Components: translations
+Source: {#BUILD_ROOT}\po\zh_TW\LC_MESSAGES\aegisub.mo;       DestDir: {app}\locale\zh_TW; DestName: aegisub.mo; Flags: ignoreversion; Components: translations
 #endif
 ; END ENABLE_TRANSLATIONS
 

--- a/subprojects/ffms2.wrap
+++ b/subprojects/ffms2.wrap
@@ -1,8 +1,6 @@
-[wrap-file]
-directory = ffms2-2.40
-source_url = https://github.com/FFMS/ffms2/archive/2.40.tar.gz
-source_filename = 2.40.tar.gz
-source_hash = 82e95662946f3d6e1b529eadbd72bed196adfbc41368b2d50493efce6e716320
+[wrap-git]
+url = https://github.com/FFMS/ffms2.git
+revision = head
 patch_directory = ffms2
 
 [provide]

--- a/tools/osx-fix-libs.py
+++ b/tools/osx-fix-libs.py
@@ -49,6 +49,11 @@ def collectlibs(lib, masterlist, targetdir):
                 basename = os.path.basename(check)
                 target = os.path.join(targetdir, basename)
 
+                if os.path.islink(target):
+                    # If a library was a symlink to a file with the same name in another directory,
+                    # this could otherwise cause a FileNotFoundError
+                    os.remove(target)
+
                 if os.path.isfile(check) and not os.path.islink(check):
                     try:
                         shutil.copy(check, target)


### PR DESCRIPTION
- Fix the current compile error when building on Linux (say, using the AUR package).
- Fix missing file errors for Avisynth and the localization files when building the installer on windows.

Tested with:
- On Linux: Latest Arch Linux
- On Windows: VS2019 and Meson 0.61.2

The CI builds also [finish](https://github.com/arch1t3cht/Aegisub/actions/runs/2599195494) without errors on Windows and Linux now, although that CI run is with a few more commits on top of it. These other commits are also various bugfixes, but for those I'm not sure if you want them PR'd. Let me know if I should add any of them.
I didn't test VS2022 on my machine though (reinstalling all of that is too much of a pain right now...) and a while ago I ran into some compilation errors with `stdatomic.h` on VS2022 only, but judging from the CI runs those might just have magically vanished (unless they were magically fixed by one of my other commits).