### PR TITLE
use system gtest if available

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,6 +1,10 @@
-gtest_proj = subproject('gtest')
-gtest_dep = gtest_proj.get_variable('gtest_dep')
-gmock_dep = gtest_proj.get_variable('gmock_dep')
+gtest_ver = '>=1.14.0'
+gtest_dep = dependency('gtest', 
+                       fallback : ['gtest', 'gtest_dep'], 
+                       version : gtest_ver)
+gmock_dep = dependency('gmock', 
+                       fallback : ['gtest', 'gmock_dep'], 
+                       version : gtest_ver)
 
 tests_deps = [
     gtest_dep,


### PR DESCRIPTION
Package maintainers won't need to patch Aegisub to use the system version. This also helps Aegisub compile on platforms where the unmodified gtest source doesn't compile but a package is available, such as OpenBSD.

I've tested the conditional branch where gtest is present in the system on OpenBSD. I can't properly test the branch where it isn't present because the subproject doesn't compile on OpenBSD, but I've checked that it tries to compile the subproject.