### PR TITLE
Allow \an in SubRip

### DIFF
--- a/src/subtitle_format_srt.cpp
+++ b/src/subtitle_format_srt.cpp
@@ -464,9 +464,9 @@ bool SRTSubtitleFormat::CanSave(const AssFile *file) const {
 		for (auto ovr : blocks | agi::of_type<AssDialogueBlockOverride>()) {
 			// Verify that all overrides used are supported
 			for (auto const& tag : ovr->Tags) {
-				if (tag.Name.size() != 2)
+				if (tag.Name.size() != 2 && tag.Name != "\\an")
 					return false;
-				if (!strchr("bisu", tag.Name[1]))
+				if (tag.Name.size() == 2 && !strchr("bisu", tag.Name[1]))
 					return false;
 			}
 		}
@@ -489,7 +489,13 @@ std::string SRTSubtitleFormat::ConvertTags(const AssDialogue *diag) const {
 		switch (block->GetType()) {
 		case AssBlockType::OVERRIDE:
 			for (auto const& tag : static_cast<AssDialogueBlockOverride&>(*block).Tags) {
-				if (!tag.IsValid() || tag.Name.size() != 2)
+				if (!tag.IsValid())
+					continue;
+				if (tag.Name == "\\an") {
+					final += agi::format("{%s}", std::string(tag));
+					continue;
+				}
+				if (tag.Name.size() != 2)
 					continue;
 				for (auto& state : tag_states) {
 					if (state.tag != tag.Name[1]) continue;


### PR DESCRIPTION
It seems to be widely supported, for instance FFmpeg has special handling for this tag since 2010.

This allows one to edit and save SubRip files that contain lines with `{\an8}`. I've encountered many such files on [Jimaku](https://jimaku.cc), in particular among those purportedly originating from Netflix.