### PR TITLE
Remove unneeded type conversions in spellchecker_hunspell.cpp

### DIFF
--- a/src/spellchecker_hunspell.cpp
+++ b/src/spellchecker_hunspell.cpp
@@ -59,7 +59,7 @@ void HunspellSpellChecker::AddWord(std::string_view word) {
 	if (!hunspell) return;
 
 	// Add it to the in-memory dictionary
-	hunspell->add(conv->Convert(word).c_str());
+	hunspell->add(conv->Convert(word));
 
 	// Add the word
 	if (customWords.insert(std::string(word)).second)
@@ -70,7 +70,7 @@ void HunspellSpellChecker::RemoveWord(std::string_view word) {
 	if (!hunspell) return;
 
 	// Remove it from the in-memory dictionary
-	hunspell->remove(conv->Convert(word).c_str());
+	hunspell->remove(conv->Convert(word));
 
 	auto word_iter = customWords.find(word);
 	if (word_iter != customWords.end()) {
@@ -117,7 +117,7 @@ void HunspellSpellChecker::WriteUserDictionary() {
 bool HunspellSpellChecker::CheckWord(std::string_view word) {
 	if (!hunspell) return true;
 	try {
-		return hunspell->spell(conv->Convert(word)) == 1;
+		return hunspell->spell(conv->Convert(word));
 	}
 	catch (agi::charset::ConvError const&) {
 		return false;
@@ -205,7 +205,7 @@ void HunspellSpellChecker::OnLanguageChanged() {
 
 	for (auto const& word : customWords) {
 		try {
-			hunspell->add(conv->Convert(word).c_str());
+			hunspell->add(conv->Convert(word));
 		}
 		catch (agi::charset::ConvError const&) {
 			// Normally this shouldn't happen, but some versions of Aegisub


### PR DESCRIPTION
Since v1.5 (released in Nov. 2016), Hunspell has deprecated C style APIs and added a new set of C++ APIs.  
https://github.com/hunspell/hunspell/compare/v1.4.2...v1.5.3#diff-4c6057a8b7a2e93a0c4e414dfc8ca7cc527ab00ba2b909622bf0d3591fc146b4

Some conversions in `spellchecker_hunspell.cpp` are no longer needed.  
`GetSuggestions()`, with `hunspell->suggest()` in it, had been refactored in Plork's modernization.
