### PR TITLE
Fix boost download URL

### DIFF
--- a/subprojects/boost.wrap
+++ b/subprojects/boost.wrap
@@ -1,6 +1,6 @@
 [wrap-file]
 directory = boost_1_83_0
-source_url = https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.tar.gz
+source_url = https://archives.boost.io/release/1.83.0/source/boost_1_83_0.tar.gz
 source_filename = boost_1_83_0.tar.gz
 source_hash = c0685b68dd44cc46574cce86c4e17c0f611b15e195be9848dfd0769a0a207628
 patch_directory = boost


### PR DESCRIPTION
They appear to have moved hosts: https://github.com/boostorg/boost/issues/924