### PR TITLE
Support XDG Base directory specification for Linux

### DIFF
--- a/libaegisub/common/path.cpp
+++ b/libaegisub/common/path.cpp
@@ -29,7 +29,8 @@ constexpr std::string_view tokens[] = {
 	"?script",
 	"?temp",
 	"?user",
-	"?video"
+	"?video",
+	"?state"
 };
 
 int find_token(std::string_view str) {
@@ -44,6 +45,7 @@ int find_token(std::string_view str) {
 	case 't' + 'p': idx = 5; break;
 	case 'u' + 'r': idx = 6; break;
 	case 'v' + 'e': idx = 7; break;
+	case 's' + 't': idx = 8; break;
 	default: return -1;
 	}
 	return str.starts_with(tokens[idx]) ? idx : -1;

--- a/libaegisub/common/path.cpp
+++ b/libaegisub/common/path.cpp
@@ -36,16 +36,16 @@ constexpr std::string_view tokens[] = {
 int find_token(std::string_view str) {
 	if (str.size() < 5 || str[0] != '?') return -1;
 	int idx;
-	switch (str[1] + str[4]) {
-	case 'a' + 'i': idx = 0; break;
-	case 'd' + 'a': idx = 1; break;
-	case 'd' + 't': idx = 2; break;
-	case 'l' + 'a': idx = 3; break;
-	case 's' + 'i': idx = 4; break;
-	case 't' + 'p': idx = 5; break;
-	case 'u' + 'r': idx = 6; break;
-	case 'v' + 'e': idx = 7; break;
-	case 's' + 't': idx = 8; break;
+	switch (str[2] + str[4]) {
+	case 'u' + 'i': idx = 0; break;
+	case 'a' + 'a': idx = 1; break;
+	case 'i' + 't': idx = 2; break;
+	case 'o' + 'a': idx = 3; break;
+	case 'c' + 'i': idx = 4; break;
+	case 'e' + 'p': idx = 5; break;
+	case 's' + 'r': idx = 6; break;
+	case 'i' + 'e': idx = 7; break;
+	case 't' + 't': idx = 8; break;
 	default: return -1;
 	}
 	return str.starts_with(tokens[idx]) ? idx : -1;

--- a/libaegisub/include/libaegisub/path.h
+++ b/libaegisub/include/libaegisub/path.h
@@ -22,7 +22,7 @@ namespace agi {
 /// Class for handling everything path-related in Aegisub
 class Path {
 	/// Token -> Path map
-	std::array<fs::path, 8> paths;
+	std::array<fs::path, 9> paths;
 
 	/// Platform-specific code to fill in the default paths, called in the constructor
 	void FillPlatformSpecificPaths();

--- a/libaegisub/windows/path_win.cpp
+++ b/libaegisub/windows/path_win.cpp
@@ -45,6 +45,7 @@ void Path::FillPlatformSpecificPaths() {
 
 	SetToken("?user", WinGetFolderPath(CSIDL_APPDATA)/"Aegisub");
 	SetToken("?local", WinGetFolderPath(CSIDL_LOCAL_APPDATA)/"Aegisub");
+	SetToken("?state", WinGetFolderPath(CSIDL_APPDATA)/"Aegisub");
 
 	std::wstring filename(MAX_PATH + 1, L'\0');
 	while (static_cast<DWORD>(filename.size()) == GetModuleFileNameW(nullptr, &filename[0], filename.size()))

--- a/src/dialog_autosave.cpp
+++ b/src/dialog_autosave.cpp
@@ -92,7 +92,7 @@ DialogAutosave::DialogAutosave(wxWindow *parent)
 	std::map<wxString, AutosaveFile> files_map;
 	Populate(files_map, OPT_GET("Path/Auto/Save")->GetString(), ".AUTOSAVE.ass", "%s");
 	Populate(files_map, OPT_GET("Path/Auto/Backup")->GetString(), ".ORIGINAL.ass", _("%s [ORIGINAL BACKUP]"));
-	Populate(files_map, "?user/recovered", ".ass", _("%s [RECOVERED]"));
+	Populate(files_map, "?state/recovered", ".ass", _("%s [RECOVERED]"));
 
 	for (auto& file : files_map | boost::adaptors::map_values)
 		files.emplace_back(std::move(file));

--- a/src/dialog_shift_times.cpp
+++ b/src/dialog_shift_times.cpp
@@ -133,7 +133,7 @@ static wxString get_history_string(json::Object &obj) {
 DialogShiftTimes::DialogShiftTimes(agi::Context *context)
 : wxDialog(context->parent, -1, _("Shift Times"))
 , context(context)
-, history_filename(config::path->Decode("?user/shift_history.json"))
+, history_filename(config::path->Decode("?state/shift_history.json"))
 , timecodes_loaded_slot(context->project->AddTimecodesListener(&DialogShiftTimes::OnTimecodesLoaded, this))
 , selected_set_changed_slot(context->selectionController->AddSelectionListener(&DialogShiftTimes::OnSelectedSetChanged, this))
 {

--- a/src/libresrc/default_config.json
+++ b/src/libresrc/default_config.json
@@ -285,8 +285,8 @@
 
 	"Path" : {
 		"Auto" : {
-			"Backup" : "?user/autoback",
-			"Save" : "?user/autosave"
+			"Backup" : "?state/autoback",
+			"Save" : "?state/autosave"
 		},
 		"Automation" : {
 			"Autoload" : "?user/automation/autoload/|?data/automation/autoload/",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -154,6 +154,7 @@ bool AegisubApp::OnInit() {
 		// Local config, make ?user mean ?data so all user settings are placed in install dir
 		config::path->SetToken("?user", config::path->Decode("?data"));
 		config::path->SetToken("?local", config::path->Decode("?data"));
+		config::path->SetToken("?state", config::path->Decode("?data"));
 		crash_writer::Initialize(config::path->Decode("?user"));
 	} catch (agi::fs::FileSystemError const&) {
 		// File doesn't exist or we can't read it
@@ -162,7 +163,7 @@ bool AegisubApp::OnInit() {
 #endif
 
 	StartupLog("Create log writer");
-	auto path_log = config::path->Decode("?user/log/");
+	auto path_log = config::path->Decode("?state/log/");
 	agi::fs::CreateDirectory(path_log);
 	agi::log::log->Subscribe(std::make_unique<agi::log::JsonEmitter>(path_log));
 	CleanCache(path_log, "*.json", 10, 100);
@@ -373,7 +374,7 @@ void AegisubApp::UnhandledException(bool stackWalk) {
 		auto c = frame->context.get();
 		if (!c || !c->ass || !c->subsController) continue;
 
-		path = config::path->Decode("?user/recovered");
+		path = config::path->Decode("?state/recovered");
 		agi::fs::CreateDirectory(path);
 
 		auto filename = c->subsController->Filename().stem();


### PR DESCRIPTION
This PR will fix Issue https://github.com/Aegisub/Aegisub/issues/226. Adapted from https://github.com/aria2/aria2/commit/8bc1d37.

The basic idea just is:
- If $HOME/.aegisub exists, then the program will still read/write config/cache/data/state from there;
- If $HOME/.aegisub doesn't exist, then the program will read/write config/cache/data/state from corresponding XDG base Directory.

The original PR is here: https://github.com/wangqr/Aegisub/pull/132