### PR TITLE
WIP: CPS customizable

### DIFF
--- a/src/grid_column.h
+++ b/src/grid_column.h
@@ -16,6 +16,7 @@
 
 #include "flyweight_hash.h"
 
+#include <cmath>
 #include <memory>
 #include <string>
 #include <vector>

--- a/src/libresrc/default_config.json
+++ b/src/libresrc/default_config.json
@@ -371,8 +371,10 @@
 		"Character Counter" : {
 			"Ignore Whitespace" : true,
 			"Ignore Punctuation" : true,
-			"CPS Warning Threshold" : 15,
-			"CPS Error Threshold" : 30
+			"CPS Warning Threshold" : 15.0,
+			"CPS Error Threshold" : 30.0,
+			"Display Format" : 0,
+			"Column Alignment": 0
 		},
 		"Character Limit" : 40,
 		"Default Resolution" : {

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -215,10 +215,18 @@ void Interface(wxTreebook *book, Preferences *parent) {
 
 	auto character_count = p->PageSizer(_("Character Counter"));
 	p->OptionAdd(character_count, _("Maximum characters per line"), "Subtitle/Character Limit", 0, 1000);
-	p->OptionAdd(character_count, _("Characters Per Second Warning Threshold"), "Subtitle/Character Counter/CPS Warning Threshold", 0, 1000);
-	p->OptionAdd(character_count, _("Characters Per Second Error Threshold"), "Subtitle/Character Counter/CPS Error Threshold", 0, 1000);
+	p->OptionAdd(character_count, _("Characters Per Second Warning Threshold"), "Subtitle/Character Counter/CPS Warning Threshold", 0.1, 1000., 0.1);
+	p->OptionAdd(character_count, _("Characters Per Second Error Threshold"), "Subtitle/Character Counter/CPS Error Threshold", 0.1, 1000., 0.1);
 	p->OptionAdd(character_count, _("Ignore whitespace"), "Subtitle/Character Counter/Ignore Whitespace");
 	p->OptionAdd(character_count, _("Ignore punctuation"), "Subtitle/Character Counter/Ignore Punctuation");
+
+	const wxString ccpsf_arr[3] = {_("Nearest integer"), _("Nearest 0.1"), _("2 sig figs")};
+	wxArrayString cpsf_res(3, ccpsf_arr);
+	p->OptionChoice(character_count, _("CPS display format"), cpsf_res, "Subtitle/Character Counter/Display Format");
+
+	const wxString calign_arr[2] = {_("Center"), _("Center with virtual 0")};
+	wxArrayString calign_res(2, calign_arr);
+	p->OptionChoice(character_count, _("CPS column alignment"), calign_res, "Subtitle/Character Counter/Column Alignment");
 
 	auto grid = p->PageSizer(_("Grid"));
 	p->OptionAdd(grid, _("Focus grid on click"), "Subtitle/Grid/Focus Allow");


### PR DESCRIPTION
- [x] Two new display formats: "Round to nearest 0.1" and "2 sig figs", in addition to the current format "Round to nearest integer"
  + [ ] Use C++20 `std::format` for clearance?
- [x] A new alignments: "add virtual 0 to make everyone have same number of digits, then center"
- [ ] Adaptive precision (2 sig figs) for CPS thresold number boxes
- [ ] set CPS thresold per styles. Useful for biligual subtitle that use different styles and lines for two languages
  + [ ] per file, by store in `[Aegisub Project Garbage]`?