### PR TITLE
Improve zh_TW Traditional Chinese locale

### DIFF
--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Aegisub 3.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-06-27 11:18-0700\n"
+"POT-Creation-Date: 2014-07-01 10:53-0700\n"
 "PO-Revision-Date: 2014-06-28 18:38+0800\n"
 "Last-Translator: COMPUTERFAN <diannaomi97@gmail.com>\n"
 "Language-Team: Vmoe字幕組 <diannaomi97@gmail.com>\n"
@@ -59,95 +59,95 @@ msgstr "從 %d 往後"
 msgid "sel "
 msgstr "所選"
 
-#: ../src/dialog_shift_times.cpp:132 ../src/command/time.cpp:153
+#: ../src/dialog_shift_times.cpp:133 ../src/command/time.cpp:153
 msgid "Shift Times"
 msgstr "平移時間"
 
-#: ../src/dialog_shift_times.cpp:141
+#: ../src/dialog_shift_times.cpp:142
 msgid "&Time: "
 msgstr "時間(&T)： "
 
-#: ../src/dialog_shift_times.cpp:142
+#: ../src/dialog_shift_times.cpp:143
 msgid "Shift by time"
 msgstr "按照時間平移"
 
-#: ../src/dialog_shift_times.cpp:145
+#: ../src/dialog_shift_times.cpp:146
 msgid "&Frames: "
 msgstr "影格數(&F)： "
 
-#: ../src/dialog_shift_times.cpp:146
+#: ../src/dialog_shift_times.cpp:147
 msgid "Shift by frames"
 msgstr "平移 (按照影格數)"
 
-#: ../src/dialog_shift_times.cpp:150
+#: ../src/dialog_shift_times.cpp:151
 msgid "Enter time in h:mm:ss.cs notation"
 msgstr "以 h:mm:ss.cs 方式輸入時間"
 
-#: ../src/dialog_shift_times.cpp:153
+#: ../src/dialog_shift_times.cpp:154
 msgid "Enter number of frames to shift by"
 msgstr "輸入平移影格數"
 
-#: ../src/dialog_shift_times.cpp:155
+#: ../src/dialog_shift_times.cpp:156
 msgid "For&ward"
 msgstr "延後(&W)"
 
-#: ../src/dialog_shift_times.cpp:156
+#: ../src/dialog_shift_times.cpp:157
 msgid ""
 "Shifts subs forward, making them appear later. Use if they are appearing too "
 "soon."
 msgstr "延後字幕使其較晚顯示。在字幕過早顯示時使用。"
 
-#: ../src/dialog_shift_times.cpp:158
+#: ../src/dialog_shift_times.cpp:159
 msgid "&Backward"
 msgstr "提前(&B)"
 
-#: ../src/dialog_shift_times.cpp:159
+#: ../src/dialog_shift_times.cpp:160
 msgid ""
 "Shifts subs backward, making them appear earlier. Use if they are appearing "
 "too late."
 msgstr "提前字幕使其較早顯示.在字幕過晚顯示時使用。"
 
-#: ../src/dialog_shift_times.cpp:161
+#: ../src/dialog_shift_times.cpp:162
 msgid "&All rows"
 msgstr "所有行(&A)"
 
-#: ../src/dialog_shift_times.cpp:161 ../src/dialog_search_replace.cpp:88
+#: ../src/dialog_shift_times.cpp:162 ../src/dialog_search_replace.cpp:88
 msgid "Selected &rows"
 msgstr "所選行(&R)"
 
-#: ../src/dialog_shift_times.cpp:161
+#: ../src/dialog_shift_times.cpp:162
 msgid "Selection &onward"
 msgstr "所選行及其後續(&O)"
 
-#: ../src/dialog_shift_times.cpp:162
+#: ../src/dialog_shift_times.cpp:163
 msgid "Affect"
 msgstr "應用於"
 
-#: ../src/dialog_shift_times.cpp:164
+#: ../src/dialog_shift_times.cpp:165
 msgid "Start a&nd End times"
 msgstr "開始和結束時間(&N)"
 
-#: ../src/dialog_shift_times.cpp:164
+#: ../src/dialog_shift_times.cpp:165
 msgid "&Start times only"
 msgstr "僅開始時間(&S)"
 
-#: ../src/dialog_shift_times.cpp:164
+#: ../src/dialog_shift_times.cpp:165
 msgid "&End times only"
 msgstr "僅結束時間(&E)"
 
-#: ../src/dialog_shift_times.cpp:165
+#: ../src/dialog_shift_times.cpp:166
 msgid "Times"
 msgstr "時間"
 
-#: ../src/dialog_shift_times.cpp:169
+#: ../src/dialog_shift_times.cpp:170
 msgid "&Clear"
 msgstr "清除(&C)"
 
-#: ../src/dialog_shift_times.cpp:200
+#: ../src/dialog_shift_times.cpp:201
 msgid "Shift by"
 msgstr "平移方式"
 
-#: ../src/dialog_shift_times.cpp:209
+#: ../src/dialog_shift_times.cpp:210
 msgid "Load from history"
 msgstr "從歷史打開"
 
@@ -208,7 +208,7 @@ msgid ""
 "Failed to load Automation script '%s':\n"
 "%s"
 msgstr ""
-"一個自動化腳本載入失敗，檔案名： '%s'，錯誤報告：\n"
+"一個自動化腳本載入失敗，檔案名稱： '%s'，錯誤報告：\n"
 " %s"
 
 #: ../src/auto4_base.cpp:467
@@ -220,13 +220,13 @@ msgstr "該檔未被識別為自動化腳本： %s"
 #: ../src/command/timecode.cpp:94 ../src/command/video.cpp:568
 #: ../src/command/audio.cpp:84 ../src/command/keyframe.cpp:74
 msgid "All Files"
-msgstr "所有檔"
+msgstr "所有檔案"
 
 #: ../src/auto4_base.cpp:502 ../src/command/timecode.cpp:74
 #: ../src/command/timecode.cpp:94 ../src/command/keyframe.cpp:74
 #: ../src/subtitle_format.cpp:312
 msgid "All Supported Formats"
-msgstr "所有支持格式"
+msgstr "所有支援的格式"
 
 #: ../src/auto4_base.cpp:508
 msgid "File was not recognized as a script"
@@ -234,17 +234,17 @@ msgstr "檔案未被識別為腳本"
 
 #: ../src/search_replace_engine.cpp:247 ../src/search_replace_engine.cpp:331
 msgid "replace"
-msgstr "替換"
+msgstr "取代"
 
 #: ../src/search_replace_engine.cpp:332
 #, c-format
 msgid "One match was replaced."
 msgid_plural "%d matches were replaced."
-msgstr[0] "%d 個匹配項已替換。"
+msgstr[0] "%d 個符合的項目已取代。"
 
 #: ../src/search_replace_engine.cpp:335
 msgid "No matches found."
-msgstr "沒有找到匹配項。"
+msgstr "沒有找到符合的項目。"
 
 #: ../src/visual_tool_drag.cpp:56
 msgid "Toggle between \\move and \\pos"
@@ -256,7 +256,7 @@ msgstr "定位"
 
 #: ../src/font_file_lister_fontconfig.cpp:80
 msgid "Updating font cache\n"
-msgstr "正在更新字體快取…\n"
+msgstr "正在更新字型快取…\n"
 
 #: ../src/subtitle_format_ebu3264.cpp:408
 #, c-format
@@ -265,11 +265,11 @@ msgstr "行超過最大長度：%s"
 
 #: ../src/dialog_video_details.cpp:44
 msgid "Video Details"
-msgstr "視頻屬性"
+msgstr "影片屬性"
 
 #: ../src/dialog_video_details.cpp:58
 msgid "File name:"
-msgstr "檔案名："
+msgstr "檔案名稱："
 
 #: ../src/dialog_video_details.cpp:59
 msgid "FPS:"
@@ -294,7 +294,7 @@ msgid "Decoder:"
 msgstr "解碼器："
 
 #: ../src/dialog_video_details.cpp:65 ../src/preferences.cpp:165
-#: ../src/preferences.cpp:414
+#: ../src/preferences.cpp:417
 msgid "Video"
 msgstr "視訊"
 
@@ -304,7 +304,7 @@ msgstr "時間後續處理器"
 
 #: ../src/dialog_timing_processor.cpp:157
 msgid "Apply to styles"
-msgstr "應用到樣式"
+msgstr "套用到樣式"
 
 #: ../src/dialog_timing_processor.cpp:159
 msgid "Select styles to process. Unchecked ones will be ignored."
@@ -334,7 +334,7 @@ msgstr "選項"
 
 #: ../src/dialog_timing_processor.cpp:169
 msgid "Affect &selection only"
-msgstr "僅應用於所選"
+msgstr "僅套用於所選"
 
 #: ../src/dialog_timing_processor.cpp:174
 msgid "Lead-in/Lead-out"
@@ -404,7 +404,7 @@ msgid ""
 "extend or shrink start time of the second line; if totally to right, it will "
 "extend or shrink the end time of the first line."
 msgstr ""
-"設置如何緊貼字幕行，如果設為完全向左，將擴展至次行的開始時間；如果完全向右,將"
+"設定如何緊貼字幕行，如果設為完全向左，將擴展至次行的開始時間；如果完全向右,將"
 "擴展至首行的結束時間。"
 
 #: ../src/dialog_timing_processor.cpp:204
@@ -509,7 +509,7 @@ msgstr "樣式助手"
 #: ../src/dialog_styling_assistant.cpp:65
 #: ../src/dialog_styling_assistant.cpp:66
 msgid "Current line"
-msgstr "當前行"
+msgstr "目前行"
 
 #: ../src/dialog_styling_assistant.cpp:72
 msgid "Styles available"
@@ -603,25 +603,25 @@ msgstr "樣式下移"
 
 #: ../src/dialog_style_manager.cpp:190
 msgid "Move style to top"
-msgstr "樣式移至頂部"
+msgstr "樣式移至頂端"
 
 #: ../src/dialog_style_manager.cpp:191
 msgid "Move style to bottom"
-msgstr "樣式移至底部"
+msgstr "樣式移至底端"
 
 #: ../src/dialog_style_manager.cpp:192
 msgid "Sort styles alphabetically"
 msgstr "按字母表順序排序樣式"
 
-#: ../src/dialog_style_manager.cpp:202 ../src/preferences.cpp:575
+#: ../src/dialog_style_manager.cpp:202 ../src/preferences.cpp:578
 msgid "&New"
 msgstr "新建(&N)"
 
-#: ../src/dialog_style_manager.cpp:203 ../src/preferences.cpp:576
+#: ../src/dialog_style_manager.cpp:203 ../src/preferences.cpp:579
 msgid "&Edit"
 msgstr "編輯(&E)"
 
-#: ../src/dialog_style_manager.cpp:205 ../src/preferences.cpp:577
+#: ../src/dialog_style_manager.cpp:205 ../src/preferences.cpp:580
 #: ../src/dialog_attachments.cpp:79
 msgid "&Delete"
 msgstr "刪除(&D)"
@@ -664,7 +664,7 @@ msgstr "刪除"
 
 #: ../src/dialog_style_manager.cpp:282
 msgid "Copy to &current script ->"
-msgstr "複製到當前腳本 ->"
+msgstr "複製到目前腳本 ->"
 
 #: ../src/dialog_style_manager.cpp:289
 msgid "Storage"
@@ -672,7 +672,7 @@ msgstr "樣式庫"
 
 #: ../src/dialog_style_manager.cpp:295
 msgid "&Import from script..."
-msgstr "從腳本中導入..."
+msgstr "從腳本中匯入..."
 
 #: ../src/dialog_style_manager.cpp:296
 msgid "<- Copy to &storage"
@@ -680,7 +680,7 @@ msgstr "<- 複製到樣式庫"
 
 #: ../src/dialog_style_manager.cpp:307
 msgid "Current script"
-msgstr "當前腳本"
+msgstr "目前腳本"
 
 #: ../src/dialog_style_manager.cpp:314 ../src/dialog_progress.cpp:179
 msgid "Close"
@@ -710,7 +710,7 @@ msgid ""
 "The catalog has been renamed to \"%s\"."
 msgstr ""
 "指定目錄名包含一個或多個非法字元，它們已經被底線所替代。\n"
-"該目錄被重命名為 \"%s\"。"
+"該目錄被重新命名為 \"%s\"。"
 
 #: ../src/dialog_style_manager.cpp:477
 msgid "Invalid characters"
@@ -730,7 +730,7 @@ msgstr "確認刪除"
 msgid ""
 "There is already a style with the name \"%s\" in the current storage. "
 "Overwrite?"
-msgstr "當前已儲存了相同的樣式名 \"%s\"。要覆蓋嗎？"
+msgstr "目前已儲存了相同的樣式名稱 \"%s\"。要覆蓋嗎？"
 
 #: ../src/dialog_style_manager.cpp:509 ../src/dialog_style_manager.cpp:536
 #: ../src/dialog_style_manager.cpp:714
@@ -742,7 +742,7 @@ msgstr "樣式名稱"
 msgid ""
 "There is already a style with the name \"%s\" in the current script. "
 "Overwrite?"
-msgstr "當前腳本中已有相同的樣式名\"%s\"。要覆蓋嗎？"
+msgstr "目前腳本中已有相同的樣式名稱\"%s\"。要覆蓋嗎？"
 
 #: ../src/dialog_style_manager.cpp:547
 msgid "style copy"
@@ -758,7 +758,7 @@ msgstr "確認從樣式庫刪除"
 
 #: ../src/dialog_style_manager.cpp:659
 msgid "Confirm delete from current"
-msgstr "確認從當前刪除"
+msgstr "確認從目前刪除"
 
 #: ../src/dialog_style_manager.cpp:663
 msgid "style delete"
@@ -775,19 +775,19 @@ msgstr "所選檔沒有可用樣式"
 
 #: ../src/dialog_style_manager.cpp:698
 msgid "Error Importing Styles"
-msgstr "導入樣式出錯"
+msgstr "匯入樣式出錯"
 
 #: ../src/dialog_style_manager.cpp:704
 msgid "Choose styles to import:"
-msgstr "選擇要導入的樣式："
+msgstr "選擇要匯入的樣式："
 
 #: ../src/dialog_style_manager.cpp:704
 msgid "Import Styles"
-msgstr "導入樣式"
+msgstr "匯入樣式"
 
 #: ../src/dialog_style_manager.cpp:730
 msgid "style import"
-msgstr "樣式導入"
+msgstr "樣式匯入"
 
 #: ../src/dialog_style_manager.cpp:839
 msgid "Are you sure? This cannot be undone!"
@@ -807,7 +807,7 @@ msgstr "關閉時間碼檔"
 
 #: ../src/command/timecode.cpp:54
 msgid "Close the currently open timecodes file"
-msgstr "關閉當前打開的時間碼檔"
+msgstr "關閉目前打開的時間碼檔"
 
 #: ../src/command/timecode.cpp:69
 msgid "Open Timecodes File..."
@@ -848,7 +848,7 @@ msgstr "電影（2.35）"
 
 #: ../src/command/video.cpp:86
 msgid "Force video to 2.35 aspect ratio"
-msgstr "強制視訊為2.35縱橫比"
+msgstr "強制視訊為2.35長寬比"
 
 #: ../src/command/video.cpp:102
 msgid "C&ustom..."
@@ -860,7 +860,7 @@ msgstr "自訂…"
 
 #: ../src/command/video.cpp:104
 msgid "Force video to a custom aspect ratio"
-msgstr "強制視訊為自訂縱橫比"
+msgstr "強制視訊為自訂長寬比"
 
 #: ../src/command/video.cpp:115
 msgid ""
@@ -869,20 +869,20 @@ msgid ""
 "  fractional (e.g. 16:9)\n"
 "  specific resolution (e.g. 853x480)"
 msgstr ""
-"可以以小數(例如 2.35)或是比數(例如16:9)輸入縱橫比。\n"
-"也可以輸入像853x480這樣的數值來設置一個特定的解析度"
+"可以以小數(例如 2.35)或是比數(例如16:9)輸入長寬比。\n"
+"也可以輸入像853x480這樣的數值來設定一個特定的解析度"
 
 #: ../src/command/video.cpp:116
 msgid "Enter aspect ratio"
-msgstr "輸入縱橫比"
+msgstr "輸入長寬比"
 
 #: ../src/command/video.cpp:135
 msgid "Invalid value! Aspect ratio must be between 0.5 and 5.0."
-msgstr "無效數值！縱橫比必須在0.5至5.0之間。"
+msgstr "無效數值！長寬比必須在0.5至5.0之間。"
 
 #: ../src/command/video.cpp:135
 msgid "Invalid Aspect Ratio"
-msgstr "無效縱橫比"
+msgstr "無效長寬比"
 
 #: ../src/command/video.cpp:145
 msgid "&Default"
@@ -894,31 +894,31 @@ msgstr "預設編碼"
 
 #: ../src/command/video.cpp:147
 msgid "Use video's original aspect ratio"
-msgstr "保持視訊原始縱橫比"
+msgstr "保持視訊原始長寬比"
 
 #: ../src/command/video.cpp:163
 msgid "&Fullscreen (4:3)"
-msgstr "全屏4:3(&F)"
+msgstr "全螢幕4:3(&F)"
 
 #: ../src/command/video.cpp:164
 msgid "Fullscreen (4:3)"
-msgstr "全屏4:3"
+msgstr "全螢幕4:3"
 
 #: ../src/command/video.cpp:165
 msgid "Force video to 4:3 aspect ratio"
-msgstr "強制視訊為4:3縱橫比"
+msgstr "強制視訊為4:3長寬比"
 
 #: ../src/command/video.cpp:181
 msgid "&Widescreen (16:9)"
-msgstr "寬屏16:9(&W)"
+msgstr "寬螢幕16:9(&W)"
 
 #: ../src/command/video.cpp:182
 msgid "Widescreen (16:9)"
-msgstr "寬屏16:9"
+msgstr "寬螢幕16:9"
 
 #: ../src/command/video.cpp:183
 msgid "Force video to 16:9 aspect ratio"
-msgstr "強制視訊為16:9縱橫比"
+msgstr "強制視訊為16:9長寬比"
 
 #: ../src/command/video.cpp:200
 msgid "&Close Video"
@@ -930,16 +930,16 @@ msgstr "關閉視訊"
 
 #: ../src/command/video.cpp:202
 msgid "Close the currently open video file"
-msgstr "關閉當前打開的視訊檔"
+msgstr "關閉目前打開的視訊檔案"
 
 #: ../src/command/video.cpp:211 ../src/command/video.cpp:212
 msgid "Copy coordinates to Clipboard"
-msgstr "複製座標至剪貼板"
+msgstr "複製座標至剪貼簿"
 
 #: ../src/command/video.cpp:213
 msgid ""
 "Copy the current coordinates of the mouse over the video to the clipboard"
-msgstr "複製當前滑鼠在視訊上的座標到剪貼板"
+msgstr "複製目前滑鼠在視訊上的座標到剪貼簿"
 
 #: ../src/command/video.cpp:222 ../src/command/video.cpp:223
 msgid "Cycle active subtitles provider"
@@ -952,7 +952,7 @@ msgstr "在可用的字幕來源中切換"
 #: ../src/command/video.cpp:235
 #, c-format
 msgid "Subtitles provider set to %s"
-msgstr "字幕來源設置為 %s"
+msgstr "字幕來源設定為 %s"
 
 #: ../src/command/video.cpp:242
 msgid "&Detach Video"
@@ -970,15 +970,15 @@ msgstr "從主介面分離視訊，在一個單獨視窗顯示"
 
 #: ../src/command/video.cpp:262
 msgid "Show &Video Details"
-msgstr "顯示視頻屬性(&V)"
+msgstr "顯示影片屬性(&V)"
 
 #: ../src/command/video.cpp:263
 msgid "Show Video Details"
-msgstr "顯示視頻屬性"
+msgstr "顯示影片屬性"
 
 #: ../src/command/video.cpp:264
 msgid "Show video details"
-msgstr "顯示視頻屬性"
+msgstr "顯示影片屬性"
 
 #: ../src/command/video.cpp:274 ../src/command/video.cpp:275
 msgid "Toggle video slider focus"
@@ -991,20 +991,20 @@ msgstr "使焦點在視訊滑塊與之前的焦點之間切換"
 
 #: ../src/command/video.cpp:297 ../src/command/video.cpp:298
 msgid "Copy image to Clipboard"
-msgstr "複製圖像至剪貼板"
+msgstr "複製圖像至剪貼簿"
 
 #: ../src/command/video.cpp:299
 msgid "Copy the currently displayed frame to the clipboard"
-msgstr "將當前顯示的畫面複製到剪貼板"
+msgstr "將目前顯示的畫面複製到剪貼簿"
 
 #: ../src/command/video.cpp:308 ../src/command/video.cpp:309
 msgid "Copy image to Clipboard (no subtitles)"
-msgstr "複製圖像至剪貼板（不帶字幕）"
+msgstr "複製圖像至剪貼簿（不帶字幕）"
 
 #: ../src/command/video.cpp:310
 msgid ""
 "Copy the currently displayed frame to the clipboard, without the subtitles"
-msgstr "將當前顯示的畫面複製到剪貼板，不帶字幕"
+msgstr "將目前顯示的畫面複製到剪貼簿，不帶字幕"
 
 #: ../src/command/video.cpp:319 ../src/command/video.cpp:320
 msgid "Next Frame"
@@ -1071,7 +1071,7 @@ msgstr "儲存 PNG 截圖"
 #: ../src/command/video.cpp:501
 msgid ""
 "Save the currently displayed frame to a PNG file in the video's directory"
-msgstr "儲存當前顯示影格為PNG格式到視訊所在目錄"
+msgstr "儲存目前顯示影格為PNG格式到視訊所在目錄"
 
 #: ../src/command/video.cpp:510 ../src/command/video.cpp:511
 msgid "Save PNG snapshot (no subtitles)"
@@ -1081,7 +1081,7 @@ msgstr "儲存 PNG 截圖（不帶字幕）"
 msgid ""
 "Save the currently displayed frame without the subtitles to a PNG file in "
 "the video's directory"
-msgstr "儲存當前顯示影格（不帶字幕）為PNG格式到視訊所在目錄"
+msgstr "儲存目前顯示影格（不帶字幕）為PNG格式到視訊所在目錄"
 
 #: ../src/command/video.cpp:522
 msgid "&Jump to..."
@@ -1101,7 +1101,7 @@ msgstr "視訊跳至結束時間"
 
 #: ../src/command/video.cpp:538
 msgid "Jump the video to the end frame of current subtitle"
-msgstr "視訊跳至當前字幕的結束影格"
+msgstr "視訊跳至目前字幕的結束影格"
 
 #: ../src/command/video.cpp:549
 msgid "Jump Video to &Start"
@@ -1113,7 +1113,7 @@ msgstr "視訊跳至開始時間"
 
 #: ../src/command/video.cpp:551
 msgid "Jump the video to the start frame of current subtitle"
-msgstr "視訊跳至當前字幕的起始影格"
+msgstr "視訊跳至目前字幕的起始影格"
 
 #: ../src/command/video.cpp:562
 msgid "&Open Video..."
@@ -1125,7 +1125,7 @@ msgstr "打開視訊…"
 
 #: ../src/command/video.cpp:564
 msgid "Open a video file"
-msgstr "打開一個視訊檔"
+msgstr "打開一個視訊檔案"
 
 #: ../src/command/video.cpp:567 ../src/command/audio.cpp:83
 msgid "Video Formats"
@@ -1133,7 +1133,7 @@ msgstr "視訊格式"
 
 #: ../src/command/video.cpp:569
 msgid "Open video file"
-msgstr "打開視訊檔"
+msgstr "打開視訊檔案"
 
 #: ../src/command/video.cpp:578
 msgid "&Use Dummy Video..."
@@ -1170,7 +1170,7 @@ msgstr "播放字幕行"
 #: ../src/command/video.cpp:623 ../src/command/audio.cpp:260
 #: ../src/command/audio.cpp:261
 msgid "Play current line"
-msgstr "播放當前行"
+msgstr "播放目前行"
 
 #: ../src/command/video.cpp:632
 msgid "Show &Overscan Mask"
@@ -1196,7 +1196,7 @@ msgstr "100%"
 
 #: ../src/command/video.cpp:652
 msgid "Set zoom to 100%"
-msgstr "設置縮放為100%"
+msgstr "設定縮放為100%"
 
 #: ../src/command/video.cpp:669 ../src/command/video.cpp:670
 msgid "Stop video"
@@ -1216,7 +1216,7 @@ msgstr "200%"
 
 #: ../src/command/video.cpp:683
 msgid "Set zoom to 200%"
-msgstr "設置縮放為200%"
+msgstr "設定縮放為200%"
 
 #: ../src/command/video.cpp:699
 msgid "&50%"
@@ -1228,7 +1228,7 @@ msgstr "50%"
 
 #: ../src/command/video.cpp:701
 msgid "Set zoom to 50%"
-msgstr "設置縮放為50%"
+msgstr "設定縮放為50%"
 
 #: ../src/command/video.cpp:717 ../src/command/video.cpp:718
 msgid "Zoom In"
@@ -1252,7 +1252,7 @@ msgstr "貼上"
 
 #: ../src/command/edit.cpp:369
 msgid "set color"
-msgstr "設置顏色"
+msgstr "設定顏色"
 
 #: ../src/command/edit.cpp:383
 msgid "Primary Color..."
@@ -1264,7 +1264,7 @@ msgstr "主要顏色"
 
 #: ../src/command/edit.cpp:385
 msgid "Set the primary fill color (\\c) at the cursor position"
-msgstr "設置主要填充色標籤(\\c)，應用於游標的位置之後"
+msgstr "設定主要填充色標籤(\\c)，套用於游標的位置之後"
 
 #: ../src/command/edit.cpp:395
 msgid "Secondary Color..."
@@ -1276,7 +1276,7 @@ msgstr "次要顏色"
 
 #: ../src/command/edit.cpp:397
 msgid "Set the secondary (karaoke) fill color (\\2c) at the cursor position"
-msgstr "設置次要填充色（用於卡拉OK效果）標籤(\\2c)，應用於滑鼠的位置之後"
+msgstr "設定次要填充色（用於卡拉OK效果）標籤(\\2c)，套用於滑鼠的位置之後"
 
 #: ../src/command/edit.cpp:407
 msgid "Outline Color..."
@@ -1288,7 +1288,7 @@ msgstr "邊框顏色"
 
 #: ../src/command/edit.cpp:409
 msgid "Set the outline color (\\3c) at the cursor position"
-msgstr "設置邊框填充色標籤(\\3c)，應用於游標的位置之後"
+msgstr "設定邊框填充色標籤(\\3c)，套用於游標的位置之後"
 
 #: ../src/command/edit.cpp:419
 msgid "Shadow Color..."
@@ -1300,7 +1300,7 @@ msgstr "陰影顏色"
 
 #: ../src/command/edit.cpp:421
 msgid "Set the shadow color (\\4c) at the cursor position"
-msgstr "設置陰影填充色標籤(\\4c)，應用於游標的位置之後"
+msgstr "設定陰影填充色標籤(\\4c)，套用於游標的位置之後"
 
 #: ../src/command/edit.cpp:431 ../src/command/edit.cpp:432
 msgid "Toggle Bold"
@@ -1309,7 +1309,7 @@ msgstr "加粗"
 #: ../src/command/edit.cpp:433
 msgid ""
 "Toggle bold (\\b) for the current selection or at the current cursor position"
-msgstr "在游標位置添加加粗標籤(\\b)"
+msgstr "在游標位置新增加粗標籤(\\b)"
 
 #: ../src/command/edit.cpp:436
 msgid "toggle bold"
@@ -1323,7 +1323,7 @@ msgstr "斜體"
 msgid ""
 "Toggle italics (\\i) for the current selection or at the current cursor "
 "position"
-msgstr "在游標位置添加斜體標籤(\\i)"
+msgstr "在游標位置新增斜體標籤(\\i)"
 
 #: ../src/command/edit.cpp:448
 msgid "toggle italic"
@@ -1337,7 +1337,7 @@ msgstr "底線"
 msgid ""
 "Toggle underline (\\u) for the current selection or at the current cursor "
 "position"
-msgstr "在游標位置添加底線標籤(\\u)"
+msgstr "在游標位置新增底線標籤(\\u)"
 
 #: ../src/command/edit.cpp:460
 msgid "toggle underline"
@@ -1351,7 +1351,7 @@ msgstr "刪除線"
 msgid ""
 "Toggle strikeout (\\s) for the current selection or at the current cursor "
 "position"
-msgstr "在游標位置添加刪除線標籤(\\s)"
+msgstr "在游標位置新增刪除線標籤(\\s)"
 
 #: ../src/command/edit.cpp:472
 msgid "toggle strikeout"
@@ -1359,31 +1359,31 @@ msgstr "刪除線"
 
 #: ../src/command/edit.cpp:479
 msgid "Font Face..."
-msgstr "字體…"
+msgstr "字型…"
 
 #: ../src/command/edit.cpp:480 ../src/preferences_base.cpp:251
 msgid "Font Face"
-msgstr "字體"
+msgstr "字型"
 
 #: ../src/command/edit.cpp:481
 msgid "Select a font face and size"
-msgstr "設置字體和大小"
+msgstr "設定字型和大小"
 
 #: ../src/command/edit.cpp:508
 msgid "set font"
-msgstr "設置字體"
+msgstr "設定字型"
 
 #: ../src/command/edit.cpp:535
 msgid "Find and R&eplace..."
-msgstr "搜索替換(&R)…"
+msgstr "搜尋取代(&R)…"
 
 #: ../src/command/edit.cpp:536
 msgid "Find and Replace"
-msgstr "搜索替換"
+msgstr "搜尋取代"
 
 #: ../src/command/edit.cpp:537
 msgid "Find and replace words in subtitles"
-msgstr "在字幕中查找並替換字串"
+msgstr "在字幕中尋找並取代字串"
 
 #: ../src/command/edit.cpp:598
 msgid "&Copy Lines"
@@ -1395,7 +1395,7 @@ msgstr "複製行"
 
 #: ../src/command/edit.cpp:600
 msgid "Copy subtitles to the clipboard"
-msgstr "複製字幕到剪貼板"
+msgstr "複製字幕到剪貼簿"
 
 #: ../src/command/edit.cpp:621
 msgid "Cu&t Lines"
@@ -1423,7 +1423,7 @@ msgstr "刪除行"
 
 #: ../src/command/edit.cpp:640
 msgid "Delete currently selected lines"
-msgstr "刪除當前所選行"
+msgstr "刪除目前所選行"
 
 #: ../src/command/edit.cpp:643
 msgid "delete lines"
@@ -1451,26 +1451,26 @@ msgstr "重複所選行"
 
 #: ../src/command/edit.cpp:726 ../src/command/edit.cpp:727
 msgid "Split lines after current frame"
-msgstr "以當前影格後分割行"
+msgstr "以目前影格後分割行"
 
 #: ../src/command/edit.cpp:728
 msgid ""
 "Split the current line into a line which ends on the current frame and a "
 "line which starts on the next frame"
 msgstr ""
-"將當前行以當前影格的時間為界分割為兩行，一行在當前影格結束，另一行在下一影格"
+"將目前行以目前影格的時間為界分割為兩行，一行在目前影格結束，另一行在下一影格"
 "開始"
 
 #: ../src/command/edit.cpp:738 ../src/command/edit.cpp:739
 msgid "Split lines before current frame"
-msgstr "以當前影格前分割行"
+msgstr "以目前影格前分割行"
 
 #: ../src/command/edit.cpp:740
 msgid ""
 "Split the current line into a line which ends on the previous frame and a "
 "line which starts on the current frame"
 msgstr ""
-"將當前行以當前影格的時間為界分割為兩行，一行在前一影格結束，另一行在當前影格"
+"將目前行以目前影格的時間為界分割為兩行，一行在前一影格結束，另一行在目前影格"
 "開始"
 
 #: ../src/command/edit.cpp:775
@@ -1499,7 +1499,7 @@ msgstr "連接"
 
 #: ../src/command/edit.cpp:788
 msgid "Join selected lines in a single one, concatenating text together"
-msgstr "將所選行合併為一個，文本結合為整體"
+msgstr "將所選行合併為一個，文字結合為整體"
 
 #: ../src/command/edit.cpp:791 ../src/command/edit.cpp:802
 msgid "join lines"
@@ -1517,7 +1517,7 @@ msgstr "保留首行"
 msgid ""
 "Join selected lines in a single one, keeping text of first and discarding "
 "remaining"
-msgstr "將所選行合併為一個，僅保留首行文本"
+msgstr "將所選行合併為一個，僅保留首行文字"
 
 #: ../src/command/edit.cpp:840
 msgid "&Paste Lines"
@@ -1602,7 +1602,7 @@ msgstr "在游標處分割（以視訊影格）"
 msgid ""
 "Split the current line at the cursor, dividing the line's duration at the "
 "current video frame"
-msgstr "在游標處分割所選行，以當前影格的時間分割行的持續時間"
+msgstr "在游標處分割所選行，以目前影格的時間分割行的持續時間"
 
 #: ../src/command/edit.cpp:1143
 msgid "Redo last undone action"
@@ -1661,13 +1661,13 @@ msgid "revert line"
 msgstr "還原行"
 
 #: ../src/command/edit.cpp:1207 ../src/command/edit.cpp:1208
-#: ../src/preferences.cpp:386
+#: ../src/preferences.cpp:389
 msgid "Clear"
 msgstr "清除"
 
 #: ../src/command/edit.cpp:1209
 msgid "Clear the current line's text"
-msgstr "清除當前行的所有文本"
+msgstr "清除目前行的所有文字"
 
 #: ../src/command/edit.cpp:1214 ../src/command/edit.cpp:1233
 msgid "clear line"
@@ -1675,11 +1675,11 @@ msgstr "清除行"
 
 #: ../src/command/edit.cpp:1221 ../src/command/edit.cpp:1222
 msgid "Clear Text"
-msgstr "清除文本"
+msgstr "清除文字"
 
 #: ../src/command/edit.cpp:1223
 msgid "Clear the current line's text, leaving override tags"
-msgstr "清除當前行的文本，只保留tag"
+msgstr "清除目前行的文字，只保留tag"
 
 #: ../src/command/edit.cpp:1239 ../src/command/edit.cpp:1240
 #: ../src/command/tool.cpp:271
@@ -1707,7 +1707,7 @@ msgstr "最近打開"
 
 #: ../src/command/recent.cpp:43 ../src/command/recent.cpp:53
 msgid "Open recent audio"
-msgstr "打開最近打開的音訊檔"
+msgstr "打開最近打開的音訊檔案"
 
 #: ../src/command/recent.cpp:44 ../src/command/recent.cpp:64
 msgid "Open recent keyframes"
@@ -1723,11 +1723,11 @@ msgstr "打開最近打開的時間碼檔"
 
 #: ../src/command/recent.cpp:47
 msgid "Open recent video"
-msgstr "打開最近打開的視訊檔"
+msgstr "打開最近打開的視訊檔案"
 
 #: ../src/command/recent.cpp:98
 msgid "Open recent videos"
-msgstr "打開最近打開的視訊檔"
+msgstr "打開最近打開的視訊檔案"
 
 #: ../src/command/subtitle.cpp:78
 msgid "A&ttachments..."
@@ -1743,27 +1743,27 @@ msgstr "打開附件管理器對話方塊"
 
 #: ../src/command/subtitle.cpp:91
 msgid "&Find..."
-msgstr "查找(&F)…"
+msgstr "尋找(&F)…"
 
 #: ../src/command/subtitle.cpp:92 ../src/dialog_search_replace.cpp:46
 msgid "Find"
-msgstr "查找"
+msgstr "尋找"
 
 #: ../src/command/subtitle.cpp:93
 msgid "Search for text in the subtitles"
-msgstr "在字幕中查找文本"
+msgstr "在字幕中尋找文字"
 
 #: ../src/command/subtitle.cpp:104
 msgid "Find &Next"
-msgstr "查找下一個(&N)"
+msgstr "尋找下一個(&N)"
 
 #: ../src/command/subtitle.cpp:105
 msgid "Find Next"
-msgstr "查找下一個"
+msgstr "尋找下一個"
 
 #: ../src/command/subtitle.cpp:106
 msgid "Find next match of last search"
-msgstr "查找下一個匹配的搜索"
+msgstr "尋找下一個符合的搜尋"
 
 #: ../src/command/subtitle.cpp:126 ../src/command/subtitle.cpp:160
 #: ../src/command/subtitle.cpp:202 ../src/command/grid.cpp:82
@@ -1772,43 +1772,43 @@ msgstr "插入行"
 
 #: ../src/command/subtitle.cpp:133
 msgid "&After Current"
-msgstr "當前行之後(&A)"
+msgstr "目前行之後(&A)"
 
 #: ../src/command/subtitle.cpp:134
 msgid "After Current"
-msgstr "當前行之後"
+msgstr "目前行之後"
 
 #: ../src/command/subtitle.cpp:135
 msgid "Insert a new line after the current one"
-msgstr "在當前行之後插入一行"
+msgstr "在目前行之後插入一行"
 
 #: ../src/command/subtitle.cpp:167 ../src/command/subtitle.cpp:168
 msgid "After Current, at Video Time"
-msgstr "當前行之後，以視訊時間起始"
+msgstr "目前行之後，以視訊時間起始"
 
 #: ../src/command/subtitle.cpp:169
 msgid "Insert a new line after the current one, starting at video time"
-msgstr "在當前行之後插入一行，以視訊時間作為開始時間"
+msgstr "在目前行之後插入一行，以視訊時間作為開始時間"
 
 #: ../src/command/subtitle.cpp:178
 msgid "&Before Current"
-msgstr "當前行之前(&B)"
+msgstr "目前行之前(&B)"
 
 #: ../src/command/subtitle.cpp:179
 msgid "Before Current"
-msgstr "當前行之前"
+msgstr "目前行之前"
 
 #: ../src/command/subtitle.cpp:180
 msgid "Insert a new line before the current one"
-msgstr "在當前行之前插入一行"
+msgstr "在目前行之前插入一行"
 
 #: ../src/command/subtitle.cpp:209 ../src/command/subtitle.cpp:210
 msgid "Before Current, at Video Time"
-msgstr "當前行之前，以視訊時間起始"
+msgstr "目前行之前，以視訊時間起始"
 
 #: ../src/command/subtitle.cpp:211
 msgid "Insert a new line before the current one, starting at video time"
-msgstr "在當前行之前插入一行，以視訊時間作為開始時間"
+msgstr "在目前行之前插入一行，以視訊時間作為開始時間"
 
 #: ../src/command/subtitle.cpp:221
 msgid "&New Subtitles"
@@ -1876,19 +1876,19 @@ msgstr "從視訊中打開字幕"
 
 #: ../src/command/subtitle.cpp:284
 msgid "Open the subtitles from the current video file"
-msgstr "從當前視訊中打開內嵌字幕"
+msgstr "從目前視訊中打開內嵌字幕"
 
 #: ../src/command/subtitle.cpp:300
 msgid "&Properties..."
-msgstr "配置(&P)…"
+msgstr "屬性(&P)…"
 
 #: ../src/command/subtitle.cpp:301
 msgid "Properties"
-msgstr "配置"
+msgstr "屬性"
 
 #: ../src/command/subtitle.cpp:302
 msgid "Open script properties window"
-msgstr "打開腳本配置視窗"
+msgstr "打開腳本屬性視窗"
 
 #: ../src/command/subtitle.cpp:313
 msgid "Save subtitles file"
@@ -1904,7 +1904,7 @@ msgstr "儲存字幕"
 
 #: ../src/command/subtitle.cpp:335
 msgid "Save the current subtitles"
-msgstr "儲存當前字幕檔案"
+msgstr "儲存目前字幕檔案"
 
 #: ../src/command/subtitle.cpp:350
 msgid "Save Subtitles &as..."
@@ -1916,7 +1916,7 @@ msgstr "另存為字幕"
 
 #: ../src/command/subtitle.cpp:352
 msgid "Save subtitles with another name"
-msgstr "以其它檔案名儲存字幕"
+msgstr "以其它檔名儲存字幕"
 
 #: ../src/command/subtitle.cpp:361 ../src/dialog_selected_choices.cpp:26
 #: ../src/subs_edit_ctrl.cpp:369 ../src/dialog_export.cpp:125
@@ -1937,7 +1937,7 @@ msgstr "選擇可見行"
 
 #: ../src/command/subtitle.cpp:377
 msgid "Select all dialogue lines that are visible on the current video frame"
-msgstr "選擇當前視訊影格中可見的所有行"
+msgstr "選擇目前視訊影格中可見的所有行"
 
 #: ../src/command/subtitle.cpp:407
 msgid "Spell &Checker..."
@@ -1979,15 +1979,15 @@ msgstr "儲存一個處理後的不同格式的字幕副本"
 
 #: ../src/command/tool.cpp:83
 msgid "&Fonts Collector..."
-msgstr "字體收集器(&F)…"
+msgstr "字型收集器(&F)…"
 
 #: ../src/command/tool.cpp:84 ../src/dialog_fonts_collector.cpp:218
 msgid "Fonts Collector"
-msgstr "字體收集器"
+msgstr "字型收集器"
 
 #: ../src/command/tool.cpp:85
 msgid "Open fonts collector"
-msgstr "打開字體收集器"
+msgstr "打開字型收集器"
 
 #: ../src/command/tool.cpp:95
 msgid "S&elect Lines..."
@@ -2037,7 +2037,7 @@ msgstr "預覽更改(&P)"
 
 #: ../src/command/tool.cpp:154 ../src/command/tool.cpp:238
 msgid "Commit changes and stay on the current line"
-msgstr "接受更改並停留在當前行"
+msgstr "接受更改並停留在目前行"
 
 #: ../src/command/tool.cpp:164
 msgid "&Styles Manager..."
@@ -2120,7 +2120,7 @@ msgstr "插入原文(&I)"
 
 #: ../src/command/tool.cpp:272
 msgid "Insert the untranslated text"
-msgstr "插入未翻譯的文本"
+msgstr "插入未翻譯的文字"
 
 #: ../src/command/app.cpp:58
 msgid "&About"
@@ -2220,15 +2220,15 @@ msgstr "檢視事件記錄"
 
 #: ../src/command/app.cpp:194
 msgid "New &Window"
-msgstr "新建視窗(&W)"
+msgstr "開新視窗(&W)"
 
 #: ../src/command/app.cpp:195
 msgid "New Window"
-msgstr "新建視窗"
+msgstr "開新視窗"
 
 #: ../src/command/app.cpp:196
 msgid "Open a new application window"
-msgstr "打開一個新的應用視窗"
+msgstr "打開一個新的應用程式視窗"
 
 #: ../src/command/app.cpp:206
 msgid "&Options..."
@@ -2236,15 +2236,15 @@ msgstr "選項(&O)…"
 
 #: ../src/command/app.cpp:208
 msgid "Configure Aegisub"
-msgstr "配置Aegisub"
+msgstr "設定Aegisub"
 
 #: ../src/command/app.cpp:222 ../src/command/app.cpp:223
 msgid "Toggle global hotkey overrides"
-msgstr "切換全域熱鍵模式"
+msgstr "切換全域快捷鍵模式"
 
 #: ../src/command/app.cpp:224
 msgid "Toggle global hotkey overrides (Medusa Mode)"
-msgstr "切換全域熱鍵模式（Medusa模式）"
+msgstr "切換全域快捷鍵模式（Medusa模式）"
 
 #: ../src/command/app.cpp:239
 msgid "Toggle the main toolbar"
@@ -2272,15 +2272,15 @@ msgstr "檢查是否有可用的新版Aegisub"
 
 #: ../src/command/grid.cpp:53
 msgid "Move to the next subtitle line"
-msgstr "移動到下一字幕行"
+msgstr "移動到下行一字幕"
 
 #: ../src/command/grid.cpp:65
 msgid "Move to the next subtitle line, creating a new one if needed"
-msgstr "移動到下一字幕行，如果需要則創建新一行"
+msgstr "移動到下行一字幕，如果需要則建立新的一行"
 
 #: ../src/command/grid.cpp:92
 msgid "Move to the previous line"
-msgstr "移動到上一字幕行"
+msgstr "移動到上行一字幕"
 
 #: ../src/command/grid.cpp:101 ../src/command/grid.cpp:121
 msgid "&Actor Name"
@@ -2449,7 +2449,7 @@ msgstr "顯示簡化標籤"
 #: ../src/command/grid.cpp:312
 msgid ""
 "Replace override tags in the subtitle grid with a simplified placeholder"
-msgstr "將字幕欄的特效標籤替換為符號顯示"
+msgstr "將字幕欄的特效標籤取代為符號顯示"
 
 #: ../src/command/grid.cpp:348 ../src/command/grid.cpp:349
 msgid "Move line up"
@@ -2520,7 +2520,7 @@ msgid "&Automation..."
 msgstr "自動化(&A)…"
 
 #: ../src/command/automation.cpp:75 ../src/command/automation.cpp:87
-#: ../src/preferences.cpp:311
+#: ../src/preferences.cpp:314
 msgid "Automation"
 msgstr "自動化"
 
@@ -2566,15 +2566,15 @@ msgstr "更改字幕時間，使開始時間從前一行的結束時間開始"
 
 #: ../src/command/time.cpp:127
 msgid "Shift to &Current Frame"
-msgstr "平移至當前影格(&C)"
+msgstr "平移至目前影格(&C)"
 
 #: ../src/command/time.cpp:128
 msgid "Shift to Current Frame"
-msgstr "平移至當前影格"
+msgstr "平移至目前影格"
 
 #: ../src/command/time.cpp:129
 msgid "Shift selection so that the active line starts at current frame"
-msgstr "平移所選行使選中的行始於當前影格"
+msgstr "平移所選行使選中的行始於目前影格"
 
 #: ../src/command/time.cpp:145
 msgid "shift to frame"
@@ -2603,7 +2603,7 @@ msgstr "視訊抓取為結束時間"
 
 #: ../src/command/time.cpp:183
 msgid "Set end of selected subtitles to current video frame"
-msgstr "將當前視訊影格設為所選字幕的結束時間"
+msgstr "將目前視訊影格設為所選字幕的結束時間"
 
 #: ../src/command/time.cpp:193
 msgid "Snap to S&cene"
@@ -2616,7 +2616,7 @@ msgstr "緊貼鏡頭"
 #: ../src/command/time.cpp:195
 msgid ""
 "Set start and end of subtitles to the keyframes around current video frame"
-msgstr "設置字幕的開始與結束緊貼至當前視訊影格附近的關鍵影格"
+msgstr "設定字幕的開始與結束緊貼至目前視訊影格附近的關鍵影格"
 
 #: ../src/command/time.cpp:232
 msgid "snap to scene"
@@ -2661,7 +2661,7 @@ msgstr "增加長度與偏移"
 #: ../src/command/time.cpp:288
 msgid ""
 "Increase the length of the current timing unit and shift the following items"
-msgstr "增加當前時間軸長度並平移下面的項目"
+msgstr "增加目前時間軸長度並平移下面的項目"
 
 #: ../src/command/time.cpp:297 ../src/command/time.cpp:298
 msgid "Decrease length"
@@ -2678,7 +2678,7 @@ msgstr "減少長度與偏移"
 #: ../src/command/time.cpp:310
 msgid ""
 "Decrease the length of the current timing unit and shift the following items"
-msgstr "減少當前時間軸長度並平移下面的項目"
+msgstr "減少目前時間軸長度並平移下面的項目"
 
 #: ../src/command/time.cpp:319 ../src/command/time.cpp:320
 msgid "Shift start time forward"
@@ -2686,7 +2686,7 @@ msgstr "向前平移開始時間"
 
 #: ../src/command/time.cpp:321
 msgid "Shift the start time of the current timing unit forward"
-msgstr "向前平移當前時間軸的開始時間"
+msgstr "向前平移目前時間軸的開始時間"
 
 #: ../src/command/time.cpp:330 ../src/command/time.cpp:331
 msgid "Shift start time backward"
@@ -2694,7 +2694,7 @@ msgstr "向後平移開始時間"
 
 #: ../src/command/time.cpp:332
 msgid "Shift the start time of the current timing unit backward"
-msgstr "向後平移當前時間軸的開始時間"
+msgstr "向後平移目前時間軸的開始時間"
 
 #: ../src/command/time.cpp:342
 msgid "Snap &Start to Video"
@@ -2706,7 +2706,7 @@ msgstr "視訊抓取為開始時間"
 
 #: ../src/command/time.cpp:344
 msgid "Set start of selected subtitles to current video frame"
-msgstr "將當前視訊影格設為所選字幕的開始時間"
+msgstr "將目前視訊影格設為所選字幕的開始時間"
 
 #: ../src/command/time.cpp:356
 msgid "Next line or syllable"
@@ -2783,19 +2783,19 @@ msgstr "關閉音訊"
 
 #: ../src/command/audio.cpp:67
 msgid "Close the currently open audio file"
-msgstr "關閉當前開啟的音訊檔案"
+msgstr "關閉目前開啟的音訊檔案"
 
 #: ../src/command/audio.cpp:77
 msgid "&Open Audio File..."
-msgstr "打開音訊檔(&O)…"
+msgstr "打開音訊檔案(&O)…"
 
 #: ../src/command/audio.cpp:78 ../src/command/audio.cpp:85
 msgid "Open Audio File"
-msgstr "打開音訊檔"
+msgstr "打開音訊檔案"
 
 #: ../src/command/audio.cpp:79
 msgid "Open an audio file"
-msgstr "打開一個音訊檔"
+msgstr "打開一個音訊檔案"
 
 #: ../src/command/audio.cpp:82
 msgid "Audio Formats"
@@ -2827,7 +2827,7 @@ msgstr "從視訊中打開音訊"
 
 #: ../src/command/audio.cpp:118
 msgid "Open the audio from the current video file"
-msgstr "從當前視訊檔中打開音訊"
+msgstr "從目前視訊檔案中打開音訊"
 
 #: ../src/command/audio.cpp:132
 msgid "&Spectrum Display"
@@ -2855,11 +2855,11 @@ msgstr "以波形方式顯示音訊"
 
 #: ../src/command/audio.cpp:187 ../src/command/audio.cpp:188
 msgid "Create audio clip"
-msgstr "創建音訊剪輯"
+msgstr "建立音訊剪輯"
 
 #: ../src/command/audio.cpp:189
 msgid "Save an audio clip of the selected line"
-msgstr "創建所選行的音訊剪輯"
+msgstr "建立所選行的音訊剪輯"
 
 #: ../src/command/audio.cpp:200
 msgid "Save audio clip"
@@ -2867,15 +2867,15 @@ msgstr "儲存音訊剪輯"
 
 #: ../src/command/audio.cpp:247 ../src/command/audio.cpp:248
 msgid "Play current audio selection"
-msgstr "播放當前選擇部分音訊"
+msgstr "播放目前選擇部分音訊"
 
 #: ../src/command/audio.cpp:249
 msgid "Play the current audio selection, ignoring changes made while playing"
-msgstr "播放當前選擇部分音訊，播放時忽略所做的更改"
+msgstr "播放目前選擇部分音訊，播放時忽略所做的更改"
 
 #: ../src/command/audio.cpp:262
 msgid "Play the audio for the current line"
-msgstr "播放當前行"
+msgstr "播放目前行"
 
 #: ../src/command/audio.cpp:275 ../src/command/audio.cpp:276
 msgid "Play audio selection"
@@ -2950,15 +2950,15 @@ msgstr "接受更改並移動到下一行"
 
 #: ../src/command/audio.cpp:426
 msgid "Commit any pending audio timing changes and move to the next line"
-msgstr "提交所有通過音訊對時間的更改並移動到下一行"
+msgstr "提交所有夠過音訊對時間的更改並移動到下一行"
 
 #: ../src/command/audio.cpp:439 ../src/command/audio.cpp:440
 msgid "Commit and stay on current line"
-msgstr "提交並留在當前行"
+msgstr "提交並留在目前行"
 
 #: ../src/command/audio.cpp:441
 msgid "Commit any pending audio timing changes and stay on the current line"
-msgstr "提交所有通過音訊對時間的更改並留在當前行"
+msgstr "提交所有夠過音訊對時間的更改並留在目前行"
 
 #: ../src/command/audio.cpp:452 ../src/command/audio.cpp:453
 msgid "Go to selection"
@@ -3019,15 +3019,15 @@ msgstr "切換卡拉OK模式"
 
 #: ../src/command/help.cpp:48
 msgid "&Bug Tracker..."
-msgstr "Bug追蹤器(&B)…"
+msgstr "Bug 追蹤器(&B)…"
 
 #: ../src/command/help.cpp:49
 msgid "Bug Tracker"
-msgstr "Bug追蹤器"
+msgstr "Bug 追蹤器"
 
 #: ../src/command/help.cpp:50
 msgid "Visit Aegisub's bug tracker to report bugs and request new features"
-msgstr "訪問Aegisub的bug追蹤器來報告bug和要求新增功能"
+msgstr "造訪 Aegisub 的 bug 追蹤器來回報 bug 和要求新增功能"
 
 #: ../src/command/help.cpp:69
 msgid "&Contents"
@@ -3051,7 +3051,7 @@ msgstr "論壇"
 
 #: ../src/command/help.cpp:83
 msgid "Visit Aegisub's forums"
-msgstr "訪問Aegisub的論壇"
+msgstr "造訪 Aegisub 的論壇"
 
 #: ../src/command/help.cpp:93
 msgid "&IRC Channel"
@@ -3063,7 +3063,7 @@ msgstr "IRC 頻道"
 
 #: ../src/command/help.cpp:95
 msgid "Visit Aegisub's official IRC channel"
-msgstr "訪問Aegisub的官方IRC頻道"
+msgstr "造訪 Aegisub 的官方 IRC 頻道"
 
 #: ../src/command/help.cpp:105
 msgid "&Visual Typesetting"
@@ -3087,7 +3087,7 @@ msgstr "網站"
 
 #: ../src/command/help.cpp:119
 msgid "Visit Aegisub's official website"
-msgstr "訪問Aegisub的官方網站"
+msgstr "造訪 Aegisub 的官方網站"
 
 #: ../src/command/keyframe.cpp:49 ../src/command/keyframe.cpp:50
 msgid "Close Keyframes"
@@ -3096,7 +3096,7 @@ msgstr "關閉關鍵影格"
 #: ../src/command/keyframe.cpp:51
 msgid ""
 "Discard the currently loaded keyframes and use those from the video, if any"
-msgstr "丟棄當前載入的關鍵影格，並使用來自視訊的關鍵影格，如果有的話"
+msgstr "丟棄目前載入的關鍵影格，並使用來自視訊的關鍵影格，如果有的話"
 
 #: ../src/command/keyframe.cpp:66
 msgid "Open Keyframes..."
@@ -3124,7 +3124,7 @@ msgstr "儲存關鍵影格"
 
 #: ../src/command/keyframe.cpp:87
 msgid "Save the current list of keyframes to a file"
-msgstr "儲存當前的關鍵影格列表"
+msgstr "儲存目前的關鍵影格列表"
 
 #: ../src/command/keyframe.cpp:95
 msgid "Save keyframes file"
@@ -3136,7 +3136,7 @@ msgstr "不選(&N)"
 
 #: ../src/subtitles_provider_libass.cpp:112
 msgid "Updating font index"
-msgstr "更新字體索引"
+msgstr "更新字型索引"
 
 #: ../src/subtitles_provider_libass.cpp:113
 msgid "This may take several minutes"
@@ -3148,11 +3148,11 @@ msgstr "拼寫錯誤詞語："
 
 #: ../src/dialog_spellchecker.cpp:127 ../src/dialog_search_replace.cpp:73
 msgid "Replace with:"
-msgstr "替換為："
+msgstr "取代為："
 
 #: ../src/dialog_spellchecker.cpp:182 ../src/dialog_search_replace.cpp:80
 msgid "&Skip Comments"
-msgstr "忽略註釋(&S)"
+msgstr "忽略註解(&S)"
 
 #: ../src/dialog_spellchecker.cpp:183
 msgid "Ignore &UPPERCASE words"
@@ -3160,11 +3160,11 @@ msgstr "忽略與大寫的單詞(&U)"
 
 #: ../src/dialog_spellchecker.cpp:187
 msgid "&Replace"
-msgstr "替換(&R)"
+msgstr "取代(&R)"
 
 #: ../src/dialog_spellchecker.cpp:190 ../src/dialog_search_replace.cpp:95
 msgid "Replace &all"
-msgstr "替換全部(&A)"
+msgstr "取代全部(&A)"
 
 #: ../src/dialog_spellchecker.cpp:197
 msgid "&Ignore"
@@ -3176,7 +3176,7 @@ msgstr "忽略全部(&L)"
 
 #: ../src/dialog_spellchecker.cpp:206
 msgid "Add to &dictionary"
-msgstr "添加至詞典(&D)"
+msgstr "新增至詞典(&D)"
 
 #: ../src/dialog_spellchecker.cpp:212
 msgid "Remove fro&m dictionary"
@@ -3196,7 +3196,7 @@ msgstr "Aegisub沒有發現該腳本的拼寫錯誤。"
 
 #: ../src/dialog_spellchecker.cpp:329 ../src/dialog_spellchecker.cpp:343
 msgid "spell check replace"
-msgstr "拼寫檢查替換"
+msgstr "拼寫檢查取代"
 
 #: ../src/preferences_base.cpp:63
 msgid "Please choose the folder:"
@@ -3212,11 +3212,11 @@ msgstr "選擇…"
 
 #: ../src/preferences_base.cpp:252
 msgid "Font Size"
-msgstr "字體大小"
+msgstr "字型大小"
 
 #: ../src/dialog_properties.cpp:89
 msgid "Script Properties"
-msgstr "腳本配置"
+msgstr "腳本屬性"
 
 #: ../src/dialog_properties.cpp:95
 msgid "Script"
@@ -3297,24 +3297,24 @@ msgstr ""
 
 #: ../src/dialog_properties.cpp:193
 msgid "property changes"
-msgstr "配置更改"
+msgstr "屬性更改"
 
 #: ../src/dialog_fonts_collector.cpp:107
 msgid "Symlinking fonts to folder...\n"
-msgstr "複製字體至資料夾…\n"
+msgstr "複製字型至資料夾…\n"
 
 #: ../src/dialog_fonts_collector.cpp:111
 msgid "Copying fonts to folder...\n"
-msgstr "複製字體至資料夾…\n"
+msgstr "複製字型至資料夾…\n"
 
 #: ../src/dialog_fonts_collector.cpp:114
 msgid "Copying fonts to archive...\n"
-msgstr "複製字體至壓縮檔…\n"
+msgstr "複製字型至壓縮檔…\n"
 
 #: ../src/dialog_fonts_collector.cpp:126
 #, c-format
 msgid "* Failed to create directory '%s': %s.\n"
-msgstr "* 無法創建目錄 '%s'： %s。 \n"
+msgstr "* 無法建立目錄 '%s'： %s。 \n"
 
 #: ../src/dialog_fonts_collector.cpp:137
 #, c-format
@@ -3343,11 +3343,11 @@ msgstr "* 複製失敗 %s。\n"
 
 #: ../src/dialog_fonts_collector.cpp:204
 msgid "Done. All fonts copied."
-msgstr "完成。所有字體已複製。"
+msgstr "完成。所有字型已複製。"
 
 #: ../src/dialog_fonts_collector.cpp:206
 msgid "Done. Some fonts could not be copied."
-msgstr "完成。部分字體未複製。"
+msgstr "完成。部分字型未複製。"
 
 #: ../src/dialog_fonts_collector.cpp:209
 msgid ""
@@ -3356,28 +3356,28 @@ msgid ""
 "player if they are all attached to a Matroska file."
 msgstr ""
 "\n"
-"超過32 MB的字體被複製。如果它們都被附加在一個Matroska(MKV)檔，一些字體可能不"
-"會被播放機被載入。"
+"超過32 MB的字型被複製。如果它們都被附加在一個 Matroska(MKV)檔，一些字型可能不"
+"會被播放器被載入。"
 
 #: ../src/dialog_fonts_collector.cpp:224
 msgid "Check fonts for availability"
-msgstr "檢查已使用的字體"
+msgstr "檢查已使用的字型"
 
 #: ../src/dialog_fonts_collector.cpp:225
 msgid "Copy fonts to folder"
-msgstr "複製字體至資料夾"
+msgstr "複製字型至資料夾"
 
 #: ../src/dialog_fonts_collector.cpp:226
 msgid "Copy fonts to subtitle file's folder"
-msgstr "複製字體至字幕檔所在資料夾"
+msgstr "複製字型至字幕檔所在資料夾"
 
 #: ../src/dialog_fonts_collector.cpp:227
 msgid "Copy fonts to zipped archive"
-msgstr "複製字體至壓縮檔"
+msgstr "複製字型至壓縮檔"
 
 #: ../src/dialog_fonts_collector.cpp:229
 msgid "Symlink fonts to folder"
-msgstr "複製字體至資料夾"
+msgstr "複製字型至資料夾"
 
 #: ../src/dialog_fonts_collector.cpp:232 ../src/dialog_selection.cpp:150
 msgid "Action"
@@ -3404,7 +3404,7 @@ msgid "Invalid destination."
 msgstr "無效目標。"
 
 #: ../src/dialog_fonts_collector.cpp:301 ../src/dialog_fonts_collector.cpp:306
-#: ../src/dialog_fonts_collector.cpp:311 ../src/preferences.cpp:255
+#: ../src/dialog_fonts_collector.cpp:311 ../src/preferences.cpp:257
 #: ../src/dialog_kara_timing_copy.cpp:574
 #: ../src/dialog_kara_timing_copy.cpp:576
 #: ../src/dialog_kara_timing_copy.cpp:626
@@ -3413,7 +3413,7 @@ msgstr "錯誤"
 
 #: ../src/dialog_fonts_collector.cpp:306
 msgid "Could not create destination folder."
-msgstr "無法創建目的檔案夾。"
+msgstr "無法建立目的檔案夾。"
 
 #: ../src/dialog_fonts_collector.cpp:311
 msgid "Invalid path for .zip file."
@@ -3425,7 +3425,7 @@ msgstr "選擇壓縮檔名"
 
 #: ../src/dialog_fonts_collector.cpp:342
 msgid "Select folder to save fonts on"
-msgstr "選取用以儲存字體的資料夾"
+msgstr "選取用以儲存字型的資料夾"
 
 #: ../src/dialog_fonts_collector.cpp:356
 msgid "N/A"
@@ -3435,7 +3435,7 @@ msgstr "空"
 msgid ""
 "Choose the folder where the fonts will be collected to. It will be created "
 "if it doesn't exist."
-msgstr "選擇用於放置所收集字體的資料夾。若資料夾不存在則會新建。"
+msgstr "選擇用於放置所收集字型的資料夾。若資料夾不存在則會新建。"
 
 #: ../src/dialog_fonts_collector.cpp:371
 msgid ""
@@ -3481,7 +3481,7 @@ msgid "Resulting duration: %s"
 msgstr "最終長度： %s"
 
 #: ../src/preferences.cpp:61 ../src/preferences.cpp:63
-#: ../src/preferences.cpp:313 ../src/preferences.cpp:338
+#: ../src/preferences.cpp:316 ../src/preferences.cpp:341
 msgid "General"
 msgstr "一般"
 
@@ -3515,7 +3515,7 @@ msgstr "詢問"
 
 #: ../src/preferences.cpp:72
 msgid "Automatically load linked files"
-msgstr "自動載入連結的檔："
+msgstr "自動載入連結的檔案："
 
 #: ../src/preferences.cpp:73
 msgid "Undo Levels"
@@ -3531,7 +3531,7 @@ msgstr "檔案"
 
 #: ../src/preferences.cpp:77
 msgid "Find/Replace"
-msgstr "搜索/替換"
+msgstr "搜尋/取代"
 
 #: ../src/preferences.cpp:83
 msgid "Default styles"
@@ -3548,9 +3548,9 @@ msgid ""
 "\n"
 "You can set up style catalogs in the Style Manager."
 msgstr ""
-"所選的樣式庫將會在新建檔或者導入不同格式的檔案時被自動加載。 \n"
+"所選的樣式庫將會在新建檔或者匯入不同格式的檔案時被自動載入。 \n"
 "\n"
-"您可以在樣式管理器中設置樣式庫。"
+"您可以在樣式管理器中設定樣式庫。"
 
 #: ../src/preferences.cpp:114
 msgid "New files"
@@ -3558,21 +3558,21 @@ msgstr "新建字幕"
 
 #: ../src/preferences.cpp:115
 msgid "MicroDVD import"
-msgstr "導入MicroDVD字幕"
+msgstr "匯入MicroDVD字幕"
 
 #: ../src/preferences.cpp:116
 msgid "SRT import"
-msgstr "導入SRT字幕"
+msgstr "匯入SRT字幕"
 
 #: ../src/preferences.cpp:117
 msgid "TTXT import"
-msgstr "導入TTXT"
+msgstr "匯入TTXT"
 
 #: ../src/preferences.cpp:118
 msgid "Plain text import"
-msgstr "導入純文本"
+msgstr "匯入純文字"
 
-#: ../src/preferences.cpp:125 ../src/preferences.cpp:351
+#: ../src/preferences.cpp:125 ../src/preferences.cpp:354
 msgid "Audio"
 msgstr "音訊"
 
@@ -3614,15 +3614,15 @@ msgstr "預設延後結束時間長度（毫秒）"
 
 #: ../src/preferences.cpp:138
 msgid "Marker drag-start sensitivity (px)"
-msgstr "標記拖動開始靈敏度（圖元）"
+msgstr "標記拖動開始靈敏度（像素）"
 
 #: ../src/preferences.cpp:139
 msgid "Line boundary thickness (px)"
-msgstr "邊線寬度（圖元）"
+msgstr "邊線寬度（像素）"
 
 #: ../src/preferences.cpp:140
 msgid "Maximum snap distance (px)"
-msgstr "最大緊貼標記距離（圖元）"
+msgstr "最大緊貼標記距離（像素）"
 
 #: ../src/preferences.cpp:142
 msgid "Don't show"
@@ -3836,370 +3836,384 @@ msgstr "語法高亮"
 msgid "Background"
 msgstr "背景"
 
-#: ../src/preferences.cpp:250 ../src/preferences.cpp:323
+#: ../src/preferences.cpp:250 ../src/preferences.cpp:326
 msgid "Normal"
 msgstr "普通"
 
 #: ../src/preferences.cpp:251
+#, fuzzy
+msgid "Comments"
+msgstr "註解(&N)"
+
+#: ../src/preferences.cpp:252
+msgid "Drawings"
+msgstr ""
+
+#: ../src/preferences.cpp:253
 msgid "Brackets"
 msgstr "大括弧"
 
-#: ../src/preferences.cpp:252
+#: ../src/preferences.cpp:254
 msgid "Slashes and Parentheses"
 msgstr "斜杠和圓括號"
 
-#: ../src/preferences.cpp:253
+#: ../src/preferences.cpp:255
 msgid "Tags"
 msgstr "標籤"
 
-#: ../src/preferences.cpp:254
+#: ../src/preferences.cpp:256
 msgid "Parameters"
 msgstr "參數"
 
-#: ../src/preferences.cpp:256
+#: ../src/preferences.cpp:258
 msgid "Error Background"
 msgstr "錯誤背景"
 
-#: ../src/preferences.cpp:257
+#: ../src/preferences.cpp:259
 msgid "Line Break"
 msgstr "分行符號"
 
-#: ../src/preferences.cpp:258
+#: ../src/preferences.cpp:260
 msgid "Karaoke templates"
-msgstr "卡拉OK模版"
+msgstr "卡拉OK範本"
 
-#: ../src/preferences.cpp:264
+#: ../src/preferences.cpp:261
+#, fuzzy
+msgid "Karaoke variables"
+msgstr "卡拉OK範本"
+
+#: ../src/preferences.cpp:267
 msgid "Audio Color Schemes"
 msgstr "音訊配色方案"
 
-#: ../src/preferences.cpp:266 ../src/preferences.cpp:367
+#: ../src/preferences.cpp:269 ../src/preferences.cpp:370
 msgid "Spectrum"
 msgstr "頻譜模式"
 
-#: ../src/preferences.cpp:267
+#: ../src/preferences.cpp:270
 msgid "Waveform"
 msgstr "波形模式"
 
-#: ../src/preferences.cpp:269
+#: ../src/preferences.cpp:272
 msgid "Subtitle Grid"
 msgstr "字幕欄"
 
-#: ../src/preferences.cpp:270
+#: ../src/preferences.cpp:273
 msgid "Standard foreground"
 msgstr "普通行前景色"
 
-#: ../src/preferences.cpp:271
+#: ../src/preferences.cpp:274
 msgid "Standard background"
 msgstr "普通行背景色"
 
-#: ../src/preferences.cpp:272
+#: ../src/preferences.cpp:275
 msgid "Selection foreground"
 msgstr "選取行前景色"
 
-#: ../src/preferences.cpp:273
+#: ../src/preferences.cpp:276
 msgid "Selection background"
 msgstr "選取行背景色"
 
-#: ../src/preferences.cpp:274
+#: ../src/preferences.cpp:277
 msgid "Collision foreground"
 msgstr "衝突行前景色"
 
-#: ../src/preferences.cpp:275
+#: ../src/preferences.cpp:278
 msgid "In frame background"
-msgstr "在當前影格顯示的行背景色"
+msgstr "在目前影格顯示的行背景色"
 
-#: ../src/preferences.cpp:276
+#: ../src/preferences.cpp:279
 msgid "Comment background"
 msgstr "注釋行背景色"
 
-#: ../src/preferences.cpp:277
+#: ../src/preferences.cpp:280
 msgid "Selected comment background"
 msgstr "選中注釋行背景色"
 
-#: ../src/preferences.cpp:278
+#: ../src/preferences.cpp:281
 msgid "Header background"
 msgstr "表頭背景色"
 
-#: ../src/preferences.cpp:279
+#: ../src/preferences.cpp:282
 msgid "Left Column"
 msgstr "左邊欄顏色"
 
-#: ../src/preferences.cpp:280
+#: ../src/preferences.cpp:283
 msgid "Active Line Border"
 msgstr "活動行邊框顏色"
 
-#: ../src/preferences.cpp:281
+#: ../src/preferences.cpp:284
 msgid "Lines"
 msgstr "分隔線顏色"
 
-#: ../src/preferences.cpp:282
+#: ../src/preferences.cpp:285
 msgid "CPS Error"
 msgstr "每秒字元數錯誤"
 
-#: ../src/preferences.cpp:291
+#: ../src/preferences.cpp:294
 msgid "Backup"
 msgstr "備份"
 
-#: ../src/preferences.cpp:293
+#: ../src/preferences.cpp:296
 msgid "Automatic Save"
 msgstr "自動儲存"
 
-#: ../src/preferences.cpp:294 ../src/preferences.cpp:302
+#: ../src/preferences.cpp:297 ../src/preferences.cpp:305
 msgid "Enable"
 msgstr "啟用"
 
-#: ../src/preferences.cpp:297
+#: ../src/preferences.cpp:300
 msgid "Interval in seconds"
 msgstr "儲存間隔（秒）"
 
-#: ../src/preferences.cpp:298 ../src/preferences.cpp:304
-#: ../src/preferences.cpp:365
+#: ../src/preferences.cpp:301 ../src/preferences.cpp:307
+#: ../src/preferences.cpp:368
 msgid "Path"
 msgstr "儲存路徑"
 
-#: ../src/preferences.cpp:299
+#: ../src/preferences.cpp:302
 msgid "Autosave after every change"
 msgstr "每次更改後自動儲存"
 
-#: ../src/preferences.cpp:301
+#: ../src/preferences.cpp:304
 msgid "Automatic Backup"
 msgstr "自動備份"
 
-#: ../src/preferences.cpp:315
+#: ../src/preferences.cpp:318
 msgid "Base path"
 msgstr "根路徑"
 
-#: ../src/preferences.cpp:316
+#: ../src/preferences.cpp:319
 msgid "Include path"
 msgstr "包含路徑"
 
-#: ../src/preferences.cpp:317
+#: ../src/preferences.cpp:320
 msgid "Auto-load path"
 msgstr "自動載入路徑"
 
-#: ../src/preferences.cpp:319
+#: ../src/preferences.cpp:322
 msgid "0: Fatal"
 msgstr "0: 致命"
 
-#: ../src/preferences.cpp:319
+#: ../src/preferences.cpp:322
 msgid "1: Error"
 msgstr "1: 錯誤"
 
-#: ../src/preferences.cpp:319
+#: ../src/preferences.cpp:322
 msgid "2: Warning"
 msgstr "2: 警告"
 
-#: ../src/preferences.cpp:319
+#: ../src/preferences.cpp:322
 msgid "3: Hint"
 msgstr "3: 提示"
 
-#: ../src/preferences.cpp:319
+#: ../src/preferences.cpp:322
 msgid "4: Debug"
-msgstr "4: 調試"
+msgstr "4: 偵錯"
 
-#: ../src/preferences.cpp:319
+#: ../src/preferences.cpp:322
 msgid "5: Trace"
 msgstr "5: 追蹤"
 
-#: ../src/preferences.cpp:321
+#: ../src/preferences.cpp:324
 msgid "Trace level"
 msgstr "跟蹤等級"
 
-#: ../src/preferences.cpp:323
+#: ../src/preferences.cpp:326
 msgid "Below Normal (recommended)"
 msgstr "低於正常（推薦）"
 
-#: ../src/preferences.cpp:323
+#: ../src/preferences.cpp:326
 msgid "Lowest"
 msgstr "最低"
 
-#: ../src/preferences.cpp:325
+#: ../src/preferences.cpp:328
 msgid "Thread priority"
 msgstr "執行緒優先順序"
 
-#: ../src/preferences.cpp:327
+#: ../src/preferences.cpp:330
 msgid "No scripts"
 msgstr "無腳本"
 
-#: ../src/preferences.cpp:327
+#: ../src/preferences.cpp:330
 msgid "Subtitle-local scripts"
 msgstr "本地字幕腳本"
 
-#: ../src/preferences.cpp:327
+#: ../src/preferences.cpp:330
 msgid "Global autoload scripts"
 msgstr "全域自動載入腳本"
 
-#: ../src/preferences.cpp:327
+#: ../src/preferences.cpp:330
 msgid "All scripts"
 msgstr "所有腳本"
 
-#: ../src/preferences.cpp:329
+#: ../src/preferences.cpp:332
 msgid "Autoreload on Export"
 msgstr "自動重新載入輸出"
 
-#: ../src/preferences.cpp:336
+#: ../src/preferences.cpp:339
 msgid "Advanced"
-msgstr "高級"
+msgstr "進階"
 
-#: ../src/preferences.cpp:340
+#: ../src/preferences.cpp:343
 msgid ""
 "Changing these settings might result in bugs and/or crashes.  Do not touch "
 "these unless you know what you're doing."
 msgstr ""
-"修改這些設置可能導致出錯，甚至異常崩潰， \n"
-"除非您知道自己在做什麼，否則請不要修改這些設置。"
+"修改這些設定可能導致出錯，甚至異常崩潰， \n"
+"除非您知道自己在做什麼，否則請不要修改這些設定。"
 
-#: ../src/preferences.cpp:353 ../src/preferences.cpp:416
+#: ../src/preferences.cpp:356 ../src/preferences.cpp:419
 msgid "Expert"
-msgstr "專家設置"
+msgstr "專家設定"
 
-#: ../src/preferences.cpp:356
+#: ../src/preferences.cpp:359
 msgid "Audio provider"
 msgstr "音訊來自"
 
-#: ../src/preferences.cpp:359
-msgid "Audio player"
-msgstr "音訊播放機"
-
-#: ../src/preferences.cpp:361
-msgid "Cache"
-msgstr "緩存"
-
 #: ../src/preferences.cpp:362
+msgid "Audio player"
+msgstr "音訊播放器"
+
+#: ../src/preferences.cpp:364
+msgid "Cache"
+msgstr "快取"
+
+#: ../src/preferences.cpp:365
 msgid "None (NOT RECOMMENDED)"
 msgstr "無 （不推薦）"
 
-#: ../src/preferences.cpp:362
+#: ../src/preferences.cpp:365
 msgid "RAM"
 msgstr "記憶體"
 
-#: ../src/preferences.cpp:362
+#: ../src/preferences.cpp:365
 msgid "Hard Disk"
 msgstr "硬碟"
 
-#: ../src/preferences.cpp:364
+#: ../src/preferences.cpp:367
 msgid "Cache type"
-msgstr "緩存類型"
+msgstr "快取類型"
 
-#: ../src/preferences.cpp:369
+#: ../src/preferences.cpp:372
 msgid "Regular quality"
 msgstr "一般品質"
 
-#: ../src/preferences.cpp:369
+#: ../src/preferences.cpp:372
 msgid "Better quality"
 msgstr "較好品質"
 
-#: ../src/preferences.cpp:369
+#: ../src/preferences.cpp:372
 msgid "High quality"
 msgstr "高品質"
 
-#: ../src/preferences.cpp:369
+#: ../src/preferences.cpp:372
 msgid "Insane quality"
 msgstr "極高品質"
 
-#: ../src/preferences.cpp:371
+#: ../src/preferences.cpp:374
 msgid "Quality"
 msgstr "品質"
 
-#: ../src/preferences.cpp:373
+#: ../src/preferences.cpp:376
 msgid "Cache memory max (MB)"
-msgstr "緩存最大容量 (MB)"
+msgstr "快取最大容量 (MB)"
 
-#: ../src/preferences.cpp:379
+#: ../src/preferences.cpp:382
 msgid "Avisynth down-mixer"
 msgstr "Avisynth down-mixer"
 
-#: ../src/preferences.cpp:380
+#: ../src/preferences.cpp:383
 msgid "Force sample rate"
 msgstr "強制取樣速率"
 
-#: ../src/preferences.cpp:386
+#: ../src/preferences.cpp:389
 msgid "Ignore"
 msgstr "忽略"
 
-#: ../src/preferences.cpp:386
+#: ../src/preferences.cpp:389
 msgid "Stop"
 msgstr "停止"
 
-#: ../src/preferences.cpp:386
+#: ../src/preferences.cpp:389
 msgid "Abort"
 msgstr "取消"
 
-#: ../src/preferences.cpp:388
+#: ../src/preferences.cpp:391
 msgid "Audio indexing error handling mode"
 msgstr "音訊索引錯誤處理模式"
 
-#: ../src/preferences.cpp:390
+#: ../src/preferences.cpp:393
 msgid "Always index all audio tracks"
 msgstr "總是索引所有音軌"
 
-#: ../src/preferences.cpp:395
+#: ../src/preferences.cpp:398
 msgid "Portaudio device"
 msgstr "Portaudio 設備"
 
-#: ../src/preferences.cpp:400
+#: ../src/preferences.cpp:403
 msgid "OSS Device"
-msgstr "OSS 設備"
+msgstr "OSS 裝置"
 
-#: ../src/preferences.cpp:405
+#: ../src/preferences.cpp:408
 msgid "Buffer latency"
 msgstr "緩衝延遲"
 
-#: ../src/preferences.cpp:406
+#: ../src/preferences.cpp:409
 msgid "Buffer length"
 msgstr "緩衝長度"
 
-#: ../src/preferences.cpp:419
+#: ../src/preferences.cpp:422
 msgid "Video provider"
 msgstr "視訊來自"
 
-#: ../src/preferences.cpp:422
+#: ../src/preferences.cpp:425
 msgid "Subtitles provider"
 msgstr "字幕來自"
 
-#: ../src/preferences.cpp:425
+#: ../src/preferences.cpp:428
 msgid "Force BT.601"
 msgstr "強制 BT.601"
 
-#: ../src/preferences.cpp:429
+#: ../src/preferences.cpp:432
 msgid "Allow pre-2.56a Avisynth"
 msgstr "允許 pre-2.56a Avisynth"
 
-#: ../src/preferences.cpp:431
+#: ../src/preferences.cpp:434
 msgid "Avisynth memory limit"
 msgstr "Avisynth 記憶體限額"
 
-#: ../src/preferences.cpp:439
+#: ../src/preferences.cpp:442
 msgid "Debug log verbosity"
 msgstr "Debug日誌的詳細級別"
 
-#: ../src/preferences.cpp:441
+#: ../src/preferences.cpp:444
 msgid "Decoding threads"
 msgstr "解碼執行緒"
 
-#: ../src/preferences.cpp:442
+#: ../src/preferences.cpp:445
 msgid "Enable unsafe seeking"
 msgstr "允許可能不安全的定位"
 
-#: ../src/preferences.cpp:571
+#: ../src/preferences.cpp:574
 msgid "Hotkeys"
-msgstr "熱鍵"
+msgstr "快捷鍵"
 
-#: ../src/preferences.cpp:669
+#: ../src/preferences.cpp:672
 msgid ""
 "Are you sure that you want to restore the defaults? All your settings will "
 "be overridden."
-msgstr "您確定要恢復預設嗎？您的所有設置都將被覆蓋。"
+msgstr "您確定要恢復預設嗎？您的所有設定都將被覆蓋。"
 
-#: ../src/preferences.cpp:669
+#: ../src/preferences.cpp:672
 msgid "Restore defaults?"
 msgstr "恢復預設？"
 
-#: ../src/preferences.cpp:687
+#: ../src/preferences.cpp:690
 msgid "Preferences"
 msgstr "偏好"
 
-#: ../src/preferences.cpp:715
+#: ../src/preferences.cpp:718
 msgid "&Restore Defaults"
 msgstr "恢復預設(&R)"
 
@@ -4232,7 +4246,7 @@ msgstr "沒有改正建議"
 #: ../src/subs_edit_ctrl.cpp:424
 #, c-format
 msgid "Add \"%s\" to dictionary"
-msgstr "添加 \"%s\" 至詞典"
+msgstr "新增 \"%s\" 至詞典"
 
 #: ../src/subs_edit_ctrl.cpp:459
 #, c-format
@@ -4249,7 +4263,7 @@ msgstr "詞典語言"
 
 #: ../src/subs_edit_ctrl.cpp:474
 msgid "Disable"
-msgstr "禁用"
+msgstr "停用"
 
 #: ../src/menu.cpp:94
 msgid "Empty"
@@ -4261,7 +4275,7 @@ msgstr "最近打開(&R)"
 
 #: ../src/menu.cpp:410
 msgid "No Automation macros loaded"
-msgstr "沒有自動化宏被載入"
+msgstr "沒有自動化巨集被載入"
 
 #: ../src/dialog_about.cpp:46
 msgid "Translated into LANGUAGE by PERSON\n"
@@ -4285,7 +4299,7 @@ msgstr "%s 編譯於 %s。"
 
 #: ../src/dialog_kara_timing_copy.cpp:57
 msgid "Source: "
-msgstr "源："
+msgstr "來源："
 
 #: ../src/dialog_kara_timing_copy.cpp:58
 msgid "Dest: "
@@ -4298,7 +4312,7 @@ msgstr "漢字計時器"
 #: ../src/dialog_kara_timing_copy.cpp:475 ../src/dialog_paste_over.cpp:73
 #: ../src/grid_column.cpp:334 ../src/grid_column.cpp:335
 msgid "Text"
-msgstr "文本"
+msgstr "文字"
 
 #: ../src/dialog_kara_timing_copy.cpp:476
 msgid "Styles"
@@ -4327,13 +4341,13 @@ msgid ""
 "Enter: Link, accept line when done\n"
 "Backspace: Unlink last"
 msgstr ""
-"當定位于目標文字方塊時，使用下列按鍵:\n"
+"當定位於目標文字方塊時，使用下列按鍵:\n"
 "\n"
-"向右箭頭：增加目標選擇的長度\n"
-"向左箭頭：減少目標選擇的長度\n"
-"向上箭頭：增加源選擇的長度\n"
-"向下箭頭：減少源選擇的長度\n"
-"回車：連結，接受完成的行\n"
+"右：增加目標選擇的長度\n"
+"左：減少目標選擇的長度\n"
+"上：增加來源選擇的長度\n"
+"下：減少來源選擇的長度\n"
+"Enter：連結，接受完成的行\n"
 "空格：解除最後的連結"
 
 #: ../src/dialog_kara_timing_copy.cpp:497
@@ -4350,7 +4364,7 @@ msgstr "解除連結(&U)"
 
 #: ../src/dialog_kara_timing_copy.cpp:500
 msgid "Skip &Source Line"
-msgstr "跳過源行(&S)"
+msgstr "跳過來源行(&S)"
 
 #: ../src/dialog_kara_timing_copy.cpp:501
 msgid "Skip &Dest Line"
@@ -4375,15 +4389,15 @@ msgstr "漢字計時器"
 
 #: ../src/dialog_kara_timing_copy.cpp:574
 msgid "Select source and destination styles first."
-msgstr "先選擇源樣式和目標樣式。"
+msgstr "先選擇來源樣式和目標樣式。"
 
 #: ../src/dialog_kara_timing_copy.cpp:576
 msgid "The source and destination styles must be different."
-msgstr "源樣式與目標樣式必須不同。"
+msgstr "來源樣式與目標樣式必須不同。"
 
 #: ../src/dialog_kara_timing_copy.cpp:626
 msgid "Group all of the source text."
-msgstr "將所有源文本分類。"
+msgstr "將所有來源文字分組。"
 
 #: ../src/hotkey.cpp:175
 msgid "Invalid command name for hotkey"
@@ -4403,7 +4417,7 @@ msgstr "請選擇想要貼上至何區域："
 
 #: ../src/dialog_paste_over.cpp:63
 msgid "Comment"
-msgstr "注釋"
+msgstr "註解"
 
 #: ../src/dialog_paste_over.cpp:67 ../src/grid_column.cpp:177
 #: ../src/grid_column.cpp:178
@@ -4457,7 +4471,7 @@ msgstr ""
 msgid ""
 "Do you want Aegisub to check for updates whenever it starts? You can still "
 "do it manually via the Help menu."
-msgstr "您想讓Aegisub啟動時檢查更新嗎？您也可以通過説明功能表手動進行。"
+msgstr "您想讓Aegisub啟動時檢查更新嗎？您也可以夠過説明功能表手動進行。"
 
 #: ../src/main.cpp:302
 msgid "Check for updates?"
@@ -4475,9 +4489,9 @@ msgid ""
 "\n"
 "Error Message: %s"
 msgstr ""
-"發生了一個意外的錯誤。請保存您的文件並重啟Aegisub。 \n"
+"發生了一個意外的錯誤。請儲存您的文件並重啟Aegisub。 \n"
 "\n"
-"錯誤信息： %s"
+"錯誤資訊： %s"
 
 #: ../src/subs_edit_box.cpp:119
 msgid "&Comment"
@@ -4510,7 +4524,7 @@ msgstr ""
 
 #: ../src/subs_edit_box.cpp:151
 msgid "Number of characters in the longest line of this subtitle."
-msgstr "在當前字幕行的最長行的字元數。"
+msgstr "在目前字幕行的最長行的字元數。"
 
 #: ../src/subs_edit_box.cpp:158
 msgid "Layer number"
@@ -4578,7 +4592,7 @@ msgid ""
 "edit box. This is sometimes useful when editing subtitles or translating "
 "subtitles into another language."
 msgstr ""
-"在編輯方塊上方顯示當前行被第一次選中時的原始內容。這個功能當你在編輯或翻譯字"
+"在編輯方塊上方顯示目前行被第一次選中時的原始內容。這個功能當你在編輯或翻譯字"
 "幕時可能會非常實用。"
 
 #: ../src/subs_edit_box.cpp:441
@@ -4587,27 +4601,27 @@ msgstr "修改文字"
 
 #: ../src/subs_edit_box.cpp:516
 msgid "modify times"
-msgstr "改變時間"
+msgstr "修改時間"
 
 #: ../src/subs_edit_box.cpp:590 ../src/dialog_style_editor.cpp:453
 msgid "style change"
-msgstr "樣式更改"
+msgstr "變更樣式"
 
 #: ../src/subs_edit_box.cpp:596
 msgid "actor change"
-msgstr "說話人更改"
+msgstr "變更說話人"
 
 #: ../src/subs_edit_box.cpp:601
 msgid "layer change"
-msgstr "層次更改"
+msgstr "變更層次"
 
 #: ../src/subs_edit_box.cpp:606
 msgid "effect change"
-msgstr "特效更改"
+msgstr "變更特效"
 
 #: ../src/subs_edit_box.cpp:611
 msgid "comment change"
-msgstr "注釋更改"
+msgstr "變更注釋"
 
 #: ../src/dialog_selection.cpp:106
 msgid "Select"
@@ -4615,15 +4629,15 @@ msgstr "選擇"
 
 #: ../src/dialog_selection.cpp:117
 msgid "Match"
-msgstr "匹配"
+msgstr "符合"
 
 #: ../src/dialog_selection.cpp:121
 msgid "&Matches"
-msgstr "匹配項(&M)"
+msgstr "符合的項目(&M)"
 
 #: ../src/dialog_selection.cpp:122
 msgid "&Doesn't Match"
-msgstr "不匹配(&D)"
+msgstr "不符合(&D)"
 
 #: ../src/dialog_selection.cpp:123
 msgid "Match c&ase"
@@ -4631,7 +4645,7 @@ msgstr "區分大小寫(&A)"
 
 #: ../src/dialog_selection.cpp:132
 msgid "&Exact match"
-msgstr "精確匹配(&E)"
+msgstr "精確符合(&E)"
 
 #: ../src/dialog_selection.cpp:132
 msgid "&Contains"
@@ -4639,7 +4653,7 @@ msgstr "包含(&C)"
 
 #: ../src/dialog_selection.cpp:132
 msgid "&Regular Expression match"
-msgstr "規則運算式匹配(&R)"
+msgstr "規則運算式符合(&R)"
 
 #: ../src/dialog_selection.cpp:133
 msgid "Mode"
@@ -4647,7 +4661,7 @@ msgstr "模式"
 
 #: ../src/dialog_selection.cpp:137 ../src/dialog_search_replace.cpp:87
 msgid "&Text"
-msgstr "文本(&T)"
+msgstr "文字(&T)"
 
 #: ../src/dialog_selection.cpp:137
 msgid "&Style"
@@ -4663,11 +4677,11 @@ msgstr "特效(&F)"
 
 #: ../src/dialog_selection.cpp:138 ../src/dialog_search_replace.cpp:90
 msgid "In Field"
-msgstr "在下列欄中搜索"
+msgstr "在下列欄位中搜尋"
 
 #: ../src/dialog_selection.cpp:142
 msgid "Match dialogues/comments"
-msgstr "匹配對話/注釋"
+msgstr "符合對話/注釋"
 
 #: ../src/dialog_selection.cpp:143
 msgid "D&ialogues"
@@ -4735,12 +4749,12 @@ msgstr "樣式 '%s' 不存在\n"
 #: ../src/font_file_lister.cpp:138
 #, c-format
 msgid "Could not find font '%s'\n"
-msgstr "無法找到字體 '%s'\n"
+msgstr "無法找到字型 '%s'\n"
 
 #: ../src/font_file_lister.cpp:145
 #, c-format
 msgid "Found '%s' at '%s'\n"
-msgstr "已找到 '%s' 字體位於 '%s'\n"
+msgstr "已找到 '%s' 字型位於 '%s'\n"
 
 #: ../src/font_file_lister.cpp:149
 #, c-format
@@ -4764,11 +4778,11 @@ msgstr "'%s' 缺少下列字形：%s\n"
 
 #: ../src/font_file_lister.cpp:168
 msgid "Used in styles:\n"
-msgstr "應用於樣式：\n"
+msgstr "使用於樣式：\n"
 
 #: ../src/font_file_lister.cpp:174
 msgid "Used on lines:"
-msgstr "應用於行："
+msgstr "使用於行："
 
 #: ../src/font_file_lister.cpp:186
 msgid "Parsing file\n"
@@ -4776,7 +4790,7 @@ msgstr "正在分析文件\n"
 
 #: ../src/font_file_lister.cpp:200
 msgid "Searching for font files\n"
-msgstr "正在搜索字體檔\n"
+msgstr "正在搜尋字型檔\n"
 
 #: ../src/font_file_lister.cpp:202
 msgid ""
@@ -4788,13 +4802,13 @@ msgstr ""
 
 #: ../src/font_file_lister.cpp:209
 msgid "All fonts found.\n"
-msgstr "所有字體已找到。\n"
+msgstr "所有字型已找到。\n"
 
 #: ../src/font_file_lister.cpp:211
 #, c-format
 msgid "One font could not be found\n"
 msgid_plural "%d fonts could not be found.\n"
-msgstr[0] "%d 字體無法被找到。\n"
+msgstr[0] "%d 字型無法被找到。\n"
 
 #: ../src/font_file_lister.cpp:214
 #, c-format
@@ -4845,7 +4859,7 @@ msgstr "輸出："
 #: ../src/audio_display.cpp:677
 #, c-format
 msgid "%d%%, %d pixel/second"
-msgstr "%d%%，%d 圖元每秒"
+msgstr "%d%%，%d 像素每秒"
 
 #: ../src/dialog_progress.cpp:197
 msgid "Cancel"
@@ -4865,7 +4879,7 @@ msgstr "直線"
 
 #: ../src/visual_tool_vector_clip.cpp:58
 msgid "Appends a line"
-msgstr "添加一條直線"
+msgstr "新增一條直線"
 
 #: ../src/visual_tool_vector_clip.cpp:59
 msgid "Bicubic"
@@ -4873,7 +4887,7 @@ msgstr "兩次立方曲線"
 
 #: ../src/visual_tool_vector_clip.cpp:59
 msgid "Appends a bezier bicubic curve"
-msgstr "添加一條雙三次貝茲曲線"
+msgstr "新增一條雙三次貝茲曲線"
 
 #: ../src/visual_tool_vector_clip.cpp:61
 msgid "Convert"
@@ -4949,7 +4963,7 @@ msgstr "名稱"
 
 #: ../src/dialog_automation.cpp:135
 msgid "Filename"
-msgstr "檔案名"
+msgstr "檔案名稱"
 
 #: ../src/dialog_automation.cpp:136
 msgid "Description"
@@ -4957,7 +4971,7 @@ msgstr "描述"
 
 #: ../src/dialog_automation.cpp:222
 msgid "Add Automation script"
-msgstr "添加自動化腳本"
+msgstr "新增自動化腳本"
 
 #: ../src/dialog_automation.cpp:277
 #, c-format
@@ -4997,7 +5011,7 @@ msgid ""
 "Features provided by script:"
 msgstr ""
 "\n"
-"腳本信息：\n"
+"腳本資訊：\n"
 "名稱： %s\n"
 "描述： %s\n"
 "作者： %s\n"
@@ -5010,7 +5024,7 @@ msgstr ""
 #: ../src/dialog_automation.cpp:298
 #, c-format
 msgid "    Macro: %s (%s)"
-msgstr "    宏：  %s (%s)"
+msgstr "    巨集：  %s (%s)"
 
 #: ../src/dialog_automation.cpp:301
 #, c-format
@@ -5051,11 +5065,11 @@ msgstr "匯出字幕檔案"
 
 #: ../src/dialog_search_replace.cpp:46
 msgid "Replace"
-msgstr "替換"
+msgstr "取代"
 
 #: ../src/dialog_search_replace.cpp:67
 msgid "Find what:"
-msgstr "查找目標："
+msgstr "尋找目標："
 
 #: ../src/dialog_search_replace.cpp:78
 msgid "&Match case"
@@ -5087,15 +5101,15 @@ msgstr "限制"
 
 #: ../src/dialog_search_replace.cpp:93
 msgid "&Find next"
-msgstr "查找下一個(&F)"
+msgstr "尋找下一個(&F)"
 
 #: ../src/dialog_search_replace.cpp:94
 msgid "Replace &next"
-msgstr "替換下一個(&R)"
+msgstr "取代下一個(&R)"
 
 #: ../src/dialog_autosave.cpp:66
 msgid "Open autosave file"
-msgstr "打開自動儲存的檔"
+msgstr "打開自動儲存的檔案"
 
 #: ../src/dialog_autosave.cpp:75
 msgid "Versions"
@@ -5181,7 +5195,7 @@ msgstr "每秒字元數"
 
 #: ../src/dialog_text_import.cpp:47
 msgid "Text import options"
-msgstr "文本導入選項"
+msgstr "文字匯入選項"
 
 #: ../src/dialog_text_import.cpp:54
 msgid "Actor separator:"
@@ -5201,11 +5215,11 @@ msgstr "視訊定位"
 
 #: ../src/video_box.cpp:62
 msgid "Current frame time and number"
-msgstr "當前影格時間和編號"
+msgstr "目前影格時間和編號"
 
 #: ../src/video_box.cpp:65
 msgid "Time of this frame relative to start and end of current subs"
-msgstr "該影格時間，相對於當前字幕的開始與結束時間"
+msgstr "該影格時間，相對於目前字幕的開始與結束時間"
 
 #: ../src/ass_style.cpp:193
 msgid "ANSI"
@@ -5472,7 +5486,7 @@ msgstr "重設解析度"
 
 #: ../src/project.cpp:187
 msgid "Do you want to load/unload the associated files?"
-msgstr "您要載入/卸載相關檔嗎？"
+msgstr "您要載入/關閉相關檔案嗎？"
 
 #: ../src/project.cpp:198
 msgid "Unload audio"
@@ -5512,7 +5526,7 @@ msgstr "載入關鍵影格檔案：%s"
 
 #: ../src/project.cpp:206
 msgid "(Un)Load files?"
-msgstr "載入/卸載相關檔嗎？"
+msgstr "載入/關閉相關檔案嗎？"
 
 #: ../src/project.cpp:255
 msgid "The audio file was not found: "
@@ -5546,7 +5560,7 @@ msgstr "樣式編輯器"
 
 #: ../src/dialog_style_editor.cpp:178
 msgid "Font"
-msgstr "字體"
+msgstr "字型"
 
 #: ../src/dialog_style_editor.cpp:180
 msgid "Margins"
@@ -5594,11 +5608,11 @@ msgstr "樣式名稱"
 
 #: ../src/dialog_style_editor.cpp:216
 msgid "Font face"
-msgstr "字體"
+msgstr "字型"
 
 #: ../src/dialog_style_editor.cpp:217
 msgid "Font size"
-msgstr "字體大小"
+msgstr "字型大小"
 
 #: ../src/dialog_style_editor.cpp:218
 msgid "Choose primary color"
@@ -5618,15 +5632,15 @@ msgstr "選擇陰影顏色"
 
 #: ../src/dialog_style_editor.cpp:222
 msgid "Distance from left edge, in pixels"
-msgstr "與左邊界距離 (圖元)"
+msgstr "與左邊界距離 (像素)"
 
 #: ../src/dialog_style_editor.cpp:223
 msgid "Distance from right edge, in pixels"
-msgstr "與右邊界距離 (圖元)"
+msgstr "與右邊界距離 (像素)"
 
 #: ../src/dialog_style_editor.cpp:224
 msgid "Distance from top/bottom edge, in pixels"
-msgstr "與上/下邊界距離 (圖元)"
+msgstr "與上/下邊界距離 (像素)"
 
 #: ../src/dialog_style_editor.cpp:225
 msgid ""
@@ -5636,11 +5650,11 @@ msgstr "選中時，則使用不透明背景取代字幕的邊框"
 
 #: ../src/dialog_style_editor.cpp:226
 msgid "Outline width, in pixels"
-msgstr "邊框寬度 (圖元)"
+msgstr "邊框寬度 (像素)"
 
 #: ../src/dialog_style_editor.cpp:227
 msgid "Shadow distance, in pixels"
-msgstr "陰影距離 (圖元)"
+msgstr "陰影距離 (像素)"
 
 #: ../src/dialog_style_editor.cpp:228
 msgid "Scale X, in percentage"
@@ -5658,15 +5672,15 @@ msgstr "沿 Z 軸旋轉角度 (角度)"
 msgid ""
 "Encoding, only useful in unicode if the font doesn't have the proper unicode "
 "mapping"
-msgstr "文字編碼，只在unicode中字體沒有正確的unicode對應時有用"
+msgstr "文字編碼，只在unicode中字型沒有正確的unicode對應時有用"
 
 #: ../src/dialog_style_editor.cpp:232
 msgid "Character spacing, in pixels"
-msgstr "字元間距 (圖元)"
+msgstr "字元間距 (像素)"
 
 #: ../src/dialog_style_editor.cpp:233
 msgid "Alignment in screen, in numpad style"
-msgstr "畫面中位置的對齊方式，按照數位鍵盤區佈局"
+msgstr "畫面中位置的對齊方式，按照數位鍵盤區配置"
 
 #: ../src/dialog_style_editor.cpp:277
 msgid "Primary"
@@ -5710,11 +5724,11 @@ msgstr "編碼："
 
 #: ../src/dialog_style_editor.cpp:328
 msgid "Preview of current style"
-msgstr "預覽當前樣式"
+msgstr "預覽目前樣式"
 
 #: ../src/dialog_style_editor.cpp:331
 msgid "Text to be used for the preview"
-msgstr "用於預覽的文本"
+msgstr "用於預覽的文字"
 
 #: ../src/dialog_style_editor.cpp:332
 msgid "Color of preview background"
@@ -5732,7 +5746,7 @@ msgstr "樣式名稱衝突"
 msgid ""
 "Do you want to change all instances of this style in the script to this new "
 "name?"
-msgstr "想將腳本中所有應用該樣式的字幕行的樣式名都改為這個新名稱嗎？"
+msgstr "想將腳本中所有套用該樣式的字幕行的樣式名稱都改為這個新的名稱嗎？"
 
 #: ../src/dialog_style_editor.cpp:426
 msgid "Update script?"
@@ -5818,7 +5832,7 @@ msgstr "自動換行（ASS方式）"
 
 #: ../src/dialog_export_ebu3264.cpp:127
 msgid "Automatically wrap long lines (Balanced)"
-msgstr "自动换行（平均方式）"
+msgstr "自動換行（平均方式）"
 
 #: ../src/dialog_export_ebu3264.cpp:128
 msgid "Abort if any lines are too long"
@@ -5854,7 +5868,7 @@ msgstr "時間碼偏移："
 
 #: ../src/dialog_export_ebu3264.cpp:154
 msgid "Text formatting"
-msgstr "文本格式"
+msgstr "文字格式"
 
 #: ../src/dialog_export_ebu3264.cpp:159
 msgid "Time codes"
@@ -5888,7 +5902,7 @@ msgstr "無標題"
 
 #: ../src/dialog_video_properties.cpp:44
 msgid "Resolution mismatch"
-msgstr "解析度不匹配"
+msgstr "解析度不符"
 
 #: ../src/dialog_video_properties.cpp:46
 #, c-format
@@ -5901,7 +5915,7 @@ msgid ""
 "\n"
 "Change subtitles resolution to match video?"
 msgstr ""
-"載入視訊的解析度與腳本指定的解析度不匹配\n"
+"載入視訊的解析度與腳本指定的解析度不符\n"
 "\n"
 "視訊解析度：\t%d × %d\n"
 "腳本解析度：\t%d × %d\n"
@@ -5910,7 +5924,7 @@ msgstr ""
 
 #: ../src/dialog_video_properties.cpp:54 ../src/dialog_video_properties.cpp:63
 msgid "Set to video resolution"
-msgstr "直接設為視頻解析度"
+msgstr "直接設為影片解析度"
 
 #: ../src/dialog_video_properties.cpp:55
 msgid "Resample script (stretch to new aspect ratio)"
@@ -5922,7 +5936,7 @@ msgstr "重設腳本解析度（等比縮放適應視訊）"
 
 #: ../src/dialog_video_properties.cpp:57
 msgid "Resample script (remove borders)"
-msgstr "重設腳本解析度（等比縮放鋪滿视讯）"
+msgstr "重設腳本解析度（等比縮放鋪滿視訊）"
 
 #: ../src/dialog_video_properties.cpp:64
 msgid "Resample script"
@@ -5938,7 +5952,7 @@ msgstr "附件清單"
 
 #: ../src/dialog_attachments.cpp:76
 msgid "Attach &Font"
-msgstr "附加字體(&F)"
+msgstr "附加字型(&F)"
 
 #: ../src/dialog_attachments.cpp:77
 msgid "Attach &Graphics"
@@ -5962,15 +5976,15 @@ msgstr "分類"
 
 #: ../src/dialog_attachments.cpp:138 ../src/dialog_attachments.cpp:147
 msgid "Choose file to be attached"
-msgstr "選擇要附加的檔"
+msgstr "選擇要附加的檔案"
 
 #: ../src/dialog_attachments.cpp:142
 msgid "attach font file"
-msgstr "附加字字體檔"
+msgstr "附加字型檔案"
 
 #: ../src/dialog_attachments.cpp:152
 msgid "attach graphics file"
-msgstr "附加圖片檔"
+msgstr "附加圖片檔案"
 
 #: ../src/dialog_attachments.cpp:164
 msgid "Select the path to save the files to:"
@@ -6011,7 +6025,7 @@ msgstr "沒有需要翻譯的行。"
 #: ../src/dialog_translation.cpp:186 ../src/dialog_translation.cpp:236
 #, c-format
 msgid "Current line: %d/%d"
-msgstr "當前行： %d/%d"
+msgstr "目前行： %d/%d"
 
 #: ../src/dialog_translation.cpp:273
 msgid "translation assistant"
@@ -6039,7 +6053,7 @@ msgstr "適應視訊"
 
 #: ../src/dialog_resample.cpp:146
 msgid "Remove borders"
-msgstr "鋪滿视讯"
+msgstr "鋪滿視訊"
 
 #: ../src/dialog_resample.cpp:146
 msgid "Manual"
@@ -6047,7 +6061,7 @@ msgstr "自訂"
 
 #: ../src/dialog_resample.cpp:147
 msgid "Aspect Ratio Handling"
-msgstr "縱橫比處理"
+msgstr "長寬比處理"
 
 #: ../src/dialog_resample.cpp:162
 msgid "Margin offset"
@@ -6092,19 +6106,19 @@ msgstr "無法從更新伺服器下載更新。"
 #: ../src/dialog_version_check.cpp:312
 #, c-format
 msgid "HTTP request failed, got HTTP response %d."
-msgstr "HTTP請求失敗，返回的狀態 %d。"
+msgstr "HTTP 請求失敗，回傳的狀態為 %d。"
 
 #: ../src/dialog_version_check.cpp:343
 msgid "An update to Aegisub was found."
-msgstr "發現Aegisub更新。"
+msgstr "發現 Aegisub 可用更新。"
 
 #: ../src/dialog_version_check.cpp:345
 msgid "Several possible updates to Aegisub were found."
-msgstr "發現幾個Aegisub可用更新。"
+msgstr "發現幾個 Aegisub 可用更新。"
 
 #: ../src/dialog_version_check.cpp:347
 msgid "There are no updates to Aegisub."
-msgstr "沒有發現Aegisub更新。"
+msgstr "沒有發現 Aegisub 更新。"
 
 #: ../src/dialog_version_check.cpp:375
 #, c-format
@@ -6115,10 +6129,10 @@ msgid ""
 "If other applications can access the Internet fine, this is probably a "
 "temporary server problem on our end."
 msgstr ""
-"Aegisub檢查更新時出錯：\n"
+"Aegisub 檢查更新時出錯：\n"
 "%s\n"
 "\n"
-"如果其他程式可以正常訪問互聯網，那麼這很可能時我們的臨時伺服器的問題。"
+"如果其他程式可以正常存取網際網路，那麼這很可能時我們的臨時伺服器的問題。"
 
 #: ../src/dialog_version_check.cpp:379
 msgid "An unknown error occurred while checking for updates to Aegisub."
@@ -6214,11 +6228,11 @@ msgstr "使時間連續"
 
 #: default_menu.json:0
 msgid "Set &Zoom"
-msgstr "設置縮放(&Z)"
+msgstr "設定縮放(&Z)"
 
 #: default_menu.json:0
 msgid "Override &AR"
-msgstr "更改縱橫比(&A)"
+msgstr "更改長寬比(&A)"
 
 #: default_menu.json:0
 msgid "&Export As..."
@@ -6230,7 +6244,7 @@ msgstr "字幕編輯方塊"
 
 #: ../automation/autoload/macro-1-edgeblur.lua:6
 msgid "Add edgeblur"
-msgstr "Add edgeblur - 添加邊角模糊"
+msgstr "Add edgeblur - 新增邊角模糊"
 
 #: ../automation/autoload/macro-1-edgeblur.lua:7
 msgid "A demo macro showing how to do simple line modification in Automation 4"
@@ -6238,7 +6252,7 @@ msgstr "此demo展示了如何用 Automation 4 編寫一個簡單的對行進行
 
 #: ../automation/autoload/macro-1-edgeblur.lua:21
 msgid "Adds \\be1 tags to all selected lines"
-msgstr "在所選行中添加 \\be1 標籤"
+msgstr "在所選行中新增 \\be1 標籤"
 
 #: ../automation/autoload/karaoke-auto-leadin.lua:32
 msgid "Automatic karaoke lead-in"
@@ -6246,7 +6260,7 @@ msgstr "Automatic karaoke lead-in"
 
 #: ../automation/autoload/karaoke-auto-leadin.lua:33
 msgid "Join up the ends of selected lines and add \\k tags to shift karaoke"
-msgstr "連接所選行的兩端，並添加\\K標籤偏移卡拉OK"
+msgstr "連接所選行的兩端，並新增\\K標籤偏移卡拉OK"
 
 #: ../automation/autoload/cleantags-autoload.lua:31
 msgid "Clean Tags"
@@ -6256,24 +6270,24 @@ msgstr "Clean Tags - 整理特效標籤"
 msgid ""
 "Clean subtitle lines by re-arranging ASS tags and override blocks within the "
 "lines"
-msgstr "通過對行內重新排列ASS標籤以及覆蓋模組，來清理字幕行。"
+msgstr "夠過對行內重新排列ASS標籤以及覆蓋模組，來清理字幕行。"
 
 #: ../automation/autoload/kara-templater.lua:36
 msgid "Karaoke Templater"
-msgstr "應用卡拉OK範本"
+msgstr "卡拉OK範本"
 
 #: ../automation/autoload/kara-templater.lua:37
 msgid ""
 "Macro and export filter to apply karaoke effects using the template language"
-msgstr "宏和匯出濾鏡通過模版語言來應用卡拉OK特效"
+msgstr "巨集和匯出濾鏡夠過範本語言來套用卡拉OK特效"
 
 #: ../automation/autoload/kara-templater.lua:858
 msgid "Apply karaoke template"
-msgstr "Apply karaoke template - 應用卡拉OK模版"
+msgstr "Apply karaoke template - 套用卡拉OK範本"
 
 #: ../automation/autoload/kara-templater.lua:858
 msgid "Applies karaoke effects from templates"
-msgstr "通過已有模版套用卡拉OK特效"
+msgstr "夠過已有範本套用卡拉OK特效"
 
 #: ../automation/autoload/kara-templater.lua:859
 msgid "Karaoke template"
@@ -6285,7 +6299,7 @@ msgid ""
 "\n"
 "See the help file for information on how to use this."
 msgstr ""
-"為字幕應用卡拉OK特效模版。\n"
+"為字幕套用卡拉OK特效範本。\n"
 "\n"
 "請閱讀幫助檔案來瞭解如何使用它。"
 
@@ -6319,15 +6333,15 @@ msgstr "字幕編輯器"
 
 #: aegisub.desktop:6
 msgid "Create and edit subtitles for film and videos."
-msgstr "為電影和視訊創建和編輯字幕。"
+msgstr "為電影和視訊建立和編輯字幕。"
 
 #: packages/win_installer/fragment_strings.iss:1
 msgid "Installing runtime libraries..."
-msgstr "正在安裝運行庫……"
+msgstr "正在安裝執行階段涵式庫……"
 
 #: packages/win_installer/fragment_strings.iss:1
 msgid "Create a start menu icon"
-msgstr "創建開始功能表圖示"
+msgstr "建立開始功能表圖示"
 
 #: packages/win_installer/fragment_strings.iss:1
 msgid "Automatically check for new versions of Aegisub"
@@ -6347,7 +6361,7 @@ msgid ""
 msgstr ""
 "將會在您的電腦上安裝Aegisub {#BUILD_GIT_VERSION_STRING} 。%n%n Aegisub適用於"
 "GNU通用公共許可證第二版(GPLv2)，這意味著您可以將該應用程式用於任何目的而不需"
-"要支付費用，但同時也不會得到任何形式的擔保。%n%n您可以到Aegisub官網獲取原始程"
+"要支付費用，但同時也不會得到任何形式的擔保。%n%n您可以到Aegisub官網取得原始程"
 "式碼資訊。"
 
 #~ msgid "%d frames (%s)"
@@ -6356,13 +6370,13 @@ msgstr ""
 #~ msgid ""
 #~ "You already have timecodes loaded. Would you like to replace them with "
 #~ "timecodes from the video file?"
-#~ msgstr "您已經載入過時間碼。是否要用視訊檔中的時間碼替換？"
+#~ msgstr "您已經載入過時間碼。是否要用視訊檔案中的時間碼取代？"
 
 #~ msgid "&Change aspect ratio"
-#~ msgstr "更改縱橫比(&C)"
+#~ msgstr "更改長寬比(&C)"
 
 #~ msgid "Clean Script Info"
-#~ msgstr "清除腳本信息"
+#~ msgstr "清除腳本資訊"
 
 #~ msgid ""
 #~ "Removes all but the absolutely required fields from the Script Info "
@@ -6375,13 +6389,13 @@ msgstr ""
 #~ msgstr "讀取至記憶體"
 
 #~ msgid "Reading to Hard Disk cache"
-#~ msgstr "讀取到磁片緩存"
+#~ msgstr "讀取到磁片快取"
 
 #~ msgid "Are you sure you want to delete these %d styles?"
 #~ msgstr "您確定要刪除這個 %d 樣式？"
 
 #~ msgid "File name"
-#~ msgstr "檔案名："
+#~ msgstr "檔案名稱："
 
 #~ msgid "Selection was set to %u lines"
 #~ msgstr "所選被設為 %u 行"


### PR DESCRIPTION
Currently, the zh_TW locale seems to be "converted" from the zh_CN locale because it contains many Simplified Chinese terminologies and some characters. Thus, it needs some improvements that would take a long time; this patch could be a better version as it only covers a partial improvement, but it should be good enough to see a difference between the current version. I'll find some spare time to make another significant improvement in the future.
