### PR TITLE
fixed "Aegisub quit unexpectedly." error

### DIFF
--- a/tools/osx-bundle.sh
+++ b/tools/osx-bundle.sh
@@ -104,6 +104,7 @@ mkdir -vp "${PKG_DIR}/Contents/Resources/en.lproj"
 echo
 echo "---- Fixing libraries ----"
 sudo python3 "${SRC_DIR}/tools/osx-fix-libs.py" "${PKG_DIR}/Contents/MacOS/aegisub" || exit $?
+ditto "${BUILD_DIR}/aegisub" "${PKG_DIR}/Contents/MacOS/aegisub" || exit $?
 
 echo
 echo "Done creating \"${PKG_DIR}\""


### PR DESCRIPTION
When creating the bundle on MacOS Sequoia 15.1.1 (M2), the app crash upon execution with the message "Aegisub quit unexpectedly." The report shows:

```
Exception Type:        EXC_BAD_ACCESS (SIGKILL (Code Signature Invalid))
Exception Codes:       UNKNOWN_0x32 at 0x0000000105718000
Exception Codes:       0x0000000000000032, 0x0000000105718000
```

With this commit, the problem is solved.