### PR TITLE
Add automatic end range of copyright year

### DIFF
--- a/src/dialog_about.cpp
+++ b/src/dialog_about.cpp
@@ -48,8 +48,8 @@ void ShowAboutDialog(wxWindow *parent) {
 		translatorCredit.clear();
 
 	// Generate about string
-	wxString aboutString = wxString("Aegisub ") + GetAegisubShortVersionString() + ".\n"
-		"Copyright (c) 2005-2019 Rodrigo Braz Monteiro, Niels Martin Hansen, Thomas Goyne et al.\n\n"
+	wxString aboutString = wxString("Aegisub ") + GetAegisubShortVersionString() + ".\n" +
+		fmt_tl("Copyright (c) 2005-%s Rodrigo Braz Monteiro, Niels Martin Hansen, Thomas Goyne et al.\n\n", GetAegisubBuildYear()) + 
 		"Programmers:\n"
 		"    Alysson Souza e Silva\n"
 		"    Amar Takhar\n"

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -55,6 +55,12 @@ const char *GetAegisubShortVersionString() {
 	return BUILD_GIT_VERSION_STRING DEBUG_SUFFIX;
 }
 
+const char *GetAegisubBuildYear() {
+	const char *build_year = __DATE__ + 7;
+	return build_year;
+}
+
+
 #ifdef BUILD_CREDIT
 const char *GetAegisubBuildTime() {
 	return __DATE__ " " __TIME__;

--- a/src/version.h
+++ b/src/version.h
@@ -36,6 +36,8 @@
 const char *GetAegisubLongVersionString();
 /// Version string used in About box, looks nicer
 const char *GetAegisubShortVersionString();
+/// Year of build, only shown in About box
+const char *GetAegisubBuildYear();
 /// Timestamp of build, only shown in About box
 const char *GetAegisubBuildTime();
 /// Name of who built the binary


### PR DESCRIPTION
This adds a Dynamic Year to the end of the Copyright notice, so that the year of the build is used automatically, so there's no need to switch it manually. this uses the fact, that  the preprocessor expands

```__DATE__```
  to a char * literal and it always has the same length, so offsetting it gets the current year at compile time