### PR TITLE
Fixed Compilation on Apple Silicon (tested on M2) MacOS Sequoia 15.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,23 @@ A vaguely recent version of Xcode and the corresponding command-line tools are r
 
 For personal usage, you can use pip and homebrew to install almost all of Aegisub's dependencies:
 
+- For Mac/Intel:
+```
     pip3 install meson
     brew install cmake ninja pkg-config  libass boost zlib ffms2 fftw hunspell
     export LDFLAGS="-L/usr/local/opt/icu4c/lib"
     export CPPFLAGS="-I/usr/local/opt/icu4c/include"
     export PKG_CONFIG_PATH="/usr/local/opt/icu4c/lib/pkgconfig"
+```
+
+- For Mac/Silicon:
+```
+    pip3 install meson
+    brew install cmake ninja pkg-config  libass boost zlib ffms2 fftw hunspell
+    export LDFLAGS="-L/opt/homebrew/opt/icu4c/lib"
+    export CPPFLAGS="-I/opt/homebrew/opt/icu4c/include"
+    export PKG_CONFIG_PATH="/opt/homebrew/opt/icu4c/lib/pkgconfig"
+```
 
 Once the dependencies are installed, build Aegisub with `meson build && meson compile -C build`.
 


### PR DESCRIPTION
- In this fork I fixed the compilation for Apple Silicon M2 on MacOS Sequoia 15.0.1.
- Added instructions for compilation on Apple Silicon with Homebrew.

The App and dmg, although they build, crash. However, one can run the compiled from a terminal by running the command
```
./build_static/aegisub  
```
from the directory where the source code was compiled.