### PR TITLE
Bring back agi::fs::path to ensure UTF-8 paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,14 +40,26 @@ jobs:
           #  msvc: false
           #}
           - {
-            name: Ubuntu Debug,
-            os: ubuntu-latest,
+            name: Ubuntu 22 Debug,
+            os: ubuntu-22.04,
             buildtype: debugoptimized,
             args: ''
           }
           - {
-            name: Ubuntu Release,
-            os: ubuntu-latest,
+            name: Ubuntu 22 Release,
+            os: ubuntu-22.04,
+            buildtype: release,
+            args: ''
+          }
+          - {
+            name: Ubuntu 24 Debug,
+            os: ubuntu-24.04,
+            buildtype: debugoptimized,
+            args: ''
+          }
+          - {
+            name: Ubuntu 24 Release,
+            os: ubuntu-24.04,
             buildtype: release,
             args: ''
           }
@@ -116,10 +128,17 @@ jobs:
           brew install pulseaudio  # NO OpenAL in github CI
 
       - name: Install dependencies (Linux)
-        if: matrix.config.os == 'ubuntu-latest'
+        if: startsWith(matrix.config.os, 'ubuntu-')
         run: |
           sudo apt-get update
-          sudo apt-get install ninja-build build-essential libx11-dev libwxgtk3.0-gtk3-dev libfreetype6-dev pkg-config libfontconfig1-dev libass-dev libasound2-dev libffms2-dev intltool libboost-all-dev libhunspell-dev libcurl4-openssl-dev libuchardet-dev
+          sudo apt-get install ninja-build build-essential libx11-dev libfreetype6-dev pkg-config libfontconfig1-dev libass-dev libasound2-dev libffms2-dev intltool libboost-all-dev libhunspell-dev libcurl4-openssl-dev libuchardet-dev ${{ matrix.config.os == 'ubuntu-22.04' && 'libwxgtk3.0-gtk3-dev' || 'libwxgtk3.2-dev' }}
+
+      - name: Set compiler (Linux)
+        if: matrix.config.os == 'ubuntu-22.04'
+        run: |
+          # We need to use Clang on Ubuntu 22 to avoid a bug with GCC 11
+          echo "CC=clang" >> $GITHUB_ENV
+          echo "CXX=clang++" >> $GITHUB_ENV
 
       - name: Configure
         run: meson setup build ${{ matrix.config.args }} -Dbuildtype=${{ matrix.config.buildtype }} ${{ github.ref_type == 'tag' && '-Dofficial_release=true' || '' }}

--- a/libaegisub/audio/provider.cpp
+++ b/libaegisub/audio/provider.cpp
@@ -81,7 +81,7 @@ class writer {
 	std::ostream& out;
 
 public:
-	writer(std::filesystem::path const& filename) : outfile(filename, true), out(outfile.Get()) { }
+	writer(agi::fs::path const& filename) : outfile(filename, true), out(outfile.Get()) { }
 
 	template<int N>
 	void write(const char(&str)[N]) {

--- a/libaegisub/audio/provider_dummy.cpp
+++ b/libaegisub/audio/provider_dummy.cpp
@@ -58,7 +58,7 @@ class DummyAudioProvider final : public AudioProvider {
 	}
 
 public:
-	DummyAudioProvider(std::filesystem::path const& uri) {
+	DummyAudioProvider(agi::fs::path const& uri) {
 		noise = uri.string().find(":noise?") != std::string::npos;
 		channels = 1;
 		sample_rate = 44100;
@@ -70,7 +70,7 @@ public:
 }
 
 namespace agi {
-std::unique_ptr<AudioProvider> CreateDummyAudioProvider(std::filesystem::path const& file, agi::BackgroundRunner *) {
+std::unique_ptr<AudioProvider> CreateDummyAudioProvider(agi::fs::path const& file, agi::BackgroundRunner *) {
 	if (!file.string().starts_with("dummy-audio:"))
 		return {};
 	return std::make_unique<DummyAudioProvider>(file);

--- a/libaegisub/audio/provider_hd.cpp
+++ b/libaegisub/audio/provider_hd.cpp
@@ -21,14 +21,12 @@
 #include <libaegisub/fs.h>
 #include <libaegisub/path.h>
 
-#include <filesystem>
 #include <boost/interprocess/detail/os_thread_functions.hpp>
 #include <ctime>
 #include <thread>
 
 namespace {
 using namespace agi;
-using namespace std::filesystem;
 
 class HDAudioProvider final : public AudioProviderWrapper {
 	mutable temp_file_mapping file;
@@ -49,7 +47,7 @@ class HDAudioProvider final : public AudioProviderWrapper {
 		}
 	}
 
-	path CacheFilename(path const& dir) {
+  fs::path CacheFilename(fs::path const& dir) {
 		// Check free space
 		if ((uint64_t)num_samples * bytes_per_sample > fs::FreeSpace(dir))
 			throw AudioProviderError("Not enough free disk space in " + dir.string() + " to cache the audio");
@@ -59,7 +57,7 @@ class HDAudioProvider final : public AudioProviderWrapper {
 	}
 
 public:
-	HDAudioProvider(std::unique_ptr<AudioProvider> src, path const& dir)
+	HDAudioProvider(std::unique_ptr<AudioProvider> src, fs::path const& dir)
 	: AudioProviderWrapper(std::move(src))
 	, file(dir / CacheFilename(dir), num_samples * bytes_per_sample)
 	{
@@ -83,7 +81,7 @@ public:
 }
 
 namespace agi {
-std::unique_ptr<AudioProvider> CreateHDAudioProvider(std::unique_ptr<AudioProvider> src, std::filesystem::path const& dir) {
+std::unique_ptr<AudioProvider> CreateHDAudioProvider(std::unique_ptr<AudioProvider> src, agi::fs::path const& dir) {
 	return std::make_unique<HDAudioProvider>(std::move(src), dir);
 }
 }

--- a/libaegisub/common/charset.cpp
+++ b/libaegisub/common/charset.cpp
@@ -22,7 +22,7 @@
 #endif
 
 namespace agi::charset {
-std::string Detect(std::filesystem::path const& file) {
+std::string Detect(agi::fs::path const& file) {
 	agi::read_file_mapping fp(file);
 
 	// First check for known magic bytes which identify the file type

--- a/libaegisub/common/file_mapping.cpp
+++ b/libaegisub/common/file_mapping.cpp
@@ -72,7 +72,7 @@ char *map(int64_t s_offset, uint64_t length, boost::interprocess::mode_t mode,
 }
 
 namespace agi {
-file_mapping::file_mapping(std::filesystem::path const& filename, bool temporary)
+file_mapping::file_mapping(agi::fs::path const& filename, bool temporary)
 #ifdef _WIN32
 : handle(CreateFileW(filename.wstring().c_str(),
 	temporary ? read_write : read_only,
@@ -116,7 +116,7 @@ file_mapping::~file_mapping() {
 	}
 }
 
-read_file_mapping::read_file_mapping(std::filesystem::path const& filename)
+read_file_mapping::read_file_mapping(agi::fs::path const& filename)
 : file(filename, false)
 {
 	offset_t size = 0;
@@ -134,7 +134,7 @@ const char *read_file_mapping::read(int64_t offset, uint64_t length) {
 	return map(offset, length, read_only, file_size, file, region, mapping_start);
 }
 
-temp_file_mapping::temp_file_mapping(std::filesystem::path const& filename, uint64_t size)
+temp_file_mapping::temp_file_mapping(agi::fs::path const& filename, uint64_t size)
 : file(filename, true)
 , file_size(size)
 {

--- a/libaegisub/common/format.cpp
+++ b/libaegisub/common/format.cpp
@@ -17,8 +17,7 @@
 #include <libaegisub/format.h>
 
 #include <libaegisub/charset_conv.h>
-
-#include <filesystem>
+#include <libaegisub/fs.h>
 
 #ifdef _MSC_VER
 #define WCHAR_T_ENC "utf-16le"

--- a/libaegisub/common/io.cpp
+++ b/libaegisub/common/io.cpp
@@ -22,7 +22,7 @@
 #include <fstream>
 
 namespace agi::io {
-using namespace std::filesystem;
+using namespace agi::fs;
 
 std::unique_ptr<std::istream> Open(path const& file, bool binary) {
 	LOG_D("agi/io/open/file") << file;

--- a/libaegisub/common/json.cpp
+++ b/libaegisub/common/json.cpp
@@ -37,7 +37,7 @@ json::UnknownElement parse(std::istream &stream) {
 	}
 }
 
-json::UnknownElement file(std::filesystem::path const& file, std::string_view default_config) {
+json::UnknownElement file(agi::fs::path const& file, std::string_view default_config) {
 	try {
 		if (fs::FileExists(file))
 			return parse(*io::Open(file));

--- a/libaegisub/common/keyframe.cpp
+++ b/libaegisub/common/keyframe.cpp
@@ -90,7 +90,7 @@ int wwxd(std::string const& line) {
 }
 
 namespace agi::keyframe {
-void Save(std::filesystem::path const& filename, std::vector<int> const& keyframes) {
+void Save(agi::fs::path const& filename, std::vector<int> const& keyframes) {
 	io::Save file(filename);
 	std::ostream& of = file.Get();
 	of << "# keyframe format v1" << std::endl;
@@ -98,7 +98,7 @@ void Save(std::filesystem::path const& filename, std::vector<int> const& keyfram
 	boost::copy(keyframes, std::ostream_iterator<int>(of, "\n"));
 }
 
-std::vector<int> Load(std::filesystem::path const& filename) {
+std::vector<int> Load(agi::fs::path const& filename) {
 	auto file = io::Open(filename);
 	std::istream &is(*file);
 

--- a/libaegisub/common/log.cpp
+++ b/libaegisub/common/log.cpp
@@ -17,11 +17,11 @@
 #include "libaegisub/cajun/elements.h"
 #include "libaegisub/cajun/writer.h"
 #include "libaegisub/dispatch.h"
+#include "libaegisub/fs.h"
 #include "libaegisub/util.h"
 
 #include <boost/range/algorithm/remove_if.hpp>
 #include <chrono>
-#include <filesystem>
 #include <fstream>
 
 namespace agi::log {
@@ -97,7 +97,7 @@ Message::~Message() {
 	agi::log::log->Log(sm);
 }
 
-JsonEmitter::JsonEmitter(std::filesystem::path const& directory)
+JsonEmitter::JsonEmitter(agi::fs::path const& directory)
 : fp(new std::ofstream(directory/util::strftime("%Y-%m-%d-%H-%M-%S.json")))
 {
 }

--- a/libaegisub/common/mru.cpp
+++ b/libaegisub/common/mru.cpp
@@ -60,7 +60,7 @@ int mru_index(std::string_view key) {
 }
 
 namespace agi {
-MRUManager::MRUManager(std::filesystem::path const& config, std::string_view default_config, agi::Options *options)
+MRUManager::MRUManager(agi::fs::path const& config, std::string_view default_config, agi::Options *options)
 : config_name(config)
 , options(options)
 {
@@ -78,7 +78,7 @@ MRUManager::MRUListMap &MRUManager::Find(std::string_view key) {
 	return mru[index];
 }
 
-void MRUManager::Add(std::string_view key, std::filesystem::path const& entry) {
+void MRUManager::Add(std::string_view key, agi::fs::path const& entry) {
 	MRUListMap &map = Find(key);
 	auto it = find(begin(map), end(map), entry);
 	if (it == begin(map) && it != end(map))
@@ -93,7 +93,7 @@ void MRUManager::Add(std::string_view key, std::filesystem::path const& entry) {
 	Flush();
 }
 
-void MRUManager::Remove(std::string_view key, std::filesystem::path const& entry) {
+void MRUManager::Remove(std::string_view key, agi::fs::path const& entry) {
 	auto& map = Find(key);
 	map.erase(remove(begin(map), end(map), entry), end(map));
 	Flush();
@@ -103,7 +103,7 @@ const MRUManager::MRUListMap* MRUManager::Get(std::string_view key) {
 	return &Find(key);
 }
 
-std::filesystem::path const& MRUManager::GetEntry(std::string_view key, const size_t entry) {
+agi::fs::path const& MRUManager::GetEntry(std::string_view key, const size_t entry) {
 	const auto map = Get(key);
 	if (entry >= map->size())
 		throw MRUError("Requested element index is out of range.");

--- a/libaegisub/common/option.cpp
+++ b/libaegisub/common/option.cpp
@@ -171,7 +171,7 @@ struct option_name_cmp {
 
 namespace agi {
 
-Options::Options(std::filesystem::path const& file, std::string_view default_config, OptionSetting setting)
+Options::Options(agi::fs::path const& file, std::string_view default_config, OptionSetting setting)
 : config_file(file)
 , setting(setting)
 {

--- a/libaegisub/common/path.cpp
+++ b/libaegisub/common/path.cpp
@@ -92,7 +92,7 @@ fs::path Path::MakeRelative(fs::path const& path, fs::path const& base) const {
 	auto ref_it = base.begin();
 	for (; path_it != path.end() && ref_it != base.end() && *path_it == *ref_it; ++path_it, ++ref_it) ;
 
-	std::filesystem::path result;
+	agi::fs::path result;
 	for (; ref_it != base.end(); ++ref_it)
 		result /= "..";
 	for (; path_it != path.end(); ++path_it)

--- a/libaegisub/common/thesaurus.cpp
+++ b/libaegisub/common/thesaurus.cpp
@@ -23,7 +23,7 @@
 
 namespace agi {
 
-Thesaurus::Thesaurus(std::filesystem::path const& dat_path, std::filesystem::path const& idx_path)
+Thesaurus::Thesaurus(agi::fs::path const& dat_path, agi::fs::path const& idx_path)
 : dat(std::make_unique<read_file_mapping>(dat_path))
 {
 	read_file_mapping idx_file(idx_path);

--- a/libaegisub/common/vfr.cpp
+++ b/libaegisub/common/vfr.cpp
@@ -171,7 +171,7 @@ Framerate::Framerate(std::initializer_list<int> timecodes)
 	SetFromTimecodes();
 }
 
-Framerate::Framerate(std::filesystem::path const& filename)
+Framerate::Framerate(agi::fs::path const& filename)
 : denominator(default_denominator)
 {
 	auto file = agi::io::Open(filename);
@@ -192,7 +192,7 @@ Framerate::Framerate(std::filesystem::path const& filename)
 	throw UnknownFormat(line);
 }
 
-void Framerate::Save(std::filesystem::path const& filename, int length) const {
+void Framerate::Save(agi::fs::path const& filename, int length) const {
 	agi::io::Save file(filename);
 	auto &out = file.Get();
 

--- a/libaegisub/include/lagi_pre.h
+++ b/libaegisub/include/lagi_pre.h
@@ -18,7 +18,6 @@
 #endif
 
 #include <algorithm>
-#include <filesystem>
 #include <functional>
 #include <iterator>
 #include <map>

--- a/libaegisub/include/libaegisub/access.h
+++ b/libaegisub/include/libaegisub/access.h
@@ -12,7 +12,7 @@
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-#include <filesystem>
+#include <libaegisub/fs.h>
 
 namespace agi::acs {
 enum Type {
@@ -22,11 +22,11 @@ enum Type {
 	DirWrite
 };
 
-void Check(std::filesystem::path const& file, acs::Type);
+void Check(agi::fs::path const& file, acs::Type);
 
-static inline void CheckFileRead(std::filesystem::path const& file) { Check(file, acs::FileRead); }
-static inline void CheckFileWrite(std::filesystem::path const& file) { Check(file, acs::FileWrite); }
+static inline void CheckFileRead(agi::fs::path const& file) { Check(file, acs::FileRead); }
+static inline void CheckFileWrite(agi::fs::path const& file) { Check(file, acs::FileWrite); }
 
-static inline void CheckDirRead(std::filesystem::path const& dir) { Check(dir, acs::DirRead); }
-static inline void CheckDirWrite(std::filesystem::path const& dir) { Check(dir, acs::DirWrite); }
+static inline void CheckDirRead(agi::fs::path const& dir) { Check(dir, acs::DirRead); }
+static inline void CheckDirWrite(agi::fs::path const& dir) { Check(dir, acs::DirWrite); }
 }

--- a/libaegisub/include/libaegisub/audio/provider.h
+++ b/libaegisub/include/libaegisub/audio/provider.h
@@ -17,9 +17,9 @@
 #pragma once
 
 #include <libaegisub/exception.h>
+#include <libaegisub/fs.h>
 
 #include <atomic>
-#include <filesystem>
 #include <memory>
 #include <vector>
 
@@ -84,14 +84,14 @@ DEFINE_EXCEPTION(AudioDataNotFound, AudioProviderError);
 
 class BackgroundRunner;
 
-std::unique_ptr<AudioProvider> CreateDummyAudioProvider(std::filesystem::path const& filename, BackgroundRunner *);
-std::unique_ptr<AudioProvider> CreatePCMAudioProvider(std::filesystem::path const& filename, BackgroundRunner *);
+std::unique_ptr<AudioProvider> CreateDummyAudioProvider(agi::fs::path const& filename, BackgroundRunner *);
+std::unique_ptr<AudioProvider> CreatePCMAudioProvider(agi::fs::path const& filename, BackgroundRunner *);
 
 std::unique_ptr<AudioProvider> CreateConvertAudioProvider(std::unique_ptr<AudioProvider> source_provider);
 std::unique_ptr<AudioProvider> CreateLockAudioProvider(std::unique_ptr<AudioProvider> source_provider);
 std::unique_ptr<AudioProvider> CreateHDAudioProvider(std::unique_ptr<AudioProvider> source_provider,
-                                                     std::filesystem::path const& dir);
+                                                     agi::fs::path const& dir);
 std::unique_ptr<AudioProvider> CreateRAMAudioProvider(std::unique_ptr<AudioProvider> source_provider);
 
-void SaveAudioClip(AudioProvider const& provider, std::filesystem::path const& path, int start_time, int end_time);
+void SaveAudioClip(AudioProvider const& provider, agi::fs::path const& path, int start_time, int end_time);
 }

--- a/libaegisub/include/libaegisub/charset.h
+++ b/libaegisub/include/libaegisub/charset.h
@@ -12,7 +12,7 @@
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-#include <filesystem>
+#include <libaegisub/fs.h>
 #include <string>
 
 namespace agi {
@@ -22,7 +22,7 @@ namespace agi {
 /// @brief Returns the character set with the highest confidence
 /// @param file File to check
 /// @return Detected character set.
-std::string Detect(std::filesystem::path const& file);
+std::string Detect(agi::fs::path const& file);
 
 	} // namespace util
 } // namespace agi

--- a/libaegisub/include/libaegisub/file_mapping.h
+++ b/libaegisub/include/libaegisub/file_mapping.h
@@ -21,7 +21,7 @@
 #endif
 
 #include <cstdint>
-#include <filesystem>
+#include <libaegisub/fs.h>
 
 namespace agi {
 	// boost::interprocess::file_mapping is awesome and uses CreateFileA on Windows
@@ -29,7 +29,7 @@ namespace agi {
 		boost::interprocess::file_handle_t handle;
 
 	public:
-		file_mapping(std::filesystem::path const& filename, bool temporary);
+		file_mapping(agi::fs::path const& filename, bool temporary);
 		~file_mapping();
 		boost::interprocess::mapping_handle_t get_mapping_handle() const {
 			return boost::interprocess::ipcdetail::mapping_handle_from_file_handle(handle);
@@ -43,7 +43,7 @@ namespace agi {
 		uint64_t file_size = 0;
 
 	public:
-		read_file_mapping(std::filesystem::path const& filename);
+		read_file_mapping(agi::fs::path const& filename);
 		~read_file_mapping();
 
 		uint64_t size() const { return file_size; }
@@ -61,7 +61,7 @@ namespace agi {
 		uint64_t write_mapping_start = 0;
 
 	public:
-		temp_file_mapping(std::filesystem::path const& filename, uint64_t size);
+		temp_file_mapping(agi::fs::path const& filename, uint64_t size);
 		~temp_file_mapping();
 
 		const char *read(int64_t offset, uint64_t length);

--- a/libaegisub/include/libaegisub/format.h
+++ b/libaegisub/include/libaegisub/format.h
@@ -16,7 +16,7 @@
 
 #include <boost/interprocess/streams/vectorstream.hpp>
 #include <boost/io/ios_state.hpp>
-#include <filesystem>
+#include <libaegisub/fs.h>
 #include <type_traits>
 
 class wxString;
@@ -66,8 +66,8 @@ struct writer<StreamChar, std::basic_string<Char>> {
 };
 
 // Ensure things with specializations don't get implicitly initialized
-template<> struct writer<char, std::filesystem::path>;
-template<> struct writer<wchar_t, std::filesystem::path>;
+template<> struct writer<char, agi::fs::path>;
+template<> struct writer<wchar_t, agi::fs::path>;
 template<> struct writer<char, wxString>;
 template<> struct writer<wchar_t, wxString>;
 

--- a/libaegisub/include/libaegisub/format_path.h
+++ b/libaegisub/include/libaegisub/format_path.h
@@ -14,20 +14,20 @@
 //
 // Aegisub Project http://www.aegisub.org/
 
-#include <filesystem>
+#include <libaegisub/fs.h>
 
 namespace agi {
 // Default version quotes the path
 template<>
-struct writer<char, std::filesystem::path> {
-	static void write(std::basic_ostream<char>& out, int max_len, std::filesystem::path const& value) {
+struct writer<char, agi::fs::path> {
+	static void write(std::basic_ostream<char>& out, int max_len, agi::fs::path const& value) {
 		out << value.string();
 	}
 };
 
 template<>
-struct writer<wchar_t, std::filesystem::path> {
-	static void write(std::basic_ostream<wchar_t>& out, int max_len, std::filesystem::path const& value) {
+struct writer<wchar_t, agi::fs::path> {
+	static void write(std::basic_ostream<wchar_t>& out, int max_len, agi::fs::path const& value) {
 		out << value.wstring();
 	}
 };

--- a/libaegisub/include/libaegisub/hotkey.h
+++ b/libaegisub/include/libaegisub/hotkey.h
@@ -12,12 +12,12 @@
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-#include <filesystem>
 #include <map>
 #include <string>
 #include <string_view>
 #include <vector>
 
+#include <libaegisub/fs.h>
 #include <libaegisub/signal.h>
 
 namespace json {
@@ -64,7 +64,7 @@ public:
 private:
 	HotkeyMap cmd_map;                  ///< Command name -> Combo
 	std::vector<const Combo *> str_map; ///< Sorted by string representation
-	const std::filesystem::path config_file;    ///< Default user config location.
+	const agi::fs::path config_file;    ///< Default user config location.
 	bool backup_config_file = false;
 
 	/// Build hotkey map.
@@ -83,7 +83,7 @@ public:
 	/// Constructor
 	/// @param file           Location of user config file.
 	/// @param default_config Default config.
-	Hotkey(std::filesystem::path const& file, std::string_view default_config);
+	Hotkey(agi::fs::path const& file, std::string_view default_config);
 
 	/// Scan for a matching key.
 	/// @param context  Context requested.

--- a/libaegisub/include/libaegisub/io.h
+++ b/libaegisub/include/libaegisub/io.h
@@ -13,8 +13,8 @@
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #include <libaegisub/exception.h>
+#include <libaegisub/fs.h>
 
-#include <filesystem>
 #include <iosfwd>
 #include <memory>
 
@@ -23,15 +23,15 @@ namespace agi::io {
 DEFINE_EXCEPTION(IOError, Exception);
 DEFINE_EXCEPTION(IOFatal, IOError);
 
-std::unique_ptr<std::istream> Open(std::filesystem::path const& file, bool binary = false);
+std::unique_ptr<std::istream> Open(agi::fs::path const& file, bool binary = false);
 
 class Save {
 	std::unique_ptr<std::ostream> fp;
-	const std::filesystem::path file_name;
-	const std::filesystem::path tmp_name;
+	const agi::fs::path file_name;
+	const agi::fs::path tmp_name;
 
 public:
-	Save(std::filesystem::path const& file, bool binary = false);
+	Save(agi::fs::path const& file, bool binary = false);
 	~Save() noexcept(false);
 	std::ostream& Get() { return *fp; }
 };

--- a/libaegisub/include/libaegisub/json.h
+++ b/libaegisub/include/libaegisub/json.h
@@ -13,8 +13,7 @@
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #include <libaegisub/cajun/elements.h>
-
-#include <filesystem>
+#include <libaegisub/fs.h>
 
 namespace agi::json_util {
 
@@ -27,6 +26,6 @@ json::UnknownElement parse(std::istream &stream);
 /// @param file Path to JSON file.
 /// @param Default config file to load incase of nonexistent file
 /// @return json::UnknownElement
-json::UnknownElement file(std::filesystem::path const& file, std::string_view default_config);
+json::UnknownElement file(agi::fs::path const& file, std::string_view default_config);
 
 }

--- a/libaegisub/include/libaegisub/keyframe.h
+++ b/libaegisub/include/libaegisub/keyframe.h
@@ -12,21 +12,21 @@
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+#include <libaegisub/fs.h>
 #include <libaegisub/exception.h>
 
-#include <filesystem>
 #include <vector>
 
 namespace agi::keyframe {
 /// @brief Load a keyframe file
 /// @param filename File to load
 /// @return List of frame numbers which are keyframes
-std::vector<int> Load(std::filesystem::path const& filename);
+std::vector<int> Load(agi::fs::path const& filename);
 
 /// @brief Save keyframes to a file
 /// @param filename File to save to
 /// @param keyframes List of keyframes to save
-void Save(std::filesystem::path const& filename, std::vector<int> const& keyframes);
+void Save(agi::fs::path const& filename, std::vector<int> const& keyframes);
 
 DEFINE_EXCEPTION(KeyframeFormatParseError, agi::InvalidInputException);
 DEFINE_EXCEPTION(UnknownKeyframeFormatError, agi::InvalidInputException);

--- a/libaegisub/include/libaegisub/log.h
+++ b/libaegisub/include/libaegisub/log.h
@@ -12,9 +12,9 @@
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+#include <libaegisub/fs.h>
 #include <boost/interprocess/streams/bufferstream.hpp>
 #include <cstdint>
-#include <filesystem>
 #include <memory>
 #include <vector>
 
@@ -112,7 +112,7 @@ class JsonEmitter final : public Emitter {
 public:
 	/// Constructor
 	/// @param directory Directory to write the log file in
-	JsonEmitter(std::filesystem::path const& directory);
+	JsonEmitter(agi::fs::path const& directory);
 
 	void log(SinkMessage const&) override;
 };

--- a/libaegisub/include/libaegisub/lua/script_reader.h
+++ b/libaegisub/include/libaegisub/lua/script_reader.h
@@ -14,15 +14,15 @@
 //
 // Aegisub Project http://www.aegisub.org/
 
-#include <filesystem>
+#include <libaegisub/fs.h>
 #include <vector>
 
 struct lua_State;
 
 namespace agi::lua {
 	/// Load a Lua or Moonscript file at the given path
-	bool LoadFile(lua_State *L, std::filesystem::path const& filename);
+	bool LoadFile(lua_State *L, agi::fs::path const& filename);
 	/// Install our module loader and add include_path to the module search
 	/// path of the given lua state
-	bool Install(lua_State *L, std::vector<std::filesystem::path> const& include_path);
+	bool Install(lua_State *L, std::vector<agi::fs::path> const& include_path);
 }

--- a/libaegisub/include/libaegisub/mru.h
+++ b/libaegisub/include/libaegisub/mru.h
@@ -13,11 +13,11 @@
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #include <array>
-#include <filesystem>
 #include <string_view>
 #include <vector>
 
 #include <libaegisub/exception.h>
+#include <libaegisub/fs.h>
 
 namespace json {
 	class UnknownElement;
@@ -39,23 +39,23 @@ DEFINE_EXCEPTION(MRUError, Exception);
 class MRUManager {
 public:
 	/// @brief Map for time->value pairs.
-	using MRUListMap = std::vector<std::filesystem::path>;
+	using MRUListMap = std::vector<agi::fs::path>;
 
 	/// @brief Constructor
 	/// @param config File to load MRU values from
-	MRUManager(std::filesystem::path const& config, std::string_view default_config, agi::Options *options = nullptr);
+	MRUManager(agi::fs::path const& config, std::string_view default_config, agi::Options *options = nullptr);
 
 	/// @brief Add entry to the list.
 	/// @param key List name
 	/// @param entry Entry to add
 	/// @exception MRUError thrown when an invalid key is used.
-	void Add(std::string_view key, std::filesystem::path const& entry);
+	void Add(std::string_view key, agi::fs::path const& entry);
 
 	/// @brief Remove entry from the list.
 	/// @param key List name
 	/// @param entry Entry to add
 	/// @exception MRUError thrown when an invalid key is used.
-	void Remove(std::string_view key, std::filesystem::path const& entry);
+	void Remove(std::string_view key, agi::fs::path const& entry);
 
 	/// @brief Return list
 	/// @param key List name
@@ -66,14 +66,14 @@ public:
 	/// @param key List name
 	/// @param entry 0-base position of entry
 	/// @exception MRUError thrown when an invalid key is used.
-	std::filesystem::path const& GetEntry(std::string_view key, const size_t entry);
+	agi::fs::path const& GetEntry(std::string_view key, const size_t entry);
 
 	/// Write MRU lists to disk.
 	void Flush();
 
 private:
 	/// Internal name of the config file, set during object construction.
-	const std::filesystem::path config_name;
+	const agi::fs::path config_name;
 
 	/// User preferences object for maximum number of items to list
 	agi::Options *const options;

--- a/libaegisub/include/libaegisub/option.h
+++ b/libaegisub/include/libaegisub/option.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <filesystem>
+#include <libaegisub/fs.h>
 #include <iosfwd>
 #include <map>
 #include <memory>
@@ -40,7 +40,7 @@ private:
 	std::vector<std::unique_ptr<OptionValue>> values;
 
 	/// User config (file that will be written to disk)
-	const std::filesystem::path config_file;
+	const agi::fs::path config_file;
 
 	/// Settings.
 	const OptionSetting setting;
@@ -54,7 +54,7 @@ public:
 	/// @brief Constructor
 	/// @param file User config that will be loaded from and written back to.
 	/// @param default_config Default configuration.
-	Options(std::filesystem::path const& file, std::string_view default_config, OptionSetting setting = NONE);
+	Options(agi::fs::path const& file, std::string_view default_config, OptionSetting setting = NONE);
 
 	/// Destructor
 	~Options();

--- a/libaegisub/include/libaegisub/path.h
+++ b/libaegisub/include/libaegisub/path.h
@@ -14,11 +14,11 @@
 //
 // Aegisub Project http://www.aegisub.org/
 
+#include <libaegisub/fs.h>
+
 #include <array>
-#include <filesystem>
 
 namespace agi {
-namespace fs { using path = std::filesystem::path; }
 /// Class for handling everything path-related in Aegisub
 class Path {
 	/// Token -> Path map

--- a/libaegisub/include/libaegisub/thesaurus.h
+++ b/libaegisub/include/libaegisub/thesaurus.h
@@ -13,7 +13,7 @@
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #include <boost/container/flat_map.hpp>
-#include <filesystem>
+#include <libaegisub/fs.h>
 #include <iosfwd>
 #include <memory>
 #include <string>
@@ -40,7 +40,7 @@ public:
 	/// Constructor
 	/// @param dat_path Path to data file
 	/// @param idx_path Path to index file
-	Thesaurus(std::filesystem::path const& dat_path, std::filesystem::path const& idx_path);
+	Thesaurus(agi::fs::path const& dat_path, agi::fs::path const& idx_path);
 	~Thesaurus();
 
 	/// Look up synonyms for a word

--- a/libaegisub/include/libaegisub/vfr.h
+++ b/libaegisub/include/libaegisub/vfr.h
@@ -15,10 +15,10 @@
 #pragma once
 
 #include <cstdint>
-#include <filesystem>
 #include <vector>
 
 #include <libaegisub/exception.h>
+#include <libaegisub/fs.h>
 
 namespace agi {
 	/// Framerate handling.
@@ -91,7 +91,7 @@ public:
 	/// not the same thing as CFR X. When timecodes are loaded from a file,
 	/// mkvmerge-style rounding is applied, while setting a constant frame rate
 	/// uses truncation.
-	Framerate(std::filesystem::path const& filename);
+	Framerate(agi::fs::path const& filename);
 
 	/// @brief CFR constructor
 	/// @param fps Frames per second or 0 for unloaded
@@ -190,7 +190,7 @@ public:
 	/// CFR, but saving CFR timecodes is a bit silly). Extra timecodes generated
 	/// to hit length with v2 timecodes will monotonically increase but may not
 	/// be otherwise sensible.
-	void Save(std::filesystem::path const& file, int length = -1) const;
+	void Save(agi::fs::path const& file, int length = -1) const;
 
 	/// Is this frame rate possibly variable?
 	bool IsVFR() const {return timecodes.size() > 1; }

--- a/libaegisub/lua/modules/lfs.cpp
+++ b/libaegisub/lua/modules/lfs.cpp
@@ -46,7 +46,7 @@ auto wrap(char **err, Func f) -> decltype(f()) {
 }
 
 template<typename Ret>
-bool setter(const char *path, char **err, Ret (*f)(sfs::path const&)) {
+bool setter(const char *path, char **err, Ret (*f)(agi::fs::path const&)) {
 	return wrap(err, [=]{
 		f(path);
 		return true;
@@ -54,12 +54,12 @@ bool setter(const char *path, char **err, Ret (*f)(sfs::path const&)) {
 }
 
 bool lfs_chdir(const char *dir, char **err) {
-	return setter(dir, err, &sfs::current_path);
+	return setter(dir, err, CurrentPath);
 }
 
 char *currentdir(char **err) {
 	return wrap(err, []{
-		return strndup(sfs::current_path().string());
+		return strndup(CurrentPath().string());
 	});
 }
 

--- a/libaegisub/lua/script_reader.cpp
+++ b/libaegisub/lua/script_reader.cpp
@@ -25,7 +25,7 @@
 #include <lauxlib.h>
 
 namespace agi::lua {
-	bool LoadFile(lua_State *L, std::filesystem::path const& raw_filename) {
+	bool LoadFile(lua_State *L, agi::fs::path const& raw_filename) {
 		auto filename = raw_filename;
 		try {
 			filename = agi::fs::Canonicalize(raw_filename);
@@ -89,9 +89,9 @@ namespace agi::lua {
 
 			// If there's a .moon file at that path, load it instead of the
 			// .lua file
-			std::filesystem::path path = filename;
+			agi::fs::path path = filename;
 			if (agi::fs::HasExtension(path, "lua")) {
-				std::filesystem::path moonpath = path;
+				agi::fs::path moonpath = path;
 				moonpath.replace_extension("moon");
 				if (agi::fs::FileExists(moonpath))
 					path = moonpath;

--- a/libaegisub/unix/access.cpp
+++ b/libaegisub/unix/access.cpp
@@ -16,14 +16,13 @@
 
 #include "libaegisub/fs.h"
 
-#include <filesystem>
 #include <sys/stat.h>
 #include <cerrno>
 #include <unistd.h>
 
 namespace agi::acs {
 
-void Check(std::filesystem::path const& file, acs::Type type) {
+void Check(agi::fs::path const& file, acs::Type type) {
 	auto cu = std::filesystem::current_path();
 	std::error_code ec;
 	auto s = std::filesystem::status(file, ec);

--- a/libaegisub/unix/fs.cpp
+++ b/libaegisub/unix/fs.cpp
@@ -19,7 +19,6 @@
 #include "libaegisub/io.h"
 
 #include <fcntl.h>
-#include <filesystem>
 #include <fnmatch.h>
 #include <istream>
 #include <sys/time.h>

--- a/libaegisub/unix/path.cpp
+++ b/libaegisub/unix/path.cpp
@@ -69,12 +69,12 @@ std::string exe_dir() {
 namespace agi {
 void Path::FillPlatformSpecificPaths() {
 #ifndef __APPLE__
-	std::filesystem::path home = home_dir();
+	agi::fs::path home = home_dir();
 	SetToken("?user", home/".aegisub");
 	SetToken("?local", home/".aegisub");
 
 #ifdef APPIMAGE_BUILD
-	std::filesystem::path data = exe_dir();
+	agi::fs::path data = exe_dir();
 	if (data == "") data = home/".aegisub";
 	SetToken("?data", data);
 	SetToken("?dictionary", Decode("?data/dictionaries"));
@@ -84,13 +84,13 @@ void Path::FillPlatformSpecificPaths() {
 #endif
 
 #else
-	std::filesystem::path app_support = agi::util::GetApplicationSupportDirectory();
+	agi::fs::path app_support = agi::util::GetApplicationSupportDirectory();
 	SetToken("?user", app_support/"Aegisub");
 	SetToken("?local", app_support/"Aegisub");
 	SetToken("?data", agi::util::GetBundleSharedSupportDirectory());
 	SetToken("?dictionary", Decode("?data/dictionaries"));
 #endif
-	SetToken("?temp", std::filesystem::temp_directory_path());
+	SetToken("?temp", agi::fs::path(std::filesystem::temp_directory_path()));
 }
 
 }

--- a/libaegisub/windows/path_win.cpp
+++ b/libaegisub/windows/path_win.cpp
@@ -26,18 +26,22 @@
 #include <Shellapi.h>
 
 namespace {
+agi::fs::path PathFromWString(std::wstring_view path) {
+	return agi::fs::path(std::filesystem::path(path));
+}
+
 agi::fs::path WinGetFolderPath(int folder) {
 	wchar_t path[MAX_PATH+1] = {0};
 	if (FAILED(SHGetFolderPathW(0, folder, 0, 0, path)))
 		throw agi::EnvironmentError("SHGetFolderPath failed. This should not happen.");
-	return path;
+	return PathFromWString(path);
 }
 }
 
 namespace agi {
 
 void Path::FillPlatformSpecificPaths() {
-	SetToken("?temp", std::filesystem::temp_directory_path());
+	SetToken("?temp", agi::fs::path(std::filesystem::temp_directory_path()));
 
 	SetToken("?user", WinGetFolderPath(CSIDL_APPDATA)/"Aegisub");
 	SetToken("?local", WinGetFolderPath(CSIDL_LOCAL_APPDATA)/"Aegisub");
@@ -45,7 +49,7 @@ void Path::FillPlatformSpecificPaths() {
 	std::wstring filename(MAX_PATH + 1, L'\0');
 	while (static_cast<DWORD>(filename.size()) == GetModuleFileNameW(nullptr, &filename[0], filename.size()))
 		filename.resize(filename.size() * 2);
-	SetToken("?data", filename);
+	SetToken("?data", PathFromWString(filename));
 
 	SetToken("?dictionary", Decode("?data/dictionaries"));
 }

--- a/src/ass_attachment.cpp
+++ b/src/ass_attachment.cpp
@@ -33,7 +33,7 @@ AssAttachment::AssAttachment(std::string const& header, AssEntryGroup group)
 {
 }
 
-AssAttachment::AssAttachment(std::filesystem::path const& name, AssEntryGroup group)
+AssAttachment::AssAttachment(agi::fs::path const& name, AssEntryGroup group)
 : filename(name.filename().string())
 , group(group)
 {
@@ -53,7 +53,7 @@ size_t AssAttachment::GetSize() const {
 	return entry_data.get().size() - header_end - 1;
 }
 
-void AssAttachment::Extract(std::filesystem::path const& filename) const {
+void AssAttachment::Extract(agi::fs::path const& filename) const {
 	auto header_end = entry_data.get().find('\n');
 	auto decoded = agi::ass::UUDecode(entry_data.get().c_str() + header_end + 1, &entry_data.get().back() + 1);
 	agi::io::Save(filename, true).Get().write(&decoded[0], decoded.size());

--- a/src/ass_attachment.h
+++ b/src/ass_attachment.h
@@ -17,7 +17,7 @@
 #include "ass_entry.h"
 
 #include <boost/flyweight.hpp>
-#include <filesystem>
+#include <libaegisub/fs.h>
 
 /// @class AssAttachment
 class AssAttachment final : public AssEntry {
@@ -38,7 +38,7 @@ public:
 
 	/// Extract the contents of this attachment to a file
 	/// @param filename Path to save the attachment to
-	void Extract(std::filesystem::path const& filename) const;
+	void Extract(agi::fs::path const& filename) const;
 
 	/// Get the name of the attached file
 	/// @param raw If false, remove the SSA filename mangling
@@ -49,5 +49,5 @@ public:
 
 	AssAttachment(AssAttachment const& rgt) = default;
 	AssAttachment(std::string const& header, AssEntryGroup group);
-	AssAttachment(std::filesystem::path const& name, AssEntryGroup group);
+	AssAttachment(agi::fs::path const& name, AssEntryGroup group);
 };

--- a/src/ass_exporter.cpp
+++ b/src/ass_exporter.cpp
@@ -79,7 +79,7 @@ std::vector<std::string> AssExporter::GetAllFilterNames() const {
 	return names;
 }
 
-void AssExporter::Export(std::filesystem::path const& filename, const char *charset, wxWindow *export_dialog) {
+void AssExporter::Export(agi::fs::path const& filename, const char *charset, wxWindow *export_dialog) {
 	AssFile subs(*c->ass);
 
 	for (auto filter : filters) {

--- a/src/ass_exporter.h
+++ b/src/ass_exporter.h
@@ -27,7 +27,7 @@
 //
 // Aegisub Project http://www.aegisub.org/
 
-#include <filesystem>
+#include <libaegisub/fs.h>
 #include <map>
 #include <string>
 #include <vector>
@@ -67,7 +67,7 @@ public:
 	/// @param file Target filename
 	/// @param charset Target charset
 	/// @param parent_window Parent window the filters should use when opening dialogs
-	void Export(std::filesystem::path const& file, const char *charset, wxWindow *parent_window= nullptr);
+	void Export(agi::fs::path const& file, const char *charset, wxWindow *parent_window= nullptr);
 
 	/// Add configuration panels for all registered filters to the target sizer
 	/// @param parent Parent window for controls

--- a/src/ass_file.cpp
+++ b/src/ass_file.cpp
@@ -97,7 +97,7 @@ EntryList<AssDialogue>::iterator AssFile::iterator_to(AssDialogue& line) {
 	return in_list ? Events.iterator_to(line) : Events.end();
 }
 
-void AssFile::InsertAttachment(std::filesystem::path const& filename) {
+void AssFile::InsertAttachment(agi::fs::path const& filename) {
 	AssEntryGroup group = AssEntryGroup::GRAPHIC;
 
 	auto ext = boost::to_lower_copy(filename.extension().string());

--- a/src/ass_file.h
+++ b/src/ass_file.h
@@ -29,9 +29,9 @@
 
 #include "ass_entry.h"
 
+#include <libaegisub/fs.h>
 #include <libaegisub/signal.h>
 
-#include <filesystem>
 #include <boost/intrusive/list.hpp>
 #include <map>
 #include <set>
@@ -105,7 +105,7 @@ public:
 	/// @param style_catalog Style catalog name to fill styles from, blank to use default style
 	void LoadDefault(bool defline = true, std::string const& style_catalog = std::string());
 	/// Attach a file to the ass file
-	void InsertAttachment(std::filesystem::path const& filename);
+	void InsertAttachment(agi::fs::path const& filename);
 	/// Get the names of all of the styles available
 	std::vector<std::string> GetStyles() const;
 	/// @brief Get a style by name

--- a/src/ass_style_storage.cpp
+++ b/src/ass_style_storage.cpp
@@ -57,7 +57,7 @@ void AssStyleStorage::Save() const {
 		out.Get() << cur->GetEntryData() << "\n";
 }
 
-void AssStyleStorage::Load(std::filesystem::path const& filename) {
+void AssStyleStorage::Load(agi::fs::path const& filename) {
 	file = filename;
 	clear();
 
@@ -102,7 +102,7 @@ AssStyle *AssStyleStorage::GetStyle(std::string_view name) {
 std::vector<std::string> AssStyleStorage::GetCatalogs() {
 	std::vector<std::string> catalogs;
 	for (auto const& file : agi::fs::DirectoryIterator(config::path->Decode("?user/catalog/"), "*.sty"))
-		catalogs.push_back(std::filesystem::path(file).stem().string());
+		catalogs.push_back(agi::fs::path(file).stem().string());
 	return catalogs;
 }
 

--- a/src/ass_style_storage.h
+++ b/src/ass_style_storage.h
@@ -27,7 +27,7 @@
 //
 // Aegisub Project http://www.aegisub.org/
 
-#include <filesystem>
+#include <libaegisub/fs.h>
 #include <memory>
 #include <string>
 #include <vector>
@@ -36,7 +36,7 @@ class AssFile;
 class AssStyle;
 
 class AssStyleStorage {
-	std::filesystem::path file;
+	agi::fs::path file;
 	std::vector<std::unique_ptr<AssStyle>> style;
 
 public:
@@ -70,7 +70,7 @@ public:
 
 	/// Load stored styles from a file
 	/// @param filename Catalog filename. Does not have to exist.
-	void Load(std::filesystem::path const& filename);
+	void Load(agi::fs::path const& filename);
 
 	/// Load stored styles from a file in the default location
 	/// @param catalogname Basename for the catalog file. Does not have to exist.

--- a/src/async_video_provider.cpp
+++ b/src/async_video_provider.cpp
@@ -91,7 +91,7 @@ static std::unique_ptr<SubtitlesProvider> get_subs_provider(wxEvtHandler *evt_ha
 	}
 }
 
-AsyncVideoProvider::AsyncVideoProvider(std::filesystem::path const& video_filename, std::string_view colormatrix, wxEvtHandler *parent, agi::BackgroundRunner *br)
+AsyncVideoProvider::AsyncVideoProvider(agi::fs::path const& video_filename, std::string_view colormatrix, wxEvtHandler *parent, agi::BackgroundRunner *br)
 : worker(agi::dispatch::Create())
 , subs_provider(get_subs_provider(parent, br))
 , source_provider(VideoProviderFactory::GetProvider(video_filename, colormatrix, br))

--- a/src/async_video_provider.h
+++ b/src/async_video_provider.h
@@ -17,9 +17,9 @@
 #include "include/aegisub/video_provider.h"
 
 #include <libaegisub/exception.h>
+#include <libaegisub/fs.h>
 
 #include <atomic>
-#include <filesystem>
 #include <memory>
 #include <set>
 #include <wx/event.h>
@@ -127,7 +127,7 @@ public:
 	/// @brief Constructor
 	/// @param videoFileName File to open
 	/// @param parent Event handler to send FrameReady events to
-	AsyncVideoProvider(std::filesystem::path const& filename, std::string_view colormatrix, wxEvtHandler *parent, agi::BackgroundRunner *br);
+	AsyncVideoProvider(agi::fs::path const& filename, std::string_view colormatrix, wxEvtHandler *parent, agi::BackgroundRunner *br);
 	~AsyncVideoProvider();
 };
 

--- a/src/audio_provider_avs.cpp
+++ b/src/audio_provider_avs.cpp
@@ -57,12 +57,12 @@ class AvisynthAudioProvider final : public agi::AudioProvider {
 	void FillBuffer(void *buf, int64_t start, int64_t count) const;
 
 public:
-	AvisynthAudioProvider(std::filesystem::path const& filename);
+	AvisynthAudioProvider(agi::fs::path const& filename);
 
 	bool NeedsCache() const override { return true; }
 };
 
-AvisynthAudioProvider::AvisynthAudioProvider(std::filesystem::path const& filename) {
+AvisynthAudioProvider::AvisynthAudioProvider(agi::fs::path const& filename) {
 	agi::acs::CheckFileRead(filename);
 
 	std::lock_guard<std::mutex> lock(avs_wrapper.GetMutex());
@@ -79,7 +79,7 @@ AvisynthAudioProvider::AvisynthAudioProvider(std::filesystem::path const& filena
 			AVSValue args[3] = { env->SaveString(agi::fs::ShortName(filename).c_str()), false, true };
 
 			// Load DirectShowSource.dll from app dir if it exists
-			std::filesystem::path dsspath(config::path->Decode("?data/DirectShowSource.dll"));
+			agi::fs::path dsspath(config::path->Decode("?data/DirectShowSource.dll"));
 			if (agi::fs::FileExists(dsspath))
 				env->Invoke("LoadPlugin", env->SaveString(agi::fs::ShortName(dsspath).c_str()));
 
@@ -142,7 +142,7 @@ void AvisynthAudioProvider::FillBuffer(void *buf, int64_t start, int64_t count) 
 }
 }
 
-std::unique_ptr<agi::AudioProvider> CreateAvisynthAudioProvider(std::filesystem::path const& file, agi::BackgroundRunner *) {
+std::unique_ptr<agi::AudioProvider> CreateAvisynthAudioProvider(agi::fs::path const& file, agi::BackgroundRunner *) {
 	return std::make_unique<AvisynthAudioProvider>(file);
 }
 #endif

--- a/src/audio_provider_factory.h
+++ b/src/audio_provider_factory.h
@@ -14,7 +14,7 @@
 //
 // Aegisub Project http://www.aegisub.org/
 
-#include <filesystem>
+#include <libaegisub/fs.h>
 #include <memory>
 #include <vector>
 
@@ -24,7 +24,7 @@ namespace agi {
 	class Path;
 }
 
-std::unique_ptr<agi::AudioProvider> GetAudioProvider(std::filesystem::path const& filename,
+std::unique_ptr<agi::AudioProvider> GetAudioProvider(agi::fs::path const& filename,
                                                      agi::Path const& path_helper,
                                                      agi::BackgroundRunner *br);
 std::vector<std::string> GetAudioProviderNames();

--- a/src/audio_provider_ffmpegsource.cpp
+++ b/src/audio_provider_ffmpegsource.cpp
@@ -50,21 +50,21 @@ class FFmpegSourceAudioProvider final : public agi::AudioProvider, FFmpegSourceP
 	mutable char FFMSErrMsg[1024];			///< FFMS error message
 	mutable FFMS_ErrorInfo ErrInfo;			///< FFMS error codes/messages
 
-	void LoadAudio(std::filesystem::path const& filename);
+	void LoadAudio(agi::fs::path const& filename);
 	void FillBuffer(void *Buf, int64_t Start, int64_t Count) const override {
 		if (FFMS_GetAudio(AudioSource, Buf, Start, Count, &ErrInfo))
 			throw agi::AudioDecodeError(std::string("Failed to get audio samples: ") + ErrInfo.Buffer);
 	}
 
 public:
-	FFmpegSourceAudioProvider(std::filesystem::path const& filename, agi::BackgroundRunner *br);
+	FFmpegSourceAudioProvider(agi::fs::path const& filename, agi::BackgroundRunner *br);
 
 	bool NeedsCache() const override { return true; }
 };
 
 /// @brief Constructor
 /// @param filename The filename to open
-FFmpegSourceAudioProvider::FFmpegSourceAudioProvider(std::filesystem::path const& filename, agi::BackgroundRunner *br) try
+FFmpegSourceAudioProvider::FFmpegSourceAudioProvider(agi::fs::path const& filename, agi::BackgroundRunner *br) try
 : FFmpegSourceProvider(br)
 , AudioSource(nullptr, FFMS_DestroyAudioSource)
 {
@@ -80,7 +80,7 @@ catch (agi::EnvironmentError const& err) {
 	throw agi::AudioProviderError(err.GetMessage());
 }
 
-void FFmpegSourceAudioProvider::LoadAudio(std::filesystem::path const& filename) {
+void FFmpegSourceAudioProvider::LoadAudio(agi::fs::path const& filename) {
 	FFMS_Indexer *Indexer = FFMS_CreateIndexer(filename.string().c_str(), &ErrInfo);
 	if (!Indexer) {
 		if (ErrInfo.SubType == FFMS_ERROR_FILE_READ)
@@ -106,7 +106,7 @@ void FFmpegSourceAudioProvider::LoadAudio(std::filesystem::path const& filename)
 		throw agi::AudioDataNotFound("no audio tracks found");
 
 	// generate a name for the cache file
-	std::filesystem::path CacheName = GetCacheFilename(filename);
+	agi::fs::path CacheName = GetCacheFilename(filename);
 
 	// try to read index
 	agi::scoped_holder<FFMS_Index*, void (FFMS_CC*)(FFMS_Index*)>
@@ -181,7 +181,7 @@ void FFmpegSourceAudioProvider::LoadAudio(std::filesystem::path const& filename)
 
 }
 
-std::unique_ptr<agi::AudioProvider> CreateFFmpegSourceAudioProvider(std::filesystem::path const& file, agi::BackgroundRunner *br) {
+std::unique_ptr<agi::AudioProvider> CreateFFmpegSourceAudioProvider(agi::fs::path const& file, agi::BackgroundRunner *br) {
 	return std::make_unique<FFmpegSourceAudioProvider>(file, br);
 }
 

--- a/src/auto4_base.cpp
+++ b/src/auto4_base.cpp
@@ -249,7 +249,7 @@ namespace Automation4 {
 	}
 
 	// Script
-	Script::Script(std::filesystem::path const& filename)
+	Script::Script(agi::fs::path const& filename)
 	: filename(filename)
 	{
 		include_path.emplace_back(filename.parent_path());
@@ -315,7 +315,7 @@ namespace Automation4 {
 
 		std::vector<std::future<std::unique_ptr<Script>>> script_futures;
 
-		std::set<std::filesystem::path> dirnames;
+		std::set<agi::fs::path> dirnames;
 		for (auto tok : agi::Split(path, '|')) {
 			auto dirname = config::path->Decode(std::string(tok));
 			if (!agi::fs::DirectoryExists(dirname)) continue;
@@ -375,7 +375,7 @@ namespace Automation4 {
 			char first_char = tok[0];
 			std::string trimmed(begin(tok) + 1, end(tok));
 
-			std::filesystem::path basepath;
+			agi::fs::path basepath;
 			if (first_char == '~') {
 				basepath = context->subsController->Filename().parent_path();
 			} else if (first_char == '$') {
@@ -407,7 +407,7 @@ namespace Automation4 {
 		// 3. If step 2 failed, or absolute path is shorter than path relative to ass, use absolute path ("/")
 		// 4. Otherwise, use path relative to ass ("~")
 		std::string scripts_string;
-		std::filesystem::path autobasefn(OPT_GET("Path/Automation/Base")->GetString());
+		agi::fs::path autobasefn(OPT_GET("Path/Automation/Base")->GetString());
 
 		for (auto& script : GetScripts()) {
 			if (!scripts_string.empty())
@@ -445,7 +445,7 @@ namespace Automation4 {
 		Factories().emplace_back(std::move(factory));
 	}
 
-	std::unique_ptr<Script> ScriptFactory::CreateFromFile(std::filesystem::path const& filename, bool complain_about_unrecognised, bool create_unknown)
+	std::unique_ptr<Script> ScriptFactory::CreateFromFile(agi::fs::path const& filename, bool complain_about_unrecognised, bool create_unknown)
 	{
 		for (auto& factory : Factories()) {
 			auto s = factory->Produce(filename);

--- a/src/auto4_base.h
+++ b/src/auto4_base.h
@@ -33,9 +33,9 @@
 
 #include <libaegisub/background_runner.h>
 #include <libaegisub/exception.h>
+#include <libaegisub/fs.h>
 #include <libaegisub/signal.h>
 
-#include <filesystem>
 #include <memory>
 #include <vector>
 
@@ -135,13 +135,13 @@ namespace Automation4 {
 	};
 
 	class Script {
-		std::filesystem::path filename;
+		agi::fs::path filename;
 
 	protected:
 		/// The automation include path, consisting of the user-specified paths
 		/// along with the script's path
-		std::vector<std::filesystem::path> include_path;
-		Script(std::filesystem::path const& filename);
+		std::vector<agi::fs::path> include_path;
+		Script(agi::fs::path const& filename);
 
 	public:
 		virtual ~Script() = default;
@@ -150,9 +150,9 @@ namespace Automation4 {
 		virtual void Reload() = 0;
 
 		/// The script's file name with path
-		std::filesystem::path GetFilename() const { return filename; }
+		agi::fs::path GetFilename() const { return filename; }
 		/// The script's file name without path
-		std::filesystem::path GetPrettyFilename() const { return filename.filename(); }
+		agi::fs::path GetPrettyFilename() const { return filename.filename(); }
 		/// The script's name. Not required to be unique.
 		virtual std::string GetName() const=0;
 		/// A short description of the script
@@ -234,7 +234,7 @@ namespace Automation4 {
 		///
 		/// This is private as it should only ever be called through
 		/// CreateFromFile
-		virtual std::unique_ptr<Script> Produce(std::filesystem::path const& filename) const = 0;
+		virtual std::unique_ptr<Script> Produce(agi::fs::path const& filename) const = 0;
 
 		static std::vector<std::unique_ptr<ScriptFactory>>& Factories();
 
@@ -259,7 +259,7 @@ namespace Automation4 {
 		/// @param filename Script to load
 		/// @param complain_about_unrecognised Should an error be displayed for files that aren't automation scripts?
 		/// @param create_unknown Create a placeholder rather than returning nullptr if no script engine supports the file
-		static std::unique_ptr<Script> CreateFromFile(std::filesystem::path const& filename, bool complain_about_unrecognised, bool create_unknown=true);
+		static std::unique_ptr<Script> CreateFromFile(agi::fs::path const& filename, bool complain_about_unrecognised, bool create_unknown=true);
 
 		static const std::vector<std::unique_ptr<ScriptFactory>>& GetFactories();
 	};
@@ -268,7 +268,7 @@ namespace Automation4 {
 	/// automation engines
 	class UnknownScript final : public Script {
 	public:
-		UnknownScript(std::filesystem::path const& filename) : Script(filename) { }
+		UnknownScript(agi::fs::path const& filename) : Script(filename) { }
 
 		void Reload() override { }
 

--- a/src/auto4_lua.cpp
+++ b/src/auto4_lua.cpp
@@ -387,7 +387,7 @@ namespace {
 		static int LuaInclude(lua_State *L);
 
 	public:
-		LuaScript(std::filesystem::path const& filename);
+		LuaScript(agi::fs::path const& filename);
 		~LuaScript() { Destroy(); }
 
 		void RegisterCommand(LuaCommand *command);
@@ -409,7 +409,7 @@ namespace {
 		std::vector<ExportFilter*> GetFilters() const override;
 	};
 
-	LuaScript::LuaScript(std::filesystem::path const& filename)
+	LuaScript::LuaScript(agi::fs::path const& filename)
 	: Script(filename)
 	{
 		Create();
@@ -594,7 +594,7 @@ namespace {
 		const LuaScript *s = GetScriptObject(L);
 
 		const std::string filename(check_string(L, 1));
-		std::filesystem::path filepath;
+		agi::fs::path filepath;
 
 		// Relative or absolute path
 		if (!boost::all(filename, !boost::is_any_of("/\\")))
@@ -1039,7 +1039,7 @@ namespace Automation4 {
 	{
 	}
 
-	std::unique_ptr<Script> LuaScriptFactory::Produce(std::filesystem::path const& filename) const
+	std::unique_ptr<Script> LuaScriptFactory::Produce(agi::fs::path const& filename) const
 	{
 		if (agi::fs::HasExtension(filename, "lua") || agi::fs::HasExtension(filename, "moon"))
 			return std::make_unique<LuaScript>(filename);

--- a/src/auto4_lua_factory.h
+++ b/src/auto4_lua_factory.h
@@ -36,7 +36,7 @@
 
 namespace Automation4 {
 	class LuaScriptFactory final : public ScriptFactory {
-		std::unique_ptr<Script> Produce(std::filesystem::path const& filename) const override;
+		std::unique_ptr<Script> Produce(agi::fs::path const& filename) const override;
 	public:
 		LuaScriptFactory();
 	};

--- a/src/charset_detect.cpp
+++ b/src/charset_detect.cpp
@@ -40,7 +40,7 @@
 
 namespace CharSetDetect {
 
-std::string GetEncoding(std::filesystem::path const& filename) {
+std::string GetEncoding(agi::fs::path const& filename) {
 	auto encoding = agi::charset::Detect(filename);
 	if (!encoding.empty())
 		return encoding;

--- a/src/charset_detect.h
+++ b/src/charset_detect.h
@@ -27,12 +27,12 @@
 //
 // Aegisub Project http://www.aegisub.org/
 
-#include <filesystem>
+#include <libaegisub/fs.h>
 #include <string>
 
 namespace CharSetDetect {
 	/// @brief Get character set name.
 	/// @param filename File to check
 	/// @return Character set name
-	std::string GetEncoding(std::filesystem::path const& filename);
+	std::string GetEncoding(agi::fs::path const& filename);
 }

--- a/src/command/subtitle.cpp
+++ b/src/command/subtitle.cpp
@@ -224,7 +224,7 @@ bool is_okay_to_close_subtitles(agi::Context *c) {
 #endif
 }
 
-void load_subtitles(agi::Context *c, std::filesystem::path const& path, std::string const& encoding="") {
+void load_subtitles(agi::Context *c, agi::fs::path const& path, std::string const& encoding="") {
 #ifdef __APPLE__
 	wxGetApp().NewProjectContext().project->LoadSubtitles(path, encoding);
 #else
@@ -341,7 +341,7 @@ struct subtitle_properties final : public Command {
 	}
 };
 
-static void save_subtitles(agi::Context *c, std::filesystem::path filename) {
+static void save_subtitles(agi::Context *c, agi::fs::path filename) {
 	if (filename.empty()) {
 		c->videoController->Stop();
 		filename = SaveFileSelector(_("Save subtitles file"), "Path/Last/Subtitles",

--- a/src/command/video.cpp
+++ b/src/command/video.cpp
@@ -457,7 +457,7 @@ struct video_frame_prev_large final : public validator_video_loaded {
 
 static void save_snapshot(agi::Context *c, bool raw) {
 	auto option = OPT_GET("Path/Screenshot")->GetString();
-	std::filesystem::path basepath;
+	agi::fs::path basepath;
 
 	auto videoname = c->project->VideoName();
 	bool is_dummy = boost::starts_with(videoname.string(), "?dummy");

--- a/src/compat.cpp
+++ b/src/compat.cpp
@@ -9,7 +9,7 @@ wxArrayString lagi_MRU_wxAS(const char *list) {
 	wxArrayString ret;
 	ret.reserve(vec.size());
 	transform(vec.begin(), vec.end(), std::back_inserter(ret),
-		[](std::filesystem::path const& p) { return p.wstring(); });
+		[](agi::fs::path const& p) { return p.wstring(); });
 	return ret;
 }
 

--- a/src/crash_writer.cpp
+++ b/src/crash_writer.cpp
@@ -19,9 +19,9 @@
 #include "version.h"
 
 #include <libaegisub/format.h>
+#include <libaegisub/fs.h>
 #include <libaegisub/util.h>
 
-#include <filesystem>
 #include <fstream>
 #include <wx/string.h>
 #include <wx/stackwalk.h>
@@ -29,7 +29,7 @@
 using namespace agi;
 
 namespace {
-std::filesystem::path crashlog_path;
+agi::fs::path crashlog_path;
 
 #if wxUSE_STACKWALKER == 1
 class StackWalker : public wxStackWalker {
@@ -67,7 +67,7 @@ public:
 }
 
 namespace crash_writer {
-void Initialize(std::filesystem::path const& path) {
+void Initialize(agi::fs::path const& path) {
 	crashlog_path = path / "crashlog.txt";
 }
 

--- a/src/crash_writer.h
+++ b/src/crash_writer.h
@@ -14,11 +14,11 @@
 //
 // Aegisub Project http://www.aegisub.org/
 
-#include <filesystem>
+#include <libaegisub/fs.h>
 #include <string>
 
 namespace crash_writer {
-	void Initialize(std::filesystem::path const& path);
+	void Initialize(agi::fs::path const& path);
 	void Cleanup();
 
 	void Write();

--- a/src/crash_writer_minidump.cpp
+++ b/src/crash_writer_minidump.cpp
@@ -35,7 +35,7 @@ extern EXCEPTION_POINTERS *wxGlobalSEInformation;
 
 namespace {
 wchar_t crash_dump_path[MAX_PATH];
-std::filesystem::path crashlog_path;
+agi::fs::path crashlog_path;
 
 using MiniDumpWriteDump = BOOL(WINAPI *)(
 	HANDLE hProcess,
@@ -101,7 +101,7 @@ std::unique_ptr<dump_thread_state> dump_thread;
 }
 
 namespace crash_writer {
-void Initialize(std::filesystem::path const& path) {
+void Initialize(agi::fs::path const& path) {
 	crashlog_path = path / "crashlog.txt";
 
 	auto dump_path = path / "crashdumps";

--- a/src/dialog_attachments.cpp
+++ b/src/dialog_attachments.cpp
@@ -126,7 +126,7 @@ void DialogAttachments::AttachFile(wxFileDialog &diag, wxString const& commit_ms
 	diag.GetPaths(paths);
 
 	for (auto const& fn : paths)
-		ass->InsertAttachment(std::filesystem::path(fn.wx_str()));
+		ass->InsertAttachment(agi::fs::path(fn.wx_str()));
 
 	ass->Commit(commit_msg, AssFile::COMMIT_ATTACHMENT);
 
@@ -156,7 +156,7 @@ void DialogAttachments::OnExtract(wxCommandEvent &) {
 	long i = listView->GetFirstSelected();
 	if (i == -1) return;
 
-	std::filesystem::path path;
+	agi::fs::path path;
 	bool fullPath = false;
 
 	// Multiple or single?

--- a/src/dialog_automation.cpp
+++ b/src/dialog_automation.cpp
@@ -210,7 +210,7 @@ void DialogAutomation::UpdateDisplay()
 }
 
 template<class Container>
-static bool has_file(Container const& c, std::filesystem::path const& fn)
+static bool has_file(Container const& c, agi::fs::path const& fn)
 {
 	return any_of(c.begin(), c.end(),
 		[&](std::unique_ptr<Automation4::Script> const& s) { return fn == s->GetFilename(); });
@@ -231,7 +231,7 @@ void DialogAutomation::OnAdd(wxCommandEvent &)
 	diag.GetPaths(fnames);
 
 	for (auto const& fname : fnames) {
-		std::filesystem::path fnpath(fname.wx_str());
+		agi::fs::path fnpath(fname.wx_str());
 		OPT_SET("Path/Last/Automation")->SetString(fnpath.parent_path().string());
 
 		if (has_file(local_manager->GetScripts(), fnpath) || has_file(global_manager->GetScripts(), fnpath)) {

--- a/src/dialog_fonts_collector.cpp
+++ b/src/dialog_fonts_collector.cpp
@@ -87,7 +87,7 @@ using color_str_pair = std::pair<int, wxString>;
 wxDEFINE_EVENT(EVT_ADD_TEXT, ValueEvent<color_str_pair>);
 wxDEFINE_EVENT(EVT_COLLECTION_DONE, wxThreadEvent);
 
-void FontsCollectorThread(AssFile *subs, std::filesystem::path const& destination, FcMode oper, wxEvtHandler *collector) {
+void FontsCollectorThread(AssFile *subs, agi::fs::path const& destination, FcMode oper, wxEvtHandler *collector) {
 	agi::dispatch::Background().Async([=]{
 		auto AppendText = [&](wxString text, int colour) {
 			collector->AddPendingEvent(ValueEvent<color_str_pair>(EVT_ADD_TEXT, -1, {colour, text.Clone()}));
@@ -293,7 +293,7 @@ void DialogFontsCollector::OnStart(wxCommandEvent &) {
 	collection_log->ClearAll();
 	collection_log->SetReadOnly(true);
 
-	std::filesystem::path dest_path;
+	agi::fs::path dest_path;
 	if (mode != FcMode::CheckFontsOnly) {
 		auto dest = mode == FcMode::CopyToScriptFolder ? "?script/" : from_wx(dest_ctrl->GetValue());
 		dest_path = path.Decode(dest);

--- a/src/dialog_shift_times.cpp
+++ b/src/dialog_shift_times.cpp
@@ -51,7 +51,7 @@ namespace {
 class DialogShiftTimes final : public wxDialog {
 	agi::Context *context;
 
-	std::filesystem::path history_filename;
+	agi::fs::path history_filename;
 	json::Array history;
 	agi::vfr::Framerate fps;
 	agi::signal::Connection timecodes_loaded_slot;

--- a/src/ffmpegsource_common.cpp
+++ b/src/ffmpegsource_common.cpp
@@ -61,7 +61,7 @@ FFmpegSourceProvider::FFmpegSourceProvider(agi::BackgroundRunner *br)
 /// @param CacheName    The filename of the output index file
 /// @param Trackmask    A binary mask of the track numbers to index
 FFMS_Index *FFmpegSourceProvider::DoIndexing(FFMS_Indexer *Indexer,
-	                                         std::filesystem::path const& CacheName,
+	                                         agi::fs::path const& CacheName,
 	                                         TrackSelection Track,
 	                                         FFMS_IndexErrorHandling IndexEH) {
 	char FFMSErrMsg[1024];
@@ -178,7 +178,7 @@ FFMS_IndexErrorHandling FFmpegSourceProvider::GetErrorHandlingMode() {
 /// @brief	Generates an unique name for the ffms2 index file and prepares the cache folder if it doesn't exist
 /// @param filename	The name of the source file
 /// @return			Returns the generated filename.
-std::filesystem::path FFmpegSourceProvider::GetCacheFilename(std::filesystem::path const& filename) {
+agi::fs::path FFmpegSourceProvider::GetCacheFilename(agi::fs::path const& filename) {
 	// Get the size of the file to be hashed
 	uintmax_t len = agi::fs::Size(filename);
 

--- a/src/ffmpegsource_common.h
+++ b/src/ffmpegsource_common.h
@@ -33,11 +33,11 @@
 ///
 
 #ifdef WITH_FFMS2
-#include <filesystem>
 #include <map>
 
 #include <ffms.h>
 
+#include <libaegisub/fs.h>
 #include <libaegisub/scoped_ptr.h>
 
 namespace agi { class BackgroundRunner; }
@@ -61,12 +61,12 @@ public:
 
 	void CleanCache();
 
-	FFMS_Index *DoIndexing(FFMS_Indexer *Indexer, std::filesystem::path const& Cachename,
+	FFMS_Index *DoIndexing(FFMS_Indexer *Indexer, agi::fs::path const& Cachename,
 		                   TrackSelection Track,
 		                   FFMS_IndexErrorHandling IndexEH);
 	std::map<int, std::string> GetTracksOfType(FFMS_Indexer *Indexer, FFMS_TrackType Type);
 	TrackSelection AskForTrackSelection(const std::map<int, std::string>& TrackList, FFMS_TrackType Type);
-	std::filesystem::path GetCacheFilename(std::filesystem::path const& filename);
+	agi::fs::path GetCacheFilename(agi::fs::path const& filename);
 	void SetLogLevel();
 	FFMS_IndexErrorHandling GetErrorHandlingMode();
 };

--- a/src/font_file_lister.cpp
+++ b/src/font_file_lister.cpp
@@ -204,7 +204,7 @@ void FontCollector::PrintUsage(UsageData const& data) {
 	status_callback("\n", 2);
 }
 
-std::vector<std::filesystem::path> FontCollector::GetFontPaths(const AssFile *file) {
+std::vector<agi::fs::path> FontCollector::GetFontPaths(const AssFile *file) {
 	missing = 0;
 	missing_glyphs = 0;
 
@@ -226,7 +226,7 @@ std::vector<std::filesystem::path> FontCollector::GetFontPaths(const AssFile *fi
 	for (auto const& style : used_styles) ProcessChunk(style);
 	status_callback(_("Done\n\n"), 0);
 
-	std::vector<std::filesystem::path> paths;
+	std::vector<agi::fs::path> paths;
 	paths.reserve(results.size());
 	paths.insert(paths.end(), results.begin(), results.end());
 

--- a/src/font_file_lister.h
+++ b/src/font_file_lister.h
@@ -14,9 +14,9 @@
 //
 // Aegisub Project http://www.aegisub.org/
 
+#include <libaegisub/fs.h>
 #include <libaegisub/scoped_ptr.h>
 
-#include <filesystem>
 #include <functional>
 #include <map>
 #include <string>
@@ -34,14 +34,14 @@ struct CollectionResult {
 	/// Characters which could not be found in any font files
 	wxString missing;
 	/// Paths to the file(s) containing the requested font
-	std::vector<std::filesystem::path> paths;
+	std::vector<agi::fs::path> paths;
 	bool fake_bold = false;
 	bool fake_italic = false;
 };
 
 #ifdef _WIN32
 class GdiFontFileLister {
-	std::unordered_multimap<uint32_t, std::filesystem::path> index;
+	std::unordered_multimap<uint32_t, agi::fs::path> index;
 	agi::scoped_holder<HDC> dc;
 	std::string buffer;
 
@@ -141,7 +141,7 @@ class FontCollector {
 	/// Style name -> ASS style definition
 	std::map<std::string, StyleInfo> styles;
 	/// Paths to found required font files
-	std::vector<std::filesystem::path> results;
+	std::vector<agi::fs::path> results;
 	/// Number of fonts which could not be found
 	int missing = 0;
 	/// Number of fonts which were found, but did not contain all used glyphs
@@ -166,5 +166,5 @@ public:
 	/// @param file Lines in the subtitle file to check
 	/// @param status Callback function for messages
 	/// @return List of paths to fonts
-	std::vector<std::filesystem::path> GetFontPaths(const AssFile *file);
+	std::vector<agi::fs::path> GetFontPaths(const AssFile *file);
 };

--- a/src/font_file_lister_gdi.cpp
+++ b/src/font_file_lister_gdi.cpp
@@ -28,7 +28,7 @@
 #include <unicode/utf16.h>
 #include <Usp10.h>
 
-static void read_fonts_from_key(HKEY hkey, std::filesystem::path font_dir, std::vector<std::filesystem::path> &files) {
+static void read_fonts_from_key(HKEY hkey, agi::fs::path font_dir, std::vector<agi::fs::path> &files) {
 	static const auto fonts_key_name = L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts";
 	
 	HKEY key;
@@ -57,7 +57,7 @@ retry:
 		if (ret == ERROR_NO_MORE_ITEMS) break;
 		if (ret != ERROR_SUCCESS) continue;
 
-		std::filesystem::path font_path(font_filename);
+		agi::fs::path font_path(font_filename);
 		if (!agi::fs::FileExists(font_path))
 			// Doesn't make a ton of sense to do this with user fonts, but they seem to be stored as full paths anyway
 			font_path = font_dir / font_path;
@@ -102,12 +102,12 @@ uint32_t murmur3(const char *data, uint32_t len) {
 	return hash;
 }
 
-std::vector<std::filesystem::path> get_installed_fonts() {
-	std::vector<std::filesystem::path> files;
+std::vector<agi::fs::path> get_installed_fonts() {
+	std::vector<agi::fs::path> files;
 
 	wchar_t fdir[MAX_PATH];
 	SHGetFolderPathW(NULL, CSIDL_FONTS, NULL, 0, fdir);
-	std::filesystem::path font_dir(fdir);
+	agi::fs::path font_dir(fdir);
 
 	// System fonts
 	read_fonts_from_key(HKEY_LOCAL_MACHINE, font_dir, files);
@@ -118,7 +118,7 @@ std::vector<std::filesystem::path> get_installed_fonts() {
 	return files;
 }
 
-using font_index = std::unordered_multimap<uint32_t, std::filesystem::path>;
+using font_index = std::unordered_multimap<uint32_t, agi::fs::path>;
 
 font_index index_fonts(FontCollectorStatusCallback &cb) {
 	font_index hash_to_path;

--- a/src/frame_main.cpp
+++ b/src/frame_main.cpp
@@ -84,7 +84,7 @@ class AegisubFileDropTarget final : public wxFileDropTarget {
 public:
 	AegisubFileDropTarget(agi::Context *context) : context(context) { }
 	bool OnDropFiles(wxCoord, wxCoord, wxArrayString const& filenames) override {
-		std::vector<std::filesystem::path> files;
+		std::vector<agi::fs::path> files;
 		for (wxString const& fn : filenames)
 			files.push_back(from_wx(fn));
 		agi::dispatch::Main().Async([=, this] { context->project->LoadList(files); });

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -368,7 +368,7 @@ void AegisubApp::CloseAll() {
 void AegisubApp::UnhandledException(bool stackWalk) {
 #if (!defined(_DEBUG) || defined(WITH_EXCEPTIONS)) && (wxUSE_ON_FATAL_EXCEPTION+0)
 	bool any = false;
-	std::filesystem::path path;
+	agi::fs::path path;
 	for (auto& frame : frames) {
 		auto c = frame->context.get();
 		if (!c || !c->ass || !c->subsController) continue;
@@ -451,7 +451,7 @@ void AegisubApp::MacOpenFiles(wxArrayString const& filenames) {
 }
 
 void AegisubApp::OpenFiles(wxArrayStringsAdapter filenames) {
-	std::vector<std::filesystem::path> files;
+	std::vector<agi::fs::path> files;
 	for (size_t i = 0; i < filenames.GetCount(); ++i)
 		files.push_back(from_wx(filenames[i]));
 	if (!files.empty())

--- a/src/mkv_wrap.cpp
+++ b/src/mkv_wrap.cpp
@@ -101,7 +101,7 @@ struct MkvStdIO final : InputStream {
 		return static_cast<MkvStdIO*>(st)->file.size();
 	}
 
-	MkvStdIO(std::filesystem::path const& filename) : file(filename) {
+	MkvStdIO(agi::fs::path const& filename) : file(filename) {
 		read = &MkvStdIO::Read;
 		scan = &MkvStdIO::Scan;
 		getcachesize = [](InputStream *) -> unsigned int { return 16 * 1024 * 1024; };
@@ -197,7 +197,7 @@ static bool read_subtitles(agi::ProgressSink *ps, MatroskaFile *file, MkvStdIO *
 	return true;
 }
 
-void MatroskaWrapper::GetSubtitles(std::filesystem::path const& filename, AssFile *target) {
+void MatroskaWrapper::GetSubtitles(agi::fs::path const& filename, AssFile *target) {
 	MkvStdIO input(filename);
 	char err[2048];
 	agi::scoped_holder<MatroskaFile*, decltype(&mkv_Close)> file(mkv_Open(&input, err, sizeof(err)), mkv_Close);
@@ -288,7 +288,7 @@ void MatroskaWrapper::GetSubtitles(std::filesystem::path const& filename, AssFil
 		throw MatroskaException("Failed to read subtitles");
 }
 
-bool MatroskaWrapper::HasSubtitles(std::filesystem::path const& filename) {
+bool MatroskaWrapper::HasSubtitles(agi::fs::path const& filename) {
 	char err[2048];
 	try {
 		MkvStdIO input(filename);

--- a/src/mkv_wrap.h
+++ b/src/mkv_wrap.h
@@ -15,8 +15,7 @@
 // Aegisub Project http://www.aegisub.org/
 
 #include <libaegisub/exception.h>
-
-#include <filesystem>
+#include <libaegisub/fs.h>
 
 DEFINE_EXCEPTION(MatroskaException, agi::Exception);
 
@@ -25,7 +24,7 @@ class AssFile;
 class MatroskaWrapper {
 public:
 	/// Check if the file is a matroska file with at least one subtitle track
-	static bool HasSubtitles(std::filesystem::path const& filename);
+	static bool HasSubtitles(agi::fs::path const& filename);
 	/// Load subtitles from a matroska file
-	static void GetSubtitles(std::filesystem::path const& filename, AssFile *target);
+	static void GetSubtitles(agi::fs::path const& filename, AssFile *target);
 };

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -89,7 +89,7 @@ void Project::ShowError(std::string const& message) {
 	ShowError(to_wx(message));
 }
 
-void Project::SetPath(std::filesystem::path& var, const char *token, const char *mru, std::filesystem::path const& value) {
+void Project::SetPath(agi::fs::path& var, const char *token, const char *mru, agi::fs::path const& value) {
 	var = value;
 	if (*token)
 		context->path->SetToken(token, value);
@@ -98,7 +98,7 @@ void Project::SetPath(std::filesystem::path& var, const char *token, const char 
 	UpdateRelativePaths();
 }
 
-bool Project::DoLoadSubtitles(std::filesystem::path const& path, std::string encoding, ProjectProperties &properties) {
+bool Project::DoLoadSubtitles(agi::fs::path const& path, std::string encoding, ProjectProperties &properties) {
 	try {
 		if (encoding.empty())
 			encoding = CharSetDetect::GetEncoding(path);
@@ -156,7 +156,7 @@ bool Project::DoLoadSubtitles(std::filesystem::path const& path, std::string enc
 	return true;
 }
 
-void Project::LoadSubtitles(std::filesystem::path path, std::string encoding, bool load_linked) {
+void Project::LoadSubtitles(agi::fs::path path, std::string encoding, bool load_linked) {
 	ProjectProperties properties;
 	if (DoLoadSubtitles(path, encoding, properties) && load_linked)
 		LoadUnloadFiles(properties);
@@ -186,7 +186,7 @@ void Project::LoadUnloadFiles(ProjectProperties properties) {
 		wxString str = _("Do you want to load/unload the associated files?");
 		str += "\n";
 
-		auto append_file = [&](std::filesystem::path const& p, wxString const& unload, wxString const& load) {
+		auto append_file = [&](agi::fs::path const& p, wxString const& unload, wxString const& load) {
 			if (p.empty())
 				str += "\n" + unload;
 			else
@@ -236,7 +236,7 @@ void Project::LoadUnloadFiles(ProjectProperties properties) {
 		DoLoadAudio(video, true);
 }
 
-void Project::DoLoadAudio(std::filesystem::path const& path, bool quiet) {
+void Project::DoLoadAudio(agi::fs::path const& path, bool quiet) {
 	if (!progress)
 		progress = new DialogProgress(context->parent);
 
@@ -272,7 +272,7 @@ void Project::DoLoadAudio(std::filesystem::path const& path, bool quiet) {
 	AnnounceAudioProviderModified(audio_provider.get());
 }
 
-void Project::LoadAudio(std::filesystem::path path) {
+void Project::LoadAudio(agi::fs::path path) {
 	DoLoadAudio(path, false);
 }
 
@@ -282,7 +282,7 @@ void Project::CloseAudio() {
 	SetPath(audio_file, "?audio", "", "");
 }
 
-bool Project::DoLoadVideo(std::filesystem::path const& path) {
+bool Project::DoLoadVideo(agi::fs::path const& path) {
 	if (!progress)
 		progress = new DialogProgress(context->parent);
 
@@ -326,7 +326,7 @@ bool Project::DoLoadVideo(std::filesystem::path const& path) {
 	return true;
 }
 
-void Project::LoadVideo(std::filesystem::path path) {
+void Project::LoadVideo(agi::fs::path path) {
 	if (path.empty()) return;
 	if (!DoLoadVideo(path)) return;
 	if (OPT_GET("Video/Open Audio")->GetBool() && audio_file != video_file && video_provider->HasAudio())
@@ -350,13 +350,13 @@ void Project::CloseVideo() {
 	context->ass->Properties.video_position = 0;
 }
 
-void Project::DoLoadTimecodes(std::filesystem::path const& path) {
+void Project::DoLoadTimecodes(agi::fs::path const& path) {
 	timecodes = agi::vfr::Framerate(path);
 	SetPath(timecodes_file, "", "Timecodes", path);
 	AnnounceTimecodesModified(timecodes);
 }
 
-void Project::LoadTimecodes(std::filesystem::path path) {
+void Project::LoadTimecodes(agi::fs::path path) {
 	try {
 		DoLoadTimecodes(path);
 	}
@@ -376,13 +376,13 @@ void Project::CloseTimecodes() {
 	AnnounceTimecodesModified(timecodes);
 }
 
-void Project::DoLoadKeyframes(std::filesystem::path const& path) {
+void Project::DoLoadKeyframes(agi::fs::path const& path) {
 	keyframes = agi::keyframe::Load(path);
 	SetPath(keyframes_file, "", "Keyframes", path);
 	AnnounceKeyframesModified(keyframes);
 }
 
-void Project::LoadKeyframes(std::filesystem::path path) {
+void Project::LoadKeyframes(agi::fs::path path) {
 	try {
 		DoLoadKeyframes(path);
 	}
@@ -406,7 +406,7 @@ void Project::CloseKeyframes() {
 	AnnounceKeyframesModified(keyframes);
 }
 
-void Project::LoadList(std::vector<std::filesystem::path> const& files) {
+void Project::LoadList(std::vector<agi::fs::path> const& files) {
 	// Keep these lists sorted
 
 	// Video formats
@@ -467,9 +467,9 @@ void Project::LoadList(std::vector<std::filesystem::path> const& files) {
 		});
 	};
 
-	std::filesystem::path audio, video, subs, timecodes, keyframes;
+	agi::fs::path audio, video, subs, timecodes, keyframes;
 	for (auto file : files) {
-		if (file.is_relative()) file = absolute(file);
+		if (file.is_relative()) file = agi::fs::Absolute(file);
 		if (!agi::fs::FileExists(file)) continue;
 
 		auto ext = file.extension().string();

--- a/src/project.h
+++ b/src/project.h
@@ -14,10 +14,10 @@
 //
 // Aegisub Project http://www.aegisub.org/
 
+#include <libaegisub/fs.h>
 #include <libaegisub/signal.h>
 #include <libaegisub/vfr.h>
 
-#include <filesystem>
 #include <memory>
 #include <vector>
 
@@ -34,10 +34,10 @@ class Project {
 	agi::vfr::Framerate timecodes;
 	std::vector<int> keyframes;
 
-	std::filesystem::path audio_file;
-	std::filesystem::path video_file;
-	std::filesystem::path timecodes_file;
-	std::filesystem::path keyframes_file;
+	agi::fs::path audio_file;
+	agi::fs::path video_file;
+	agi::fs::path timecodes_file;
+	agi::fs::path keyframes_file;
 
 	agi::signal::Signal<agi::AudioProvider *> AnnounceAudioProviderModified;
 	agi::signal::Signal<AsyncVideoProvider *> AnnounceVideoProviderModified;
@@ -51,48 +51,48 @@ class Project {
 	void ShowError(wxString const& message);
 	void ShowError(std::string const& message);
 
-	bool DoLoadSubtitles(std::filesystem::path const& path, std::string encoding, ProjectProperties &properties);
-	void DoLoadAudio(std::filesystem::path const& path, bool quiet);
-	bool DoLoadVideo(std::filesystem::path const& path);
-	void DoLoadTimecodes(std::filesystem::path const& path);
-	void DoLoadKeyframes(std::filesystem::path const& path);
+	bool DoLoadSubtitles(agi::fs::path const& path, std::string encoding, ProjectProperties &properties);
+	void DoLoadAudio(agi::fs::path const& path, bool quiet);
+	bool DoLoadVideo(agi::fs::path const& path);
+	void DoLoadTimecodes(agi::fs::path const& path);
+	void DoLoadKeyframes(agi::fs::path const& path);
 
 	void LoadUnloadFiles(ProjectProperties properties);
 	void UpdateRelativePaths();
 	void ReloadAudio();
 	void ReloadVideo();
 
-	void SetPath(std::filesystem::path& var, const char *token, const char *mru, std::filesystem::path const& value);
+	void SetPath(agi::fs::path& var, const char *token, const char *mru, agi::fs::path const& value);
 
 public:
 	Project(agi::Context *context);
 	~Project();
 
-	void LoadSubtitles(std::filesystem::path path, std::string encoding="", bool load_linked=true);
+	void LoadSubtitles(agi::fs::path path, std::string encoding="", bool load_linked=true);
 	void CloseSubtitles();
 	bool CanLoadSubtitlesFromVideo() const { return video_has_subtitles; }
 
-	void LoadAudio(std::filesystem::path path);
+	void LoadAudio(agi::fs::path path);
 	void CloseAudio();
 	agi::AudioProvider *AudioProvider() const { return audio_provider.get(); }
-	std::filesystem::path const& AudioName() const { return audio_file; }
+	agi::fs::path const& AudioName() const { return audio_file; }
 
-	void LoadVideo(std::filesystem::path path);
+	void LoadVideo(agi::fs::path path);
 	void CloseVideo();
 	AsyncVideoProvider *VideoProvider() const { return video_provider.get(); }
-	std::filesystem::path const& VideoName() const { return video_file; }
+	agi::fs::path const& VideoName() const { return video_file; }
 
-	void LoadTimecodes(std::filesystem::path path);
+	void LoadTimecodes(agi::fs::path path);
 	void CloseTimecodes();
 	bool CanCloseTimecodes() const { return !timecodes_file.empty(); }
 	agi::vfr::Framerate const& Timecodes() const { return timecodes; }
 
-	void LoadKeyframes(std::filesystem::path path);
+	void LoadKeyframes(agi::fs::path path);
 	void CloseKeyframes();
 	bool CanCloseKeyframes() const { return !keyframes_file.empty(); }
 	std::vector<int> const& Keyframes() const { return keyframes; }
 
-	void LoadList(std::vector<std::filesystem::path> const& files);
+	void LoadList(std::vector<agi::fs::path> const& files);
 
 	DEFINE_SIGNAL_ADDERS(AnnounceAudioProviderModified, AddAudioProviderListener)
 	DEFINE_SIGNAL_ADDERS(AnnounceVideoProviderModified, AddVideoProviderListener)

--- a/src/spellchecker_hunspell.cpp
+++ b/src/spellchecker_hunspell.cpp
@@ -166,8 +166,8 @@ std::vector<std::string> HunspellSpellChecker::GetLanguageList() {
 	return languages;
 }
 
-static bool check_path(std::filesystem::path const& path, std::string_view language,
-	                   std::filesystem::path& aff, std::filesystem::path& dic) {
+static bool check_path(agi::fs::path const& path, std::string_view language,
+	                   agi::fs::path& aff, agi::fs::path& dic) {
 	aff = path/agi::format("%s.aff", language);
 	dic = path/agi::format("%s.dic", language);
 	return agi::fs::FileExists(aff) && agi::fs::FileExists(dic);
@@ -179,7 +179,7 @@ void HunspellSpellChecker::OnLanguageChanged() {
 	auto language = OPT_GET("Tool/Spell Checker/Language")->GetString();
 	if (language.empty()) return;
 
-	std::filesystem::path aff, dic;
+	agi::fs::path aff, dic;
 	auto path = config::path->Decode(OPT_GET("Path/Dictionary")->GetString() + "/");
 	if (!check_path(path, language, aff, dic)) {
 		path = config::path->Decode("?dictionary/");

--- a/src/spellchecker_hunspell.h
+++ b/src/spellchecker_hunspell.h
@@ -22,9 +22,9 @@
 #ifdef WITH_HUNSPELL
 #include <libaegisub/spellchecker.h>
 
+#include <libaegisub/fs.h>
 #include <libaegisub/signal.h>
 
-#include <filesystem>
 #include <memory>
 #include <set>
 
@@ -44,7 +44,7 @@ class HunspellSpellChecker final : public agi::SpellChecker {
 	std::vector<std::string> languages;
 
 	/// Path to user-local dictionary.
-	std::filesystem::path userDicPath;
+	agi::fs::path userDicPath;
 
 	/// Words in the custom user dictionary
 	std::set<std::string, std::less<>> customWords;

--- a/src/subs_controller.cpp
+++ b/src/subs_controller.cpp
@@ -165,7 +165,7 @@ void SubsController::SetSelectionController(SelectionController *selection_contr
 	selection_connection = context->selectionController->AddSelectionListener(&SubsController::OnSelectionChanged, this);
 }
 
-ProjectProperties SubsController::Load(std::filesystem::path const& filename, const char *charset) {
+ProjectProperties SubsController::Load(agi::fs::path const& filename, const char *charset) {
 	AssFile temp;
 
 	SubtitleFormat::GetReader(filename, charset)->ReadFile(&temp, filename, context->project->Timecodes(), charset);
@@ -184,7 +184,7 @@ ProjectProperties SubsController::Load(std::filesystem::path const& filename, co
 	// Save backup of file
 	if (CanSave() && OPT_GET("App/Auto/Backup")->GetBool()) {
 		auto path_str = OPT_GET("Path/Auto/Backup")->GetString();
-		std::filesystem::path path;
+		agi::fs::path path;
 		if (path_str.empty())
 			path = filename.parent_path();
 		else
@@ -197,7 +197,7 @@ ProjectProperties SubsController::Load(std::filesystem::path const& filename, co
 	return props;
 }
 
-void SubsController::Save(std::filesystem::path const& filename, const char *encoding) {
+void SubsController::Save(agi::fs::path const& filename, const char *encoding) {
 	const SubtitleFormat *writer = SubtitleFormat::GetWriter(filename);
 	if (!writer)
 		throw agi::InvalidInputException("Unknown file type.");
@@ -300,7 +300,7 @@ bool SubsController::CanSave() const {
 	}
 }
 
-void SubsController::SetFileName(std::filesystem::path const& path) {
+void SubsController::SetFileName(agi::fs::path const& path) {
 	filename = path;
 	context->path->SetToken("?script", path.parent_path());
 	config::mru->Add("Subtitle", path);
@@ -396,13 +396,13 @@ wxString SubsController::GetRedoDescription() const {
 	return IsRedoStackEmpty() ? wxString() : redo_stack.back().undo_description;
 }
 
-std::filesystem::path SubsController::Filename() const {
+agi::fs::path SubsController::Filename() const {
 	if (!filename.empty()) return filename;
 
 	// Apple HIG says "untitled" should not be capitalised
 #ifndef __WXMAC__
-	return _("Untitled").wx_str();
+	return from_wx(_("Untitled"));
 #else
-	return _("untitled").wx_str();
+	return from_wx(_("untitled"));
 #endif
 }

--- a/src/subs_controller.h
+++ b/src/subs_controller.h
@@ -14,10 +14,10 @@
 //
 // Aegisub Project http://www.aegisub.org/
 
+#include <libaegisub/fs.h>
 #include <libaegisub/signal.h>
 
 #include <boost/container/list.hpp>
-#include <filesystem>
 #include <wx/timer.h>
 
 class SelectionController;
@@ -59,15 +59,15 @@ class SubsController {
 	std::unique_ptr<agi::dispatch::Queue> autosave_queue;
 
 	/// A new file has been opened (filename)
-	agi::signal::Signal<std::filesystem::path> FileOpen;
+	agi::signal::Signal<agi::fs::path> FileOpen;
 	/// The file has been saved
 	agi::signal::Signal<> FileSave;
 
 	/// The filename of the currently open file, if any
-	std::filesystem::path filename;
+	agi::fs::path filename;
 
 	/// Set the filename, updating things like the MRU and last used path
-	void SetFileName(std::filesystem::path const& file);
+	void SetFileName(agi::fs::path const& file);
 
 	/// Autosave the file if there have been any chances since the last autosave
 	void AutoSave();
@@ -88,7 +88,7 @@ public:
 	void SetSelectionController(SelectionController *selection_controller);
 
 	/// The file's path and filename if any, or platform-appropriate "untitled"
-	std::filesystem::path Filename() const;
+	agi::fs::path Filename() const;
 
 	/// Does the file have unsaved changes?
 	bool IsModified() const { return commit_id != saved_commit_id; };
@@ -96,12 +96,12 @@ public:
 	/// @brief Load from a file
 	/// @param file File name
 	/// @param charset Character set of file
-	ProjectProperties Load(std::filesystem::path const& file, const char *charset);
+	ProjectProperties Load(agi::fs::path const& file, const char *charset);
 
 	/// @brief Save to a file
 	/// @param file Path to save to
 	/// @param encoding Encoding to use, or empty to let the writer decide (which usually means "App/Save Charset")
-	void Save(std::filesystem::path const& file, const char *encoding="");
+	void Save(agi::fs::path const& file, const char *encoding="");
 
 	/// Close the currently open file (i.e. open a new blank file)
 	void Close();

--- a/src/subtitle_format.cpp
+++ b/src/subtitle_format.cpp
@@ -67,13 +67,13 @@ SubtitleFormat::SubtitleFormat(std::string_view name)
 {
 }
 
-bool SubtitleFormat::CanReadFile(std::filesystem::path const& filename, const char *) const {
+bool SubtitleFormat::CanReadFile(agi::fs::path const& filename, const char *) const {
 	auto wildcards = GetReadWildcards();
 	return agi::util::any_of(wildcards,
 		[&](std::string const& ext) { return agi::fs::HasExtension(filename, ext); });
 }
 
-bool SubtitleFormat::CanWriteFile(std::filesystem::path const& filename) const {
+bool SubtitleFormat::CanWriteFile(agi::fs::path const& filename) const {
 	auto wildcards = GetWriteWildcards();
 	return agi::util::any_of(wildcards,
 		[&](std::string const& ext) { return agi::fs::HasExtension(filename, ext); });
@@ -283,14 +283,14 @@ SubtitleFormat *find_or_throw(Cont &container, Pred pred) {
 	return it->get();
 }
 
-const SubtitleFormat *SubtitleFormat::GetReader(std::filesystem::path const& filename, const char *encoding) {
+const SubtitleFormat *SubtitleFormat::GetReader(agi::fs::path const& filename, const char *encoding) {
 	LoadFormats();
 	return find_or_throw(formats, [&](std::unique_ptr<SubtitleFormat> const& f) {
 		return f->CanReadFile(filename, encoding);
 	});
 }
 
-const SubtitleFormat *SubtitleFormat::GetWriter(std::filesystem::path const& filename) {
+const SubtitleFormat *SubtitleFormat::GetWriter(agi::fs::path const& filename) {
 	LoadFormats();
 	return find_or_throw(formats, [&](std::unique_ptr<SubtitleFormat> const& f) {
 		return f->CanWriteFile(filename);

--- a/src/subtitle_format.h
+++ b/src/subtitle_format.h
@@ -30,8 +30,8 @@
 #pragma once
 
 #include <libaegisub/exception.h>
+#include <libaegisub/fs.h>
 
-#include <filesystem>
 #include <string>
 #include <vector>
 
@@ -80,13 +80,13 @@ public:
 	///
 	/// Default implementation simply checks if the file's extension is in the
 	/// format's wildcard list
-	virtual bool CanReadFile(std::filesystem::path const& filename, const char *encoding) const;
+	virtual bool CanReadFile(agi::fs::path const& filename, const char *encoding) const;
 
 	/// @brief Check if the given file can be written by this format
 	///
 	/// Default implementation simply checks if the file's extension is in the
 	/// format's wildcard list
-	virtual bool CanWriteFile(std::filesystem::path const& filename) const;
+	virtual bool CanWriteFile(agi::fs::path const& filename) const;
 
 	/// @brief Check if the given subtitles can be losslessly written by this format
 	///
@@ -98,20 +98,20 @@ public:
 	/// @param[out] target Destination to read lines into
 	/// @param filename File to load
 	/// @param encoding Encoding to use. May be ignored by the reader.
-	virtual void ReadFile(AssFile *target, std::filesystem::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const { }
+	virtual void ReadFile(AssFile *target, agi::fs::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const { }
 
 	/// Save a subtitle file
 	/// @param src Data to write
 	/// @param filename File to write to
 	/// @param forceEncoding Encoding to use or empty string for default
-	virtual void WriteFile(const AssFile *src, std::filesystem::path const& filename, agi::vfr::Framerate const& fps, const char *encoding="") const { }
+	virtual void WriteFile(const AssFile *src, agi::fs::path const& filename, agi::vfr::Framerate const& fps, const char *encoding="") const { }
 
 	/// Export a subtitle file
 	///
 	/// This is used when saving via Export As..., for subtitle formats which
 	/// want to distinguish between exporting a final version of a script and
 	/// saving a project.
-	virtual void ExportFile(const AssFile *src, std::filesystem::path const& filename, agi::vfr::Framerate const& fps, const char *encoding="") const {
+	virtual void ExportFile(const AssFile *src, agi::fs::path const& filename, agi::vfr::Framerate const& fps, const char *encoding="") const {
 		WriteFile(src, filename, fps, encoding);
 	}
 
@@ -120,9 +120,9 @@ public:
 	static std::string GetWildcards(int mode);
 
 	/// Get a subtitle format that can read the given file or nullptr if none can
-	static const SubtitleFormat *GetReader(std::filesystem::path const& filename, const char *encoding);
+	static const SubtitleFormat *GetReader(agi::fs::path const& filename, const char *encoding);
 	/// Get a subtitle format that can write the given file or nullptr if none can
-	static const SubtitleFormat *GetWriter(std::filesystem::path const& filename);
+	static const SubtitleFormat *GetWriter(agi::fs::path const& filename);
 	/// Initialize subtitle formats
 	static void LoadFormats();
 };

--- a/src/subtitle_format_ass.cpp
+++ b/src/subtitle_format_ass.cpp
@@ -33,7 +33,7 @@
 
 DEFINE_EXCEPTION(AssParseError, SubtitleFormatParseError);
 
-void AssSubtitleFormat::ReadFile(AssFile *target, std::filesystem::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const {
+void AssSubtitleFormat::ReadFile(AssFile *target, agi::fs::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const {
 	int version = !agi::fs::HasExtension(filename, "ssa");
 
 	TextFileReader file(filename, encoding);
@@ -61,7 +61,7 @@ struct Writer {
 	TextFileWriter file;
 	AssEntryGroup group = AssEntryGroup::INFO;
 
-	Writer(std::filesystem::path const& filename, std::string const& encoding)
+	Writer(agi::fs::path const& filename, std::string const& encoding)
 	: file(filename, encoding)
 	{
 		file.WriteLineToFile("[Script Info]");
@@ -151,7 +151,7 @@ struct Writer {
 };
 }
 
-void AssSubtitleFormat::WriteFile(const AssFile *src, std::filesystem::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const {
+void AssSubtitleFormat::WriteFile(const AssFile *src, agi::fs::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const {
 	Writer writer(filename, encoding);
 	writer.Write(src->Info);
 	writer.Write(src->Properties);
@@ -161,7 +161,7 @@ void AssSubtitleFormat::WriteFile(const AssFile *src, std::filesystem::path cons
 	writer.WriteExtradata(src->Extradata);
 }
 
-void AssSubtitleFormat::ExportFile(const AssFile *src, std::filesystem::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const {
+void AssSubtitleFormat::ExportFile(const AssFile *src, agi::fs::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const {
 	Writer writer(filename, encoding);
 	writer.Write(src->Info);
 	writer.Write(src->Styles);

--- a/src/subtitle_format_ass.h
+++ b/src/subtitle_format_ass.h
@@ -26,9 +26,9 @@ public:
 	// Naturally the ASS subtitle format can save all ASS files
 	bool CanSave(const AssFile*) const override { return true; }
 
-	void ReadFile(AssFile *target, std::filesystem::path const& filename, agi::vfr::Framerate const& fps, const char *forceEncoding) const override;
-	void WriteFile(const AssFile *src, std::filesystem::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const override;
+	void ReadFile(AssFile *target, agi::fs::path const& filename, agi::vfr::Framerate const& fps, const char *forceEncoding) const override;
+	void WriteFile(const AssFile *src, agi::fs::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const override;
 
 	// Does not write [Aegisub Project Garbage] and [Aegisub Extradata] sections when exporting
-	void ExportFile(const AssFile *src, std::filesystem::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const override;
+	void ExportFile(const AssFile *src, agi::fs::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const override;
 };

--- a/src/subtitle_format_ebu3264.cpp
+++ b/src/subtitle_format_ebu3264.cpp
@@ -622,7 +622,7 @@ Ebu3264SubtitleFormat::Ebu3264SubtitleFormat()
 {
 }
 
-void Ebu3264SubtitleFormat::WriteFile(const AssFile *src, std::filesystem::path const& filename, agi::vfr::Framerate const& fps, const char *) const
+void Ebu3264SubtitleFormat::WriteFile(const AssFile *src, agi::fs::path const& filename, agi::vfr::Framerate const& fps, const char *) const
 {
 	// collect data from user
 	EbuExportSettings export_settings = get_export_config(nullptr);

--- a/src/subtitle_format_ebu3264.h
+++ b/src/subtitle_format_ebu3264.h
@@ -28,7 +28,7 @@ class Ebu3264SubtitleFormat final : public SubtitleFormat {
 public:
 	Ebu3264SubtitleFormat();
 	std::vector<std::string> GetWriteWildcards() const override { return {"stl"}; }
-	void WriteFile(const AssFile *src, std::filesystem::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const override;
+	void WriteFile(const AssFile *src, agi::fs::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const override;
 
 	DEFINE_EXCEPTION(ConversionFailed, agi::InvalidInputException);
 };

--- a/src/subtitle_format_encore.cpp
+++ b/src/subtitle_format_encore.cpp
@@ -50,7 +50,7 @@ std::vector<std::string> EncoreSubtitleFormat::GetWriteWildcards() const {
 	return {"encore.txt"};
 }
 
-void EncoreSubtitleFormat::WriteFile(const AssFile *src, std::filesystem::path const& filename, agi::vfr::Framerate const& video_fps, const char *) const {
+void EncoreSubtitleFormat::WriteFile(const AssFile *src, agi::fs::path const& filename, agi::vfr::Framerate const& video_fps, const char *) const {
 	agi::vfr::Framerate fps = AskForFPS(false, true, video_fps);
 	if (!fps.IsLoaded()) return;
 

--- a/src/subtitle_format_encore.h
+++ b/src/subtitle_format_encore.h
@@ -38,5 +38,5 @@ class EncoreSubtitleFormat final : public SubtitleFormat {
 public:
 	EncoreSubtitleFormat();
 	std::vector<std::string> GetWriteWildcards() const override;
-	void WriteFile(const AssFile *src, std::filesystem::path const& filename, agi::vfr::Framerate const& fps, const char *) const override;
+	void WriteFile(const AssFile *src, agi::fs::path const& filename, agi::vfr::Framerate const& fps, const char *) const override;
 };

--- a/src/subtitle_format_microdvd.cpp
+++ b/src/subtitle_format_microdvd.cpp
@@ -65,7 +65,7 @@ std::vector<std::string> MicroDVDSubtitleFormat::GetWriteWildcards() const {
 
 static const boost::regex line_regex(R"(^[\{\[]([0-9]+)[\}\]][\{\[]([0-9]+)[\}\]](.*)$)");
 
-bool MicroDVDSubtitleFormat::CanReadFile(std::filesystem::path const& filename, const char *encoding) const {
+bool MicroDVDSubtitleFormat::CanReadFile(agi::fs::path const& filename, const char *encoding) const {
 	// Return false immediately if extension is wrong
 	if (!agi::fs::HasExtension(filename, "sub")) return false;
 
@@ -77,7 +77,7 @@ bool MicroDVDSubtitleFormat::CanReadFile(std::filesystem::path const& filename, 
 	return false;
 }
 
-void MicroDVDSubtitleFormat::ReadFile(AssFile *target, std::filesystem::path const& filename, agi::vfr::Framerate const& vfps, const char *encoding) const {
+void MicroDVDSubtitleFormat::ReadFile(AssFile *target, agi::fs::path const& filename, agi::vfr::Framerate const& vfps, const char *encoding) const {
 	TextFileReader file(filename, encoding);
 
 	target->LoadDefault(false, OPT_GET("Subtitle Format/MicroDVD/Default Style Catalog")->GetString());
@@ -120,7 +120,7 @@ void MicroDVDSubtitleFormat::ReadFile(AssFile *target, std::filesystem::path con
 	}
 }
 
-void MicroDVDSubtitleFormat::WriteFile(const AssFile *src, std::filesystem::path const& filename, agi::vfr::Framerate const& vfps, const char *encoding) const {
+void MicroDVDSubtitleFormat::WriteFile(const AssFile *src, agi::fs::path const& filename, agi::vfr::Framerate const& vfps, const char *encoding) const {
 	agi::vfr::Framerate fps = AskForFPS(true, false, vfps);
 	if (!fps.IsLoaded()) return;
 

--- a/src/subtitle_format_microdvd.h
+++ b/src/subtitle_format_microdvd.h
@@ -41,8 +41,8 @@ public:
 	std::vector<std::string> GetReadWildcards() const override;
 	std::vector<std::string> GetWriteWildcards() const override;
 
-	bool CanReadFile(std::filesystem::path const& filename, const char *encoding) const override;
-	void ReadFile(AssFile *target, std::filesystem::path const& filename, agi::vfr::Framerate const& fps, const char *forceEncoding) const override;
+	bool CanReadFile(agi::fs::path const& filename, const char *encoding) const override;
+	void ReadFile(AssFile *target, agi::fs::path const& filename, agi::vfr::Framerate const& fps, const char *forceEncoding) const override;
 
-	void WriteFile(const AssFile *src, std::filesystem::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const override;
+	void WriteFile(const AssFile *src, agi::fs::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const override;
 };

--- a/src/subtitle_format_mkv.h
+++ b/src/subtitle_format_mkv.h
@@ -38,7 +38,7 @@ public:
 		return {"mkv", "mka", "mks"};
 	}
 
-	void ReadFile(AssFile *target, std::filesystem::path const& filename, agi::vfr::Framerate const&, const char *) const override {
+	void ReadFile(AssFile *target, agi::fs::path const& filename, agi::vfr::Framerate const&, const char *) const override {
 		MatroskaWrapper::GetSubtitles(filename, target);
 	}
 };

--- a/src/subtitle_format_srt.cpp
+++ b/src/subtitle_format_srt.cpp
@@ -305,7 +305,7 @@ enum class ParseState {
 	LAST_WAS_BLANK
 };
 
-void SRTSubtitleFormat::ReadFile(AssFile *target, std::filesystem::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const {
+void SRTSubtitleFormat::ReadFile(AssFile *target, agi::fs::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const {
 	using namespace std;
 
 	TextFileReader file(filename, encoding);
@@ -426,7 +426,7 @@ void SRTSubtitleFormat::ReadFile(AssFile *target, std::filesystem::path const& f
 		line->Text = tag_parser.ToAss(text);
 }
 
-void SRTSubtitleFormat::WriteFile(const AssFile *src, std::filesystem::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const {
+void SRTSubtitleFormat::WriteFile(const AssFile *src, agi::fs::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const {
 	TextFileWriter file(filename, encoding);
 
 	// Convert to SRT

--- a/src/subtitle_format_srt.h
+++ b/src/subtitle_format_srt.h
@@ -45,6 +45,6 @@ public:
 
 	bool CanSave(const AssFile *file) const override;
 
-	void ReadFile(AssFile *target, std::filesystem::path const& filename, agi::vfr::Framerate const& fps, const char *forceEncoding) const override;
-	void WriteFile(const AssFile *src, std::filesystem::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const override;
+	void ReadFile(AssFile *target, agi::fs::path const& filename, agi::vfr::Framerate const& fps, const char *forceEncoding) const override;
+	void WriteFile(const AssFile *src, agi::fs::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const override;
 };

--- a/src/subtitle_format_ssa.cpp
+++ b/src/subtitle_format_ssa.cpp
@@ -42,7 +42,7 @@ std::string strip_newlines(std::string str) {
 }
 }
 
-void SsaSubtitleFormat::WriteFile(const AssFile *src, std::filesystem::path const& filename, agi::vfr::Framerate const&, const char *encoding) const {
+void SsaSubtitleFormat::WriteFile(const AssFile *src, agi::fs::path const& filename, agi::vfr::Framerate const&, const char *encoding) const {
 	TextFileWriter file(filename, encoding);
 
 	file.WriteLineToFile("[Script Info]");

--- a/src/subtitle_format_ssa.h
+++ b/src/subtitle_format_ssa.h
@@ -22,5 +22,5 @@ public:
 	std::vector<std::string> GetWriteWildcards() const override { return {"ssa"}; }
 	/// @todo Not actually true
 	bool CanSave(const AssFile*) const override { return true; }
-	void WriteFile(const AssFile *src, std::filesystem::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const override;
+	void WriteFile(const AssFile *src, agi::fs::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const override;
 };

--- a/src/subtitle_format_transtation.cpp
+++ b/src/subtitle_format_transtation.cpp
@@ -47,7 +47,7 @@ std::vector<std::string> TranStationSubtitleFormat::GetWriteWildcards() const {
 	return {"transtation.txt"};
 }
 
-void TranStationSubtitleFormat::WriteFile(const AssFile *src, std::filesystem::path const& filename, agi::vfr::Framerate const& vfps, const char *encoding) const {
+void TranStationSubtitleFormat::WriteFile(const AssFile *src, agi::fs::path const& filename, agi::vfr::Framerate const& vfps, const char *encoding) const {
 	auto fps = AskForFPS(false, true, vfps);
 	if (!fps.IsLoaded()) return;
 

--- a/src/subtitle_format_transtation.h
+++ b/src/subtitle_format_transtation.h
@@ -38,5 +38,5 @@ class TranStationSubtitleFormat final : public SubtitleFormat {
 public:
 	TranStationSubtitleFormat();
 	std::vector<std::string> GetWriteWildcards() const override;
-	void WriteFile(const AssFile *src, std::filesystem::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const override;
+	void WriteFile(const AssFile *src, agi::fs::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const override;
 };

--- a/src/subtitle_format_ttxt.cpp
+++ b/src/subtitle_format_ttxt.cpp
@@ -58,7 +58,7 @@ std::vector<std::string> TTXTSubtitleFormat::GetWriteWildcards() const {
 	return GetReadWildcards();
 }
 
-void TTXTSubtitleFormat::ReadFile(AssFile *target, std::filesystem::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const {
+void TTXTSubtitleFormat::ReadFile(AssFile *target, agi::fs::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const {
 	target->LoadDefault(false, OPT_GET("Subtitle Format/TTXT/Default Style Catalog")->GetString());
 
 	// Load XML document
@@ -155,7 +155,7 @@ void TTXTSubtitleFormat::ProcessHeader(wxXmlNode *node) const {
 	// TODO
 }
 
-void TTXTSubtitleFormat::WriteFile(const AssFile *src, std::filesystem::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const {
+void TTXTSubtitleFormat::WriteFile(const AssFile *src, agi::fs::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const {
 	// Convert to TTXT
 	AssFile copy(*src);
 	ConvertToTTXT(copy);

--- a/src/subtitle_format_ttxt.h
+++ b/src/subtitle_format_ttxt.h
@@ -51,6 +51,6 @@ public:
 	std::vector<std::string> GetReadWildcards() const override;
 	std::vector<std::string> GetWriteWildcards() const override;
 
-	void ReadFile(AssFile *target, std::filesystem::path const& filename, agi::vfr::Framerate const& fps, const char *forceEncoding) const override;
-	void WriteFile(const AssFile *src, std::filesystem::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const override;
+	void ReadFile(AssFile *target, agi::fs::path const& filename, agi::vfr::Framerate const& fps, const char *forceEncoding) const override;
+	void WriteFile(const AssFile *src, agi::fs::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const override;
 };

--- a/src/subtitle_format_txt.cpp
+++ b/src/subtitle_format_txt.cpp
@@ -58,12 +58,12 @@ std::vector<std::string> TXTSubtitleFormat::GetWriteWildcards() const {
 	return GetReadWildcards();
 }
 
-bool TXTSubtitleFormat::CanWriteFile(std::filesystem::path const& filename) const {
+bool TXTSubtitleFormat::CanWriteFile(agi::fs::path const& filename) const {
 	auto str = filename.string();
 	return boost::iends_with(str, ".txt") && !(boost::iends_with(str, ".encore.txt") || boost::iends_with(str, ".transtation.txt"));
 }
 
-void TXTSubtitleFormat::ReadFile(AssFile *target, std::filesystem::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const {
+void TXTSubtitleFormat::ReadFile(AssFile *target, agi::fs::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const {
 	if (!ShowPlainTextImportDialog()) return;
 
 	TextFileReader file(filename, encoding, false);
@@ -119,7 +119,7 @@ void TXTSubtitleFormat::ReadFile(AssFile *target, std::filesystem::path const& f
 	}
 }
 
-void TXTSubtitleFormat::WriteFile(const AssFile *src, std::filesystem::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const {
+void TXTSubtitleFormat::WriteFile(const AssFile *src, agi::fs::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const {
 	size_t num_actor_names = 0, num_dialogue_lines = 0;
 
 	// Detect number of lines with Actor field filled out

--- a/src/subtitle_format_txt.h
+++ b/src/subtitle_format_txt.h
@@ -43,7 +43,7 @@ public:
 	// TXT format supports so little that it should always require an export
 	bool CanSave(const AssFile*) const override { return false; }
 
-	bool CanWriteFile(std::filesystem::path const& filename) const override;
-	void ReadFile(AssFile *target, std::filesystem::path const& filename, agi::vfr::Framerate const& fps, const char *forceEncoding) const override;
-	void WriteFile(const AssFile *src, std::filesystem::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const override;
+	bool CanWriteFile(agi::fs::path const& filename) const override;
+	void ReadFile(AssFile *target, agi::fs::path const& filename, agi::vfr::Framerate const& fps, const char *forceEncoding) const override;
+	void WriteFile(const AssFile *src, agi::fs::path const& filename, agi::vfr::Framerate const& fps, const char *encoding) const override;
 };

--- a/src/text_file_reader.cpp
+++ b/src/text_file_reader.cpp
@@ -22,7 +22,7 @@
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/interprocess/streams/bufferstream.hpp>
 
-TextFileReader::TextFileReader(std::filesystem::path const& filename, const char *encoding, bool trim)
+TextFileReader::TextFileReader(agi::fs::path const& filename, const char *encoding, bool trim)
 : file(std::make_unique<agi::read_file_mapping>(filename))
 , stream(std::make_unique<boost::interprocess::ibufferstream>(file->read(), file->size()))
 , trim(trim)

--- a/src/text_file_reader.h
+++ b/src/text_file_reader.h
@@ -15,8 +15,8 @@
 // Aegisub Project http://www.aegisub.org/
 
 #include <libaegisub/line_iterator.h>
+#include <libaegisub/fs.h>
 
-#include <filesystem>
 #include <iosfwd>
 #include <memory>
 #include <string>
@@ -36,7 +36,7 @@ public:
 	/// @param filename File to open
 	/// @param enc      Encoding to use, or empty to autodetect
 	/// @param trim     Whether to trim whitespace from lines read
-	TextFileReader(std::filesystem::path const& filename, const char *encoding, bool trim=true);
+	TextFileReader(agi::fs::path const& filename, const char *encoding, bool trim=true);
 	/// @brief Destructor
 	~TextFileReader();
 

--- a/src/text_file_writer.cpp
+++ b/src/text_file_writer.cpp
@@ -23,7 +23,7 @@
 
 #include <boost/algorithm/string/case_conv.hpp>
 
-TextFileWriter::TextFileWriter(std::filesystem::path const& filename, std::string encoding)
+TextFileWriter::TextFileWriter(agi::fs::path const& filename, std::string encoding)
 : file(new agi::io::Save(filename, true))
 {
 	if (encoding.empty())

--- a/src/text_file_writer.h
+++ b/src/text_file_writer.h
@@ -14,7 +14,7 @@
 //
 // Aegisub Project http://www.aegisub.org/
 
-#include <filesystem>
+#include <libaegisub/fs.h>
 #include <memory>
 #include <string>
 
@@ -33,7 +33,7 @@ class TextFileWriter {
 #endif
 
 public:
-	TextFileWriter(std::filesystem::path const& filename, std::string encoding="");
+	TextFileWriter(agi::fs::path const& filename, std::string encoding="");
 	~TextFileWriter();
 
 	void WriteLineToFile(std::string_view line, bool addLineBreak=true);

--- a/src/thesaurus.cpp
+++ b/src/thesaurus.cpp
@@ -74,7 +74,7 @@ std::vector<std::string> Thesaurus::GetLanguageList() const {
 	return languages;
 }
 
-static bool check_path(std::filesystem::path const& path, std::string const& language, std::filesystem::path& idx, std::filesystem::path& dat) {
+static bool check_path(agi::fs::path const& path, std::string const& language, agi::fs::path& idx, agi::fs::path& dat) {
 	idx = path/agi::format("th_%s.idx", language);
 	dat = path/agi::format("th_%s.dat", language);
 	return agi::fs::FileExists(idx) && agi::fs::FileExists(dat);
@@ -86,7 +86,7 @@ void Thesaurus::OnLanguageChanged() {
 	auto language = OPT_GET("Tool/Thesaurus/Language")->GetString();
 	if (language.empty()) return;
 
-	std::filesystem::path idx, dat;
+	agi::fs::path idx, dat;
 
 	auto path = config::path->Decode(OPT_GET("Path/Dictionary")->GetString() + "/");
 	if (!check_path(path, language, idx, dat)) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -154,7 +154,7 @@ void SetClipboard(wxBitmap const& new_data) {
 	}
 }
 
-void CleanCache(std::filesystem::path const& directory, std::string const& file_type, uint64_t max_size, uint64_t max_files) {
+void CleanCache(agi::fs::path const& directory, std::string const& file_type, uint64_t max_size, uint64_t max_files) {
 	static std::unique_ptr<agi::dispatch::Queue> queue;
 	if (!queue)
 		queue = agi::dispatch::Create();
@@ -165,10 +165,10 @@ void CleanCache(std::filesystem::path const& directory, std::string const& file_
 	queue->Async([=]{
 		LOG_D("utils/clean_cache") << "cleaning " << directory/file_type;
 		uint64_t total_size = 0;
-		using cache_item = std::pair<std::filesystem::file_time_type, std::filesystem::path>;
+		using cache_item = std::pair<std::filesystem::file_time_type, agi::fs::path>;
 		std::vector<cache_item> cachefiles;
 		for (auto const& file : agi::fs::DirectoryIterator(directory, file_type)) {
-			std::filesystem::path path = directory/file;
+			agi::fs::path path = directory/file;
 			cachefiles.push_back({agi::fs::ModifiedTime(path), path});
 			total_size += agi::fs::Size(path);
 		}
@@ -243,21 +243,21 @@ wxString FontFace(std::string opt_prefix) {
 	return to_wx(value);
 }
 
-static std::filesystem::path FileSelector(wxString const& message, std::string const& option_name, std::string const& default_filename, std::string const& default_extension, std::string const& wildcard, int flags, wxWindow *parent) {
+static agi::fs::path FileSelector(wxString const& message, std::string const& option_name, std::string const& default_filename, std::string const& default_extension, std::string const& wildcard, int flags, wxWindow *parent) {
 	wxString path;
 	if (!option_name.empty())
 		path = to_wx(OPT_GET(option_name)->GetString());
-	std::filesystem::path filename = wxFileSelector(message, path, to_wx(default_filename), to_wx(default_extension), to_wx(wildcard), flags, parent).wx_str();
+	agi::fs::path filename = from_wx(wxFileSelector(message, path, to_wx(default_filename), to_wx(default_extension), to_wx(wildcard), flags, parent));
 	if (!filename.empty() && !option_name.empty())
 		OPT_SET(option_name)->SetString(filename.parent_path().string());
 	return filename;
 }
 
-std::filesystem::path OpenFileSelector(wxString const& message, std::string const& option_name, std::string const& default_filename, std::string const& default_extension, std::string const& wildcard, wxWindow *parent) {
+agi::fs::path OpenFileSelector(wxString const& message, std::string const& option_name, std::string const& default_filename, std::string const& default_extension, std::string const& wildcard, wxWindow *parent) {
 	return FileSelector(message, option_name, default_filename, default_extension, wildcard, wxFD_OPEN | wxFD_FILE_MUST_EXIST, parent);
 }
 
-std::filesystem::path SaveFileSelector(wxString const& message, std::string const& option_name, std::string const& default_filename, std::string const& default_extension, std::string const& wildcard, wxWindow *parent) {
+agi::fs::path SaveFileSelector(wxString const& message, std::string const& option_name, std::string const& default_filename, std::string const& default_extension, std::string const& wildcard, wxWindow *parent) {
 	return FileSelector(message, option_name, default_filename, default_extension, wildcard, wxFD_SAVE | wxFD_OVERWRITE_PROMPT, parent);
 }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -29,8 +29,9 @@
 
 #pragma once
 
+#include <libaegisub/fs.h>
+
 #include <cstdint>
-#include <filesystem>
 #include <string>
 
 #include <wx/bitmap.h>
@@ -74,7 +75,7 @@ bool ForwardMouseWheelEvent(wxWindow *source, wxMouseEvent &evt);
 /// @param file_type Wildcard pattern for files to clean up
 /// @param max_size Maximum size of directory in MB
 /// @param max_files Maximum number of files
-void CleanCache(std::filesystem::path const& directory, std::string const& file_type, uint64_t max_size, uint64_t max_files = -1);
+void CleanCache(agi::fs::path const& directory, std::string const& file_type, uint64_t max_size, uint64_t max_files = -1);
 
 /// @brief Templated abs() function
 template <typename T> T tabs(T x) { return x < 0 ? -x : x; }
@@ -93,8 +94,8 @@ void SetClipboard(wxBitmap const& new_value);
 
 wxString FontFace(std::string opt_prefix);
 
-std::filesystem::path OpenFileSelector(wxString const& message, std::string const& option_name, std::string const& default_filename, std::string const& default_extension, std::string const& wildcard, wxWindow *parent);
-std::filesystem::path SaveFileSelector(wxString const& message, std::string const& option_name, std::string const& default_filename, std::string const& default_extension, std::string const& wildcard, wxWindow *parent);
+agi::fs::path OpenFileSelector(wxString const& message, std::string const& option_name, std::string const& default_filename, std::string const& default_extension, std::string const& wildcard, wxWindow *parent);
+agi::fs::path SaveFileSelector(wxString const& message, std::string const& option_name, std::string const& default_filename, std::string const& default_extension, std::string const& wildcard, wxWindow *parent);
 
 wxString LocalizedLanguageName(wxString const& lang);
 

--- a/src/video_provider_avs.cpp
+++ b/src/video_provider_avs.cpp
@@ -66,11 +66,11 @@ class AvisynthVideoProvider: public VideoProvider {
 	PClip RGB32Video;
 	VideoInfo vi;
 
-	AVSValue Open(std::filesystem::path const& filename);
+	AVSValue Open(agi::fs::path const& filename);
 	void Init(std::string_view matrix);
 
 public:
-	AvisynthVideoProvider(std::filesystem::path const& filename, std::string_view colormatrix);
+	AvisynthVideoProvider(agi::fs::path const& filename, std::string_view colormatrix);
 
 	void GetFrame(int n, VideoFrame &frame) override;
 
@@ -92,7 +92,7 @@ public:
 	bool HasAudio() const override                 { return has_audio; }
 };
 
-AvisynthVideoProvider::AvisynthVideoProvider(std::filesystem::path const& filename, std::string_view colormatrix) {
+AvisynthVideoProvider::AvisynthVideoProvider(agi::fs::path const& filename, std::string_view colormatrix) {
 	agi::acs::CheckFileRead(filename);
 
 	std::lock_guard<std::mutex> lock(avs.GetMutex());
@@ -209,7 +209,7 @@ void AvisynthVideoProvider::Init(std::string_view colormatrix) {
 	fps = (double)vi.fps_numerator / vi.fps_denominator;
 }
 
-AVSValue AvisynthVideoProvider::Open(std::filesystem::path const& filename) {
+AVSValue AvisynthVideoProvider::Open(agi::fs::path const& filename) {
 	IScriptEnvironment *env = avs.GetEnv();
 	char *videoFilename = env->SaveString(agi::fs::ShortName(filename).c_str());
 
@@ -321,7 +321,7 @@ void AvisynthVideoProvider::GetFrame(int n, VideoFrame &out) {
 }
 
 namespace agi { class BackgroundRunner; }
-std::unique_ptr<VideoProvider> CreateAvisynthVideoProvider(std::filesystem::path const& path, std::string_view colormatrix, agi::BackgroundRunner *) {
+std::unique_ptr<VideoProvider> CreateAvisynthVideoProvider(agi::fs::path const& path, std::string_view colormatrix, agi::BackgroundRunner *) {
 	return std::make_unique<AvisynthVideoProvider>(path, colormatrix);
 }
 #endif // HAVE_AVISYNTH

--- a/src/video_provider_dummy.cpp
+++ b/src/video_provider_dummy.cpp
@@ -98,7 +98,7 @@ void DummyVideoProvider::GetFrame(int, VideoFrame &frame) {
 }
 
 namespace agi { class BackgroundRunner; }
-std::unique_ptr<VideoProvider> CreateDummyVideoProvider(std::filesystem::path const& filename, std::string_view, agi::BackgroundRunner *) {
+std::unique_ptr<VideoProvider> CreateDummyVideoProvider(agi::fs::path const& filename, std::string_view, agi::BackgroundRunner *) {
 	if (!boost::starts_with(filename.string(), "?dummy"))
 		return {};
 

--- a/src/video_provider_ffmpegsource.cpp
+++ b/src/video_provider_ffmpegsource.cpp
@@ -83,10 +83,10 @@ class FFmpegSourceVideoProvider final : public VideoProvider, FFmpegSourceProvid
 	FFMS_ErrorInfo ErrInfo;         ///< FFMS error codes/messages
 	bool has_audio = false;
 
-	void LoadVideo(std::filesystem::path const& filename, std::string_view colormatrix);
+	void LoadVideo(agi::fs::path const& filename, std::string_view colormatrix);
 
 public:
-	FFmpegSourceVideoProvider(std::filesystem::path const& filename, std::string_view colormatrix, agi::BackgroundRunner *br);
+	FFmpegSourceVideoProvider(agi::fs::path const& filename, std::string_view colormatrix, agi::BackgroundRunner *br);
 
 	void GetFrame(int n, VideoFrame &out) override;
 
@@ -143,7 +143,7 @@ std::string colormatrix_description(int cs, int cr) {
 	}
 }
 
-FFmpegSourceVideoProvider::FFmpegSourceVideoProvider(std::filesystem::path const& filename, std::string_view colormatrix, agi::BackgroundRunner *br) try
+FFmpegSourceVideoProvider::FFmpegSourceVideoProvider(agi::fs::path const& filename, std::string_view colormatrix, agi::BackgroundRunner *br) try
 : FFmpegSourceProvider(br)
 , VideoSource(nullptr, FFMS_DestroyVideoSource)
 {
@@ -160,7 +160,7 @@ catch (agi::EnvironmentError const& err) {
 	throw VideoOpenError(err.GetMessage());
 }
 
-void FFmpegSourceVideoProvider::LoadVideo(std::filesystem::path const& filename, std::string_view colormatrix) {
+void FFmpegSourceVideoProvider::LoadVideo(agi::fs::path const& filename, std::string_view colormatrix) {
 	FFMS_Indexer *Indexer = FFMS_CreateIndexer(filename.string().c_str(), &ErrInfo);
 	if (!Indexer) {
 		if (ErrInfo.SubType == FFMS_ERROR_FILE_READ)
@@ -374,7 +374,7 @@ void FFmpegSourceVideoProvider::GetFrame(int n, VideoFrame &out) {
 }
 }
 
-std::unique_ptr<VideoProvider> CreateFFmpegSourceVideoProvider(std::filesystem::path const& path, std::string_view colormatrix, agi::BackgroundRunner *br) {
+std::unique_ptr<VideoProvider> CreateFFmpegSourceVideoProvider(agi::fs::path const& path, std::string_view colormatrix, agi::BackgroundRunner *br) {
 	return std::make_unique<FFmpegSourceVideoProvider>(path, colormatrix, br);
 }
 

--- a/src/video_provider_manager.cpp
+++ b/src/video_provider_manager.cpp
@@ -24,17 +24,17 @@
 #include <libaegisub/log.h>
 #include <libaegisub/string.h>
 
-std::unique_ptr<VideoProvider> CreateDummyVideoProvider(std::filesystem::path const&, std::string_view, agi::BackgroundRunner *);
-std::unique_ptr<VideoProvider> CreateYUV4MPEGVideoProvider(std::filesystem::path const&, std::string_view, agi::BackgroundRunner *);
-std::unique_ptr<VideoProvider> CreateFFmpegSourceVideoProvider(std::filesystem::path const&, std::string_view, agi::BackgroundRunner *);
-std::unique_ptr<VideoProvider> CreateAvisynthVideoProvider(std::filesystem::path const&, std::string_view, agi::BackgroundRunner *);
+std::unique_ptr<VideoProvider> CreateDummyVideoProvider(agi::fs::path const&, std::string_view, agi::BackgroundRunner *);
+std::unique_ptr<VideoProvider> CreateYUV4MPEGVideoProvider(agi::fs::path const&, std::string_view, agi::BackgroundRunner *);
+std::unique_ptr<VideoProvider> CreateFFmpegSourceVideoProvider(agi::fs::path const&, std::string_view, agi::BackgroundRunner *);
+std::unique_ptr<VideoProvider> CreateAvisynthVideoProvider(agi::fs::path const&, std::string_view, agi::BackgroundRunner *);
 
 std::unique_ptr<VideoProvider> CreateCacheVideoProvider(std::unique_ptr<VideoProvider>);
 
 namespace {
 	struct factory {
 		const char *name;
-		std::unique_ptr<VideoProvider> (*create)(std::filesystem::path const&, std::string_view, agi::BackgroundRunner *);
+		std::unique_ptr<VideoProvider> (*create)(agi::fs::path const&, std::string_view, agi::BackgroundRunner *);
 		bool hidden;
 	};
 
@@ -54,7 +54,7 @@ std::vector<std::string> VideoProviderFactory::GetClasses() {
 	return ::GetClasses(providers);
 }
 
-std::unique_ptr<VideoProvider> VideoProviderFactory::GetProvider(std::filesystem::path const& filename, std::string_view colormatrix, agi::BackgroundRunner *br) {
+std::unique_ptr<VideoProvider> VideoProviderFactory::GetProvider(agi::fs::path const& filename, std::string_view colormatrix, agi::BackgroundRunner *br) {
 	auto preferred = OPT_GET("Video/Provider")->GetString();
 	auto sorted = GetSorted(providers, preferred);
 

--- a/src/video_provider_manager.h
+++ b/src/video_provider_manager.h
@@ -14,7 +14,7 @@
 //
 // Aegisub Project http://www.aegisub.org/
 
-#include <filesystem>
+#include <libaegisub/fs.h>
 #include <memory>
 #include <string>
 #include <vector>
@@ -24,5 +24,5 @@ namespace agi { class BackgroundRunner; }
 
 struct VideoProviderFactory {
 	static std::vector<std::string> GetClasses();
-	static std::unique_ptr<VideoProvider> GetProvider(std::filesystem::path const& video_file, std::string_view colormatrix, agi::BackgroundRunner *br);
+	static std::unique_ptr<VideoProvider> GetProvider(agi::fs::path const& video_file, std::string_view colormatrix, agi::BackgroundRunner *br);
 };

--- a/src/video_provider_yuv4mpeg.cpp
+++ b/src/video_provider_yuv4mpeg.cpp
@@ -139,7 +139,7 @@ class YUV4MPEGVideoProvider final : public VideoProvider {
 	int IndexFile(uint64_t pos);
 
 public:
-	YUV4MPEGVideoProvider(std::filesystem::path const& filename);
+	YUV4MPEGVideoProvider(agi::fs::path const& filename);
 
 	void GetFrame(int n, VideoFrame &frame) override;
 	void SetColorSpace(std::string const&) override { }
@@ -157,7 +157,7 @@ public:
 
 /// @brief Constructor
 /// @param filename The filename to open
-YUV4MPEGVideoProvider::YUV4MPEGVideoProvider(std::filesystem::path const& filename)
+YUV4MPEGVideoProvider::YUV4MPEGVideoProvider(agi::fs::path const& filename)
 : file(filename)
 {
 	if (file.size() < 10)
@@ -426,6 +426,6 @@ void YUV4MPEGVideoProvider::GetFrame(int n, VideoFrame &frame) {
 }
 
 namespace agi { class BackgroundRunner; }
-std::unique_ptr<VideoProvider> CreateYUV4MPEGVideoProvider(std::filesystem::path const& path, std::string_view, agi::BackgroundRunner *) {
+std::unique_ptr<VideoProvider> CreateYUV4MPEGVideoProvider(agi::fs::path const& path, std::string_view, agi::BackgroundRunner *) {
 	return std::make_unique<YUV4MPEGVideoProvider>(path);
 }

--- a/tests/tests/format.cpp
+++ b/tests/tests/format.cpp
@@ -135,6 +135,6 @@ TEST(lagi_format, wchar_t) {
 }
 
 TEST(lagi_format, path) {
-	EXPECT_EQ("/usr/bin", agi::format("%s", std::filesystem::path("/usr/bin")));
-	EXPECT_EQ(L"/usr/bin", agi::format(L"%s", std::filesystem::path("/usr/bin")));
+	EXPECT_EQ("/usr/bin", agi::format("%s", agi::fs::path("/usr/bin")));
+	EXPECT_EQ(L"/usr/bin", agi::format(L"%s", agi::fs::path("/usr/bin")));
 }

--- a/tests/tests/mru.cpp
+++ b/tests/tests/mru.cpp
@@ -52,6 +52,14 @@ TEST(lagi_mru, add_entry) {
 	EXPECT_STREQ("/path/to/file", mru.Get("Video")->front().string().c_str());
 }
 
+TEST(lagi_mru, add_entry_utf8) {
+	agi::fs::Copy("data/mru_ok.json", "data/mru_tmp");
+	agi::MRUManager mru("data/mru_tmp", default_mru);
+	EXPECT_NO_THROW(mru.Add("Video", "/path/with/accents/é/日本語"));
+	EXPECT_STREQ("/path/with/accents/é/日本語", mru.Get("Video")->front().string().c_str());
+	EXPECT_STREQ(L"/path/with/accents/é/日本語", mru.Get("Video")->front().wstring().c_str());
+}
+
 TEST(lagi_mru, remove_entry) {
 	agi::fs::Copy("data/mru_ok.json", "data/mru_tmp");
 	agi::MRUManager mru("data/mru_tmp", default_mru);

--- a/tests/tests/path.cpp
+++ b/tests/tests/path.cpp
@@ -18,8 +18,6 @@
 
 #include <main.h>
 
-#include <filesystem>
-
 using agi::Path;
 using namespace std::string_view_literals;
 
@@ -43,7 +41,7 @@ TEST(lagi_path, relative_path_clears_token) {
 	EXPECT_NO_THROW(p.SetToken("?video", "relative/path"));
 	EXPECT_STREQ("?video", p.Decode("?video").string().c_str());
 
-	EXPECT_NO_THROW(p.SetToken("?video", std::filesystem::current_path()));
+	EXPECT_NO_THROW(p.SetToken("?video", agi::fs::path(agi::fs::CurrentPath())));
 	EXPECT_STRNE("?video", p.Decode("?video").string().c_str());
 
 	EXPECT_NO_THROW(p.SetToken("?video", "relative/path"));
@@ -53,7 +51,7 @@ TEST(lagi_path, relative_path_clears_token) {
 TEST(lagi_path, empty_path_clears_token) {
 	Path p;
 
-	EXPECT_NO_THROW(p.SetToken("?video", std::filesystem::current_path()));
+	EXPECT_NO_THROW(p.SetToken("?video", agi::fs::CurrentPath()));
 	EXPECT_STRNE("?video", p.Decode("?video").string().c_str());
 
 	EXPECT_NO_THROW(p.SetToken("?video", ""));
@@ -63,12 +61,12 @@ TEST(lagi_path, empty_path_clears_token) {
 TEST(lagi_path, decode_sets_uses_right_slashes) {
 	Path p;
 
-	std::filesystem::path expected = std::filesystem::current_path()/"foo/bar.txt";
+	agi::fs::path expected = agi::fs::CurrentPath()/"foo/bar.txt";
 	expected.make_preferred();
 
-	EXPECT_NO_THROW(p.SetToken("?video", std::filesystem::current_path()));
+	EXPECT_NO_THROW(p.SetToken("?video", agi::fs::CurrentPath()));
 
-	std::filesystem::path decoded;
+	agi::fs::path decoded;
 	ASSERT_NO_THROW(decoded = p.Decode("?video/foo/bar.txt"));
 	EXPECT_STREQ(expected.string().c_str(), decoded.string().c_str());
 }
@@ -76,12 +74,12 @@ TEST(lagi_path, decode_sets_uses_right_slashes) {
 TEST(lagi_path, trailing_slash_on_token_is_optional) {
 	Path p;
 
-	std::filesystem::path expected = std::filesystem::current_path()/"foo.txt";
+	agi::fs::path expected = agi::fs::CurrentPath()/"foo.txt";
 	expected.make_preferred();
 
-	EXPECT_NO_THROW(p.SetToken("?audio", std::filesystem::current_path()));
+	EXPECT_NO_THROW(p.SetToken("?audio", agi::fs::CurrentPath()));
 
-	std::filesystem::path decoded;
+	agi::fs::path decoded;
 	ASSERT_NO_THROW(decoded = p.Decode("?audiofoo.txt"));
 	EXPECT_STREQ(expected.string().c_str(), decoded.string().c_str());
 
@@ -92,11 +90,11 @@ TEST(lagi_path, trailing_slash_on_token_is_optional) {
 TEST(lagi_path, setting_token_to_file_sets_to_parent_directory_instead) {
 	Path p;
 
-	std::filesystem::path file = std::filesystem::absolute("data/file");
+	agi::fs::path file = agi::fs::Absolute("data/file");
 	ASSERT_NO_THROW(p.SetToken("?script", file));
 	EXPECT_STREQ(file.parent_path().string().c_str(), p.Decode("?script").string().c_str());
 
-	file = std::filesystem::absolute("data/dir");
+	file = agi::fs::Absolute("data/dir");
 	ASSERT_NO_THROW(p.SetToken("?script", file));
 	EXPECT_STREQ(file.string().c_str(), p.Decode("?script").string().c_str());
 }
@@ -116,7 +114,7 @@ TEST(lagi_path, valid_token_names) {
 
 #define TEST_PLATFORM_PATH_TOKEN(tok) \
 	do { \
-		std::filesystem::path d; \
+		agi::fs::path d; \
 		ASSERT_NO_THROW(d = p.Decode(tok)); \
 		ASSERT_FALSE(d.empty()); \
 		ASSERT_STRNE(tok, d.string().c_str()); \


### PR DESCRIPTION
See the message for the second commit, also pasted here:

---
On Windows, std::filesystem::path internally stores paths in UTF-16,
but constructing an std::filesystem::path from a string reads that
string in Windows-1252 or some other non-UTF-8 narrow encoding. This
breaks all kinds of code that previously assumed that one could simply
convert between UTF-8 strings, wstrings, and paths freely.

Before the switch from boost::filesystem to std::filesystem, this was
solved by using boost::filesystem::path::imbue to configure
boost::filesystem to always use UTF-8. However, there is no equivalent
function for std::filesystem. It seems that the encoding used can be
controlled to some degree using the C and C++ locales, but changing
these to UTF-8 breaks other things (and global locales are a headache
in general. I won't pull a wm4 here but you probably know what I mean).

So, there does not seem to be any easy solution to this. Aegisub also
isn't the only program to have this problem, see e.g.
https://www.bunkus.org/2021/03/converting-a-c-code-base-from-boostfilesystem-to-stdfilesystem/

As far as I can see, the three options are
- Somehow mess with the global locales until everything magically works.
  This feels risky, might not work on all systems, and could break in
  the future.
- Audit the entire code base and check every single conversion between
  strings and paths (Yeah, no)
- Reinvent the wheel and write a wrapper class that fixes
  std::filesystem::path by forcing all conversions from and to
  std::string to use UTF-8.

So, here we are. It doesn't feel great to have another reinvention of
something that shouldn't be Aegisub's responsibility in the first place,
and we *just* got rid of all the agi::fs wrapper code, but this seems
like the only sane way to be sure that all conversions happen the way we
expect. I guess since agi::fs wraps std::filesystem and not
boost::filesystem this time, it's still better than before.

Incidentally, std::u8string seems to be kind of a meme too. The idea of
being explicit about your string being UTF-8 is great, but how is there
not even a standard function to reinterpret a string as UTF-8 or
vice-versa?? Let alone support in any other string handling or I/O
functions.

The changeset is pretty big, but the main changes are in fs.h/fs.cpp .
The rest is just a few find&replace calls and a handful of manual fixes.

Finally, it should be noted that conversion between
std::filesystem::paths and std::wstrings is broken on gcc <= 11:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95048
This is what currently causes the added lagi_mru.add_entry_utf8 test
to fail on the Ubuntu CI. Clang and newer versions of gcc work, though.

Fixes https://github.com/TypesettingTools/Aegisub/issues/219.