### PR TITLE
Updated copyright year and added 'OK' and '&Apply' strings to aegisub.pot

### DIFF
--- a/po/aegisub.pot
+++ b/po/aegisub.pot
@@ -6312,3 +6312,8 @@ msgstr ""
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code."
 msgstr ""
 
+msgid "OK"
+msgstr ""
+
+msgid "&Apply"
+msgstr ""

--- a/src/dialog_about.cpp
+++ b/src/dialog_about.cpp
@@ -39,6 +39,7 @@
 #include <wx/statline.h>
 #include <wx/stattext.h>
 #include <wx/textctrl.h>
+#include <wx/datetime.h>
 
 void ShowAboutDialog(wxWindow *parent) {
 	wxDialog d(parent, -1, _("About Aegisub"), wxDefaultPosition, wxDefaultSize, wxCAPTION | wxCLOSE_BOX);
@@ -49,7 +50,7 @@ void ShowAboutDialog(wxWindow *parent) {
 
 	// Generate about string
 	wxString aboutString = wxString("Aegisub ") + GetAegisubShortVersionString() + ".\n"
-		"Copyright (c) 2005-2019 Rodrigo Braz Monteiro, Niels Martin Hansen, Thomas Goyne et al.\n\n"
+		"Copyright (c) 2005-" + wxString::Format("%d", wxDateTime::Now().GetYear()) + " Rodrigo Braz Monteiro, Niels Martin Hansen, Thomas Goyne et al.\n\n"
 		"Programmers:\n"
 		"    Alysson Souza e Silva\n"
 		"    Amar Takhar\n"


### PR DESCRIPTION
The copyright notice now dynamically displays the current year instead of a fixed value.

And the strings 'OK' and '&Apply' have been added to aegisub.pot.
![image](https://github.com/user-attachments/assets/a086edaf-1144-4be2-82f2-1a260b5ab094)