### PR TITLE
MatroskaParser: include <alloca.h>

### DIFF
--- a/src/MatroskaParser.c
+++ b/src/MatroskaParser.c
@@ -46,6 +46,8 @@
 #define	inline	  __inline
 
 #include <tchar.h>
+#else
+#include <alloca.h>
 #endif
 
 #ifndef EVCBUG


### PR DESCRIPTION
alloca() isn't otherwise available on my Clang build that defaults to non-GNU C++.