### PR TITLE
[version.sh] small improvement

### DIFF
--- a/tools/version.sh
+++ b/tools/version.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+
+
 builddir="$1"
 srcdir="$2"
 
@@ -46,6 +49,16 @@ else
 fi
 
 build_date="$(date "+%Y-%m-%d %H:%M %Z")"
+
+number_regex='^[0-9]+$'
+if [ -z $git_revision ]; then
+    echo "git repo was corrupted or not cloned with all refs, this is probably a 'git clone' or similar error"
+    exit 2
+elif ! [[ $git_revision =~ $number_regex ]] ; then
+    echo "git_revision is not a number, but '$git_revision', this happened probably due to a git rev issue!"
+    exit 2
+fi 
+
 
 new_version_h="\
 #define BUILD_GIT_VERSION_NUMBER ${git_revision}


### PR DESCRIPTION
Create explicit error, when the version number couldn't be fetched.

This solves some issues when running CI's that don't fetch the GitHub repo in normal mode, per example 
if you build it in flatpak with the git source, it fails to get the revs, but the compilation doesn't break because of that error, then after the whole compilation succeeds, at the end the git_version.h is corrupt, since BUILD_GIT_VERSION_NUMBER is not a valid int, since it's empty. So the Compile error is hardly readable and you could already know earlier that the compilation failed. 