### PR TITLE
fix building with GCC 14

### DIFF
--- a/libaegisub/ass/uuencode.cpp
+++ b/libaegisub/ass/uuencode.cpp
@@ -17,6 +17,7 @@
 #include <libaegisub/ass/uuencode.h>
 
 #include <algorithm>
+#include <cstring>
 
 // Despite being called uuencoding by ass_specs.doc, the format is actually
 // somewhat different from real uuencoding.  Each 3-byte chunk is split into 4

--- a/libaegisub/audio/provider_dummy.cpp
+++ b/libaegisub/audio/provider_dummy.cpp
@@ -18,6 +18,7 @@
 
 #include "libaegisub/fs.h"
 
+#include <cstring>
 #include <random>
 
 /*

--- a/libaegisub/common/cajun/reader.cpp
+++ b/libaegisub/common/cajun/reader.cpp
@@ -8,6 +8,7 @@ Author: Terry Caton
 
 #include "libaegisub/cajun/reader.h"
 
+#include <algorithm>
 #include <boost/interprocess/streams/bufferstream.hpp>
 #include <cassert>
 

--- a/libaegisub/common/calltip_provider.cpp
+++ b/libaegisub/common/calltip_provider.cpp
@@ -19,6 +19,7 @@
 #include "libaegisub/ass/dialogue_parser.h"
 
 #include <algorithm>
+#include <cstring>
 
 namespace {
 struct proto_lit {

--- a/libaegisub/common/mru.cpp
+++ b/libaegisub/common/mru.cpp
@@ -22,6 +22,8 @@
 #include "libaegisub/option.h"
 #include "libaegisub/option_value.h"
 
+#include <algorithm>
+
 namespace {
 std::string_view mru_names[] = {
 	"Audio",

--- a/libaegisub/common/option.cpp
+++ b/libaegisub/common/option.cpp
@@ -25,6 +25,7 @@
 #include "libaegisub/log.h"
 #include "libaegisub/option_value.h"
 
+#include <algorithm>
 #include <boost/interprocess/streams/bufferstream.hpp>
 #include <cassert>
 #include <memory>

--- a/libaegisub/common/thesaurus.cpp
+++ b/libaegisub/common/thesaurus.cpp
@@ -19,6 +19,7 @@
 #include "libaegisub/line_iterator.h"
 #include "libaegisub/split.h"
 
+#include <algorithm>
 #include <boost/interprocess/streams/bufferstream.hpp>
 
 namespace agi {

--- a/libaegisub/include/libaegisub/lua/ffi.h
+++ b/libaegisub/include/libaegisub/lua/ffi.h
@@ -17,6 +17,7 @@
 #include <libaegisub/type_name.h>
 
 #include <cstdlib>
+#include <cstring>
 #include <lua.hpp>
 
 namespace agi::lua {

--- a/libaegisub/unix/path.cpp
+++ b/libaegisub/unix/path.cpp
@@ -14,6 +14,8 @@
 //
 // Aegisub Project http://www.aegisub.org/
 
+#include "../acconf.h"
+
 #include <libaegisub/path.h>
 
 #include <libaegisub/exception.h>

--- a/src/aegisublocale.cpp
+++ b/src/aegisublocale.cpp
@@ -32,6 +32,8 @@
 /// @ingroup utility
 ///
 
+#include "acconf.h"
+
 #include "aegisublocale.h"
 
 #include "compat.h"

--- a/src/ass_style.cpp
+++ b/src/ass_style.cpp
@@ -40,6 +40,7 @@
 #include <libaegisub/format.h>
 #include <libaegisub/split.h>
 
+#include <algorithm>
 #include <boost/lexical_cast.hpp>
 #include <wx/intl.h>
 

--- a/src/audio_timing_dialogue.cpp
+++ b/src/audio_timing_dialogue.cpp
@@ -42,6 +42,7 @@
 #include <libaegisub/ass/time.h>
 
 #include <boost/range/algorithm.hpp>
+#include <list>
 #include <wx/pen.h>
 
 namespace {

--- a/src/base_grid.h
+++ b/src/base_grid.h
@@ -32,6 +32,8 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <wx/brush.h>
+#include <wx/scrolbar.h>
 #include <wx/window.h>
 
 namespace agi {

--- a/src/command/command.h
+++ b/src/command/command.h
@@ -17,6 +17,7 @@
 /// @ingroup command
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/src/dialog_colorpicker.cpp
+++ b/src/dialog_colorpicker.cpp
@@ -38,6 +38,7 @@
 
 #include <libaegisub/scoped_ptr.h>
 
+#include <algorithm>
 #include <memory>
 #include <vector>
 

--- a/src/frame_main.cpp
+++ b/src/frame_main.cpp
@@ -67,6 +67,7 @@
 #include <wx/sizer.h>
 #include <wx/statline.h>
 #include <wx/sysopt.h>
+#include <wx/toolbar.h>
 
 enum {
 	ID_APP_TIMER_STATUSCLEAR = 12002

--- a/src/main.h
+++ b/src/main.h
@@ -31,6 +31,8 @@
 
 #include "aegisublocale.h"
 
+#include <vector>
+
 #ifndef wxUSE_EXCEPTIONS
 #error wxWidgets is compiled without exceptions support. Aegisub requires exceptions support in wxWidgets to run safely.
 #endif

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -47,6 +47,7 @@
 
 #include <wx/checkbox.h>
 #include <wx/combobox.h>
+#include <wx/dc.h>
 #include <wx/event.h>
 #include <wx/listctrl.h>
 #include <wx/msgdlg.h>

--- a/src/spline_curve.cpp
+++ b/src/spline_curve.cpp
@@ -35,6 +35,7 @@
 #include "spline_curve.h"
 #include "utils.h"
 
+#include <algorithm>
 #include <limits>
 
 SplineCurve::SplineCurve(Vector2D p1) : p1(p1), type(POINT) { }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -41,6 +41,7 @@
 #ifdef __UNIX__
 #include <unistd.h>
 #endif
+#include <algorithm>
 #include <map>
 #include <unicode/locid.h>
 #include <unicode/unistr.h>


### PR DESCRIPTION
Implicit function declarations are now an error, so we need to include all those missing headers: https://gcc.gnu.org/gcc-14/porting_to.html