### PR TITLE
Use parent's font for warning text in preferences

### DIFF
--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -351,7 +351,9 @@ void Advanced(wxTreebook *book, Preferences *parent) {
 	auto general = p->PageSizer(_("General"));
 
 	auto warning = new wxStaticText(p, wxID_ANY ,_("Changing these settings might result in bugs and/or crashes.  Do not touch these unless you know what you're doing."));
-	warning->SetFont(wxFont(12, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD));
+	auto font = parent->GetFont().MakeBold();
+	font.SetPointSize(12);
+	warning->SetFont(font);
 	p->sizer->Fit(p);
 	warning->Wrap(400);
 	general->Add(warning, 0, wxALL, 5);


### PR DESCRIPTION
According to the [documentation](https://docs.wxwidgets.org/trunk/interface_2wx_2font_8h.html#a0cd7bfd21a4f901245d3c86d8ea0c080a81d3016e8bbcca1c2f8088f016c44191), wxFONTFAMILY_SWISS = a sans-serif font. However when Windows in zh-CN or zh-TW locales, they're displayed in SimSun（宋体）or PMingLIU（細明體）, both are serif and kinda last fallback fonts in their locales. This bug is ~~clearly attributed to wxWidgets~~ attributed to the backward compatibility of Windows. We could patch it on wxWidgets' side, but we may need a workaround for a couple of years considering wx's release cycle. 

![zh-CN](https://github.com/TypesettingTools/Aegisub/assets/118708188/8c16449d-33a0-45b0-b01e-3da3310d89c8)
![zh-TW](https://github.com/TypesettingTools/Aegisub/assets/118708188/d0b79ba4-5ab3-4d8e-8b37-62b26ad36e90)

This patch can be applied to @arch1t3cht's and @wangqr's fork.