### PR TITLE
meson_options.txt: give a boolean value to boolean option

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -25,4 +25,4 @@ option('enable_update_checker', type: 'boolean', value: true, description: 'Enab
 option('update_server', type: 'string', value: 'https://aegisub-updates.redvice.org', description: 'Server to use for the update checker')
 option('update_url', type: 'string', value: '/trunk', description: 'Base path to use for the update checker')
 
-option('build_osx_bundle', type: 'boolean', value: 'false', description: 'Package Aegisub.app on OSX')
+option('build_osx_bundle', type: 'boolean', value: false, description: 'Package Aegisub.app on OSX')


### PR DESCRIPTION
Fixes this Meson warning when running `meson setup`:
```plain
NOTICE: Future-deprecated features used:
 * 1.1.0: {'"boolean option" keyword argument "value" of type str'}
```