### PR TITLE
Add support for bash-completion

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -384,6 +384,19 @@ subdir('po')
 subdir('src')
 subdir('tests')
 
+if get_option('bash_completion')
+  bash_comp = dependency('bash_completion', required: false)
+  if bash_comp.found()
+    bash_install_dir = bash_comp.get_variable(
+      pkgconfig: 'completionsdir',
+      pkgconfig_define: ['datadir', datadir]
+    )
+  else
+    bash_install_dir = join_paths(datadir, 'bash-completion', 'completions')
+  endif
+  install_data('tools/bash-completion.sh', install_dir: bash_install_dir, rename: 'aegisub')
+endif
+
 aegisub_cpp_pch = ['src/include/agi_pre.h']
 aegisub_c_pch = ['src/include/agi_pre_c.h']
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -26,3 +26,4 @@ option('update_server', type: 'string', value: 'https://updates.aegisub.org', de
 option('update_url', type: 'string', value: '/trunk', description: 'Base path to use for the update checker')
 
 option('build_osx_bundle', type: 'boolean', value: 'false', description: 'Package Aegisub.app on OSX')
+option('bash_completion', type: 'boolean', value: 'true', description: 'Install bash shell completions.')

--- a/tools/bash-completion.sh
+++ b/tools/bash-completion.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+complete -f -o plusdirs -X '!*.@(ass|ssa|mkv|mka|mks|sub|srt|ttxt|txt)' aegisub


### PR DESCRIPTION
This allows autocomplete when calling aegisub from terminal. Before this commit, when having for example `file.webm` and `file.ass` in the directory, both were proposed while only the later could be open using CLI argument.