### PR TITLE
meson: use best practices lookup for iconv support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -78,10 +78,14 @@ cc = meson.get_compiler('c')
 deps += cc.find_library('m', required: false)
 deps += cc.find_library('dl', required: false)
 
-iconv_dep = cc.find_library('iconv', required: false)
-if not (iconv_dep.found() or cc.has_function('iconv_open'))
-    iconv_sp = subproject('iconv') # this really needs to be replaced with a proper port
-    iconv_dep = iconv_sp.get_variable('libiconv_dep')
+if meson.version().version_compare('>=0.60.0')
+  iconv_dep = dependency('iconv', fallback: ['iconv', 'libiconv_dep'])
+else
+  iconv_dep = cc.find_library('iconv', required: false)
+  if not (iconv_dep.found() or cc.has_function('iconv_open'))
+      iconv_sp = subproject('iconv') # this really needs to be replaced with a proper port
+      iconv_dep = iconv_sp.get_variable('libiconv_dep')
+  endif
 endif
 deps += iconv_dep
 


### PR DESCRIPTION
Meson 0.60.0 adds support for an "iconv" dependency that always does the right thing for you, so that you don't need to think about it. It also has some side advantages:
- you can do dependency fallback, and `--force-fallback-for=iconv` works
- it logs one line, not two, and that is "dependency found? yes or no"

Since Aegisub doesn't mandate the use of such new versions of Meson, we cannot assume the dependency works. Instead, adapt to the version of Meson being used: on new enough versions of Meson, use the new dependency, but on older versions of Meson, use the pre-existing logic, which isn't as nice but has been producing correct results so far.