### PR TITLE
wxWidgets-3.2 support

### DIFF
--- a/src/toolbar.cpp
+++ b/src/toolbar.cpp
@@ -36,6 +36,7 @@
 
 #include <wx/frame.h>
 #include <wx/toolbar.h>
+#include <wx/version.h>
 
 namespace {
 	json::Object const& get_root() {
@@ -143,7 +144,11 @@ namespace {
 					wxITEM_NORMAL;
 
 				wxBitmap const& bitmap = command->Icon(icon_size, retina_helper.GetScaleFactor(), GetLayoutDirection());
+#if wxCHECK_VERSION(3, 1, 6)
+				AddTool(TOOL_ID_BASE + commands.size(), command->StrDisplay(context), wxBitmapBundle(bitmap), GetTooltip(command), kind);
+#else
 				AddTool(TOOL_ID_BASE + commands.size(), command->StrDisplay(context), bitmap, GetTooltip(command), kind);
+#endif
 
 				commands.push_back(command);
 				needs_onidle = needs_onidle || flags != cmd::COMMAND_NORMAL;

--- a/src/visual_tool_vector_clip.cpp
+++ b/src/visual_tool_vector_clip.cpp
@@ -27,6 +27,7 @@
 #include <boost/range/algorithm/copy.hpp>
 #include <boost/range/algorithm/set_algorithm.hpp>
 #include <wx/toolbar.h>
+#include <wx/version.h>
 
 /// Button IDs
 enum {
@@ -54,7 +55,11 @@ void VisualToolVectorClip::SetToolbar(wxToolBar *toolBar) {
 
 	int icon_size = OPT_GET("App/Toolbar Icon Size")->GetInt();
 
-#define ICON(name) icon_size == 16 ? GETIMAGE(name ## _16) : GETIMAGE(name ## _24)
+#if wxCHECK_VERSION(3, 1, 6)
+# define ICON(name) icon_size == 16 ? wxBitmapBundle(GETIMAGE(name ## _16)) : wxBitmapBundle(GETIMAGE(name ## _24))
+#else
+# define ICON(name) icon_size == 16 ? GETIMAGE(name ## _16) : GETIMAGE(name ## _24)
+#endif
 	toolBar->AddTool(BUTTON_DRAG, _("Drag"), ICON(visual_vector_clip_drag), _("Drag control points"), wxITEM_CHECK);
 	toolBar->AddTool(BUTTON_LINE, _("Line"), ICON(visual_vector_clip_line), _("Appends a line"), wxITEM_CHECK);
 	toolBar->AddTool(BUTTON_BICUBIC, _("Bicubic"), ICON(visual_vector_clip_bicubic), _("Appends a bezier bicubic curve"), wxITEM_CHECK);


### PR DESCRIPTION
In wxWidgets-3.2, calls to wxToolBarToolBase::AddTool() became ambiguous. Somehow, the implicit type conversion that worked in 3.1 stopped working.

We fix this by calling the wxBitmapBundle() constructor explicitly - protected by version checks, since it was introduced in 3.1.6.