### PR TITLE
Feat: add "yes all" option to overwrite style dialogs

### DIFF
--- a/src/dialog_style_manager.cpp
+++ b/src/dialog_style_manager.cpp
@@ -254,6 +254,38 @@ int get_single_sel(wxListBox *lb) {
 	return n == 1 ? selections[0] : -1;
 }
 
+enum class StyleOverrideFlag :int {
+	No,
+	Yes,
+	YesAll
+};
+
+static StyleOverrideFlag DisplayStyleOverrideDialog(int remainingEntries, wxString styleName, wxString type){
+
+	if (remainingEntries <= 1){
+		int answer = wxMessageBox(
+				fmt_tl("There is already a style with the name \"%s\" in the current %s. Overwrite?", styleName, type),
+				_("Style name collision"),
+				wxYES_NO);
+		return (answer == wxYES) ? StyleOverrideFlag::Yes : StyleOverrideFlag::No;
+	}else{
+		wxMessageDialog *dialog = new wxMessageDialog(NULL, fmt_tl("There is already a style with the name \"%s\" in the current %s. Overwrite?", styleName,type), _("Style name collision"), wxYES_NO| wxCANCEL| wxCENTRE);
+
+		dialog->SetYesNoCancelLabels(dialog->GetYesLabel(), dialog->GetNoLabel(), _("Yes, all"));
+
+		int response = dialog->ShowModal();
+
+		if(response == wxID_YES){
+			return StyleOverrideFlag::Yes;
+		}else if(response == wxID_CANCEL){
+			return StyleOverrideFlag::YesAll;
+		}
+
+		return StyleOverrideFlag::No;
+	}
+}
+
+
 DialogStyleManager::DialogStyleManager(agi::Context *context)
 : wxDialog(context->parent, -1, _("Styles Manager"))
 , c(context)
@@ -501,11 +533,22 @@ void DialogStyleManager::OnCopyToStorage() {
 	int n = CurrentList->GetSelections(selections);
 	wxArrayString copied;
 	copied.reserve(n);
+	bool overwriteAll = false;
+
 	for (int i = 0; i < n; i++) {
 		wxString styleName = CurrentList->GetString(selections[i]);
 
 		if (AssStyle *style = Store.GetStyle(from_wx(styleName))) {
-			if (wxYES == wxMessageBox(fmt_tl("There is already a style with the name \"%s\" in the current storage. Overwrite?", styleName), _("Style name collision"), wxYES_NO)) {
+
+			bool overwriteThis = false;
+			if(!overwriteAll){
+				StyleOverrideFlag overwriteFlag = DisplayStyleOverrideDialog(n-i, styleName, "storage");
+				overwriteThis = overwriteFlag == StyleOverrideFlag::Yes;
+				overwriteAll = overwriteFlag == StyleOverrideFlag::YesAll;
+			}
+
+
+			if(overwriteAll || overwriteThis){
 				*style = *styleMap.at(selections[i]);
 				copied.push_back(styleName);
 			}
@@ -528,11 +571,21 @@ void DialogStyleManager::OnCopyToCurrent() {
 	int n = StorageList->GetSelections(selections);
 	wxArrayString copied;
 	copied.reserve(n);
+	bool overwriteAll = false;
+
 	for (int i = 0; i < n; i++) {
 		wxString styleName = StorageList->GetString(selections[i]);
 
 		if (AssStyle *style = c->ass->GetStyle(from_wx(styleName))) {
-			if (wxYES == wxMessageBox(fmt_tl("There is already a style with the name \"%s\" in the current script. Overwrite?", styleName), _("Style name collision"), wxYES_NO)) {
+
+			bool overwriteThis = false;
+			if(!overwriteAll){
+				StyleOverrideFlag overwriteFlag = DisplayStyleOverrideDialog(n-i, styleName,"script");
+				overwriteThis = overwriteFlag == StyleOverrideFlag::Yes;
+				overwriteAll = overwriteFlag == StyleOverrideFlag::YesAll;
+			}
+
+			if(overwriteAll || overwriteThis){
 				*style = *Store[selections[i]];
 				copied.push_back(styleName);
 			}
@@ -704,18 +757,27 @@ void DialogStyleManager::OnCurrentImport() {
 	int res = GetSelectedChoices(this, selections, _("Choose styles to import:"), _("Import Styles"), to_wx(styles));
 	if (res == -1 || selections.empty()) return;
 	bool modified = false;
+	bool overwriteAll = false;
+	int n = selections.GetCount();
 
 	// Loop through selection
-	for (auto const& sel : selections) {
+	for (int i =0; i < n; ++i) {
+		auto const& sel = selections.at(i);
+		auto const styleName =  styles[sel];
+
 		// Check if there is already a style with that name
 		if (AssStyle *existing = c->ass->GetStyle(styles[sel])) {
-			int answer = wxMessageBox(
-				fmt_tl("There is already a style with the name \"%s\" in the current script. Overwrite?", styles[sel]),
-				_("Style name collision"),
-				wxYES_NO);
-			if (answer == wxYES) {
+
+			bool overwriteThis = false;
+			if(!overwriteAll){
+				StyleOverrideFlag overwriteFlag = DisplayStyleOverrideDialog(n-i, styleName, "script");
+			overwriteThis = overwriteFlag == StyleOverrideFlag::Yes;
+				overwriteAll = overwriteFlag == StyleOverrideFlag::YesAll;
+			}
+
+			if (overwriteAll || overwriteThis) {
 				modified = true;
-				*existing = *temp.GetStyle(styles[sel]);
+				*existing = *temp.GetStyle(styleName);
 			}
 			continue;
 		}


### PR DESCRIPTION
This adds a third option to all style dialogs, that when clicked overwrite all conflicts.

This is really helpful, since sometimes you update styles in sub files, and then you have to click multiple times "Yes", but a "Yes, all" option is present in many programs / dialogs (e.g. file move / copy dialogs) in many ways. 

This PR needs some changes to the translation too, but that are some rather big changes in all `.po` files, and if I run `make_pot.sh` it really scrambles things around, which is really frustrating, since the actual changes are not that visible (it should remove three strings and add 4 new ones). So I'll need help on how to approach that. 😄 

Feel free to leave comments on the feature / the implementation of it 😄 

Here a screenshot of the new Feature (in german, that I already did [here](https://github.com/Totto16/Aegisub/commit/79df80541ea71121607791e2a8ee6e416d93f613)   as this current version crashes locally, for an unrelated reason 😄  ) 
![image](https://github.com/user-attachments/assets/348ed112-47fe-4097-97e8-2a930a1a4ff4)
