### PR TITLE
Fix build without PCH

### DIFF
--- a/libaegisub/ass/uuencode.cpp
+++ b/libaegisub/ass/uuencode.cpp
@@ -17,7 +17,7 @@
 #include <libaegisub/ass/uuencode.h>
 
 #include <algorithm>
-
+#include <cstring>
 // Despite being called uuencoding by ass_specs.doc, the format is actually
 // somewhat different from real uuencoding.  Each 3-byte chunk is split into 4
 // 6-bit pieces, then 33 is added to each piece. Lines are wrapped after 80

--- a/libaegisub/audio/provider_dummy.cpp
+++ b/libaegisub/audio/provider_dummy.cpp
@@ -18,6 +18,7 @@
 
 #include "libaegisub/fs.h"
 
+#include <cstring>
 #include <random>
 
 /*

--- a/libaegisub/common/cajun/reader.cpp
+++ b/libaegisub/common/cajun/reader.cpp
@@ -9,6 +9,7 @@ Author: Terry Caton
 #include "libaegisub/cajun/reader.h"
 
 #include <boost/interprocess/streams/bufferstream.hpp>
+#include <algorithm>
 #include <cassert>
 
 /*

--- a/libaegisub/common/calltip_provider.cpp
+++ b/libaegisub/common/calltip_provider.cpp
@@ -19,7 +19,7 @@
 #include "libaegisub/ass/dialogue_parser.h"
 
 #include <algorithm>
-
+#include <cstring>
 namespace {
 struct proto_lit {
 	const char *name;

--- a/libaegisub/common/mru.cpp
+++ b/libaegisub/common/mru.cpp
@@ -21,7 +21,7 @@
 #include "libaegisub/log.h"
 #include "libaegisub/option.h"
 #include "libaegisub/option_value.h"
-
+#include <algorithm>
 namespace {
 std::string_view mru_names[] = {
 	"Audio",

--- a/libaegisub/common/option.cpp
+++ b/libaegisub/common/option.cpp
@@ -26,6 +26,7 @@
 #include "libaegisub/option_value.h"
 
 #include <boost/interprocess/streams/bufferstream.hpp>
+#include <algorithm>
 #include <cassert>
 #include <memory>
 

--- a/libaegisub/common/thesaurus.cpp
+++ b/libaegisub/common/thesaurus.cpp
@@ -20,6 +20,7 @@
 #include "libaegisub/split.h"
 
 #include <boost/interprocess/streams/bufferstream.hpp>
+#include <algorithm>
 
 namespace agi {
 

--- a/libaegisub/include/libaegisub/lua/ffi.h
+++ b/libaegisub/include/libaegisub/lua/ffi.h
@@ -17,6 +17,7 @@
 #include <libaegisub/type_name.h>
 
 #include <cstdlib>
+#include <cstring>
 #include <lua.hpp>
 
 namespace agi::lua {

--- a/libaegisub/lua/modules/unicode.cpp
+++ b/libaegisub/lua/modules/unicode.cpp
@@ -17,7 +17,7 @@
 #include <libaegisub/lua/ffi.h>
 
 #include <unicode/unistr.h>
-
+#include <cstring>
 namespace {
 char *wrap(void (*fn)(icu::UnicodeString&), const char *str, char **err) {
 	auto ustr = icu::UnicodeString::fromUTF8(str);

--- a/libaegisub/unix/path.cpp
+++ b/libaegisub/unix/path.cpp
@@ -21,6 +21,8 @@
 
 #include <pwd.h>
 
+#include "../acconf.h"
+
 #ifndef __APPLE__
 #include <fstream>
 #include <stdlib.h>

--- a/src/aegisublocale.cpp
+++ b/src/aegisublocale.cpp
@@ -38,6 +38,8 @@
 #include "options.h"
 #include "utils.h"
 
+#include "../acconf.h"
+
 #include <libaegisub/path.h>
 
 #include <algorithm>

--- a/src/audio_timing_dialogue.cpp
+++ b/src/audio_timing_dialogue.cpp
@@ -39,6 +39,8 @@
 #include "selection_controller.h"
 #include "utils.h"
 
+#include <list>
+
 #include <libaegisub/ass/time.h>
 
 #include <boost/range/algorithm.hpp>

--- a/src/base_grid.h
+++ b/src/base_grid.h
@@ -32,6 +32,8 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <wx/brush.h>
+#include <wx/scrolbar.h>
 #include <wx/window.h>
 
 namespace agi {

--- a/src/command/command.h
+++ b/src/command/command.h
@@ -17,6 +17,7 @@
 /// @ingroup command
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/src/frame_main.cpp
+++ b/src/frame_main.cpp
@@ -67,7 +67,7 @@
 #include <wx/sizer.h>
 #include <wx/statline.h>
 #include <wx/sysopt.h>
-
+#include <wx/toolbar.h>
 enum {
 	ID_APP_TIMER_STATUSCLEAR = 12002
 };

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -47,6 +47,7 @@
 
 #include <wx/checkbox.h>
 #include <wx/combobox.h>
+#include <wx/dc.h>
 #include <wx/event.h>
 #include <wx/listctrl.h>
 #include <wx/msgdlg.h>


### PR DESCRIPTION
This fixes the build with PCH disabled on Linux. Here is the `setup` command I used to reproduce the failure.

```
meson setup build -Db_pch=false -Dwerror=false -Dbuildtype=plain -Denable_update_checker=false -Dffms2=enabled -Dsystem_luajit=true -Dalsa=enabled -Dfftw3=enabled -Dopenal=disabled -Dportaudio=disabled -Dlibpulse=enabled -Dhunspell=enabled -Duchardet=enabled  --libdir lib64 --localstatedir /var/lib --prefix /usr --sysconfdir /etc
```

