### PR TITLE
Replace `_()` with `wxGetTranslation()` for non-literal strings

### DIFF
--- a/po/make_pot.sh
+++ b/po/make_pot.sh
@@ -16,7 +16,9 @@ maybe_append() {
 
 find ../src ../src/command -name '*.cpp' -o -name '*.h' \
   | xgettext --files-from=- -o - --c++ --sort-by-file \
-             -k_ -kSTR_MENU -kSTR_DISP -kSTR_HELP -kfmt_tl -kfmt_plural:2,3 \
+             -k_ -kSTR_MENU -kSTR_DISP -kSTR_HELP \
+             -kCOMMAND_GROUP:3 -kCOMMAND_GROUP:4 -kCOMMAND_GROUP:5 \
+             -kfmt_tl -kfmt_plural:2,3 \
   | sed 's/SOME DESCRIPTIVE TITLE./Aegisub 3.2/' \
   | sed 's/YEAR/2005-2014/' \
   | sed "s/THE PACKAGE'S COPYRIGHT HOLDER/Rodrigo Braz Monteiro, Niels Martin Hansen, Thomas Goyne et. al./" \

--- a/po/meson.build
+++ b/po/meson.build
@@ -7,8 +7,10 @@ i18n = import('i18n')
 # Until a solution is found, POT updates should continue to use make_pot.sh.
 i18n.gettext('aegisub',
 	         args: [
-	            '-k_', '-kSTR_MENU', '-kSTR_DISP', '-kSTR_HELP', '-kwxT',
-	            '-kfmt_tl', '-kfmt_plural:2,3', '-kwxPLURAL:1,2',
+	            '-k_', '-kSTR_MENU', '-kSTR_DISP', '-kSTR_HELP',
+	            '-kCOMMAND_GROUP:3', '-kCOMMAND_GROUP:4',
+	            '-kCOMMAND_GROUP:5,', '-kwxT', '-kfmt_tl',
+	            '-kfmt_plural:2,3', '-kwxPLURAL:1,2',
 	            '--sort-by-file'
 	         ],
 	         install_dir: localedir)

--- a/src/auto4_lua.cpp
+++ b/src/auto4_lua.cpp
@@ -118,7 +118,7 @@ namespace {
 	int get_translation(lua_State *L)
 	{
 		wxString str(check_wxstring(L, 1));
-		push_value(L, _(str).utf8_str());
+		push_value(L, wxGetTranslation(str).utf8_str());
 		return 1;
 	}
 

--- a/src/command/recent.cpp
+++ b/src/command/recent.cpp
@@ -40,11 +40,11 @@
 namespace {
 	using cmd::Command;
 
-COMMAND_GROUP(recent_audio,     "recent/audio",     _("Recent"), _("Recent"), _("Open recent audio"));
-COMMAND_GROUP(recent_keyframes, "recent/keyframe",  _("Recent"), _("Recent"), _("Open recent keyframes"));
-COMMAND_GROUP(recent_subtitle,  "recent/subtitle",  _("Recent"), _("Recent"), _("Open recent subtitles"));
-COMMAND_GROUP(recent_timecodes, "recent/timecodes", _("Recent"), _("Recent"), _("Open recent timecodes"));
-COMMAND_GROUP(recent_video,     "recent/video",     _("Recent"), _("Recent"), _("Open recent video"));
+COMMAND_GROUP(recent_audio,     "recent/audio",     "Recent", "Recent", "Open recent audio");
+COMMAND_GROUP(recent_keyframes, "recent/keyframe",  "Recent", "Recent", "Open recent keyframes");
+COMMAND_GROUP(recent_subtitle,  "recent/subtitle",  "Recent", "Recent", "Open recent subtitles");
+COMMAND_GROUP(recent_timecodes, "recent/timecodes", "Recent", "Recent", "Open recent timecodes");
+COMMAND_GROUP(recent_video,     "recent/video",     "Recent", "Recent", "Open recent video");
 
 struct recent_audio_entry : public Command {
 	CMD_NAME("recent/audio/")

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -178,7 +178,7 @@ public:
 	}
 
 	int AddCommand(cmd::Command *co, wxMenu *parent, std::string const& text = "") {
-		return AddCommand(co, parent, text.empty() ? co->StrMenu(context) : _(to_wx(text)));
+		return AddCommand(co, parent, text.empty() ? co->StrMenu(context) : wxGetTranslation(to_wx(text)));
 	}
 
 	// because wxString doesn't have a move constructor
@@ -351,7 +351,7 @@ void process_menu_item(wxMenu *parent, agi::Context *c, json::Object const& ele,
 #endif
 
 	if (read_entry(ele, "submenu", &submenu) && read_entry(ele, "text", &text)) {
-		wxString tl_text = _(to_wx(text));
+		wxString tl_text = wxGetTranslation(to_wx(text));
 		parent->AppendSubMenu(build_menu(submenu, c, cm), tl_text);
 #ifdef __WXMAC__
 		if (special == "help")
@@ -522,12 +522,12 @@ namespace menu {
 			read_entry(item, "submenu", &submenu);
 			read_entry(item, "text", &disp);
 			if (!submenu.empty()) {
-				menu->Append(build_menu(submenu, c, &menu->cm), _(to_wx(disp)));
+				menu->Append(build_menu(submenu, c, &menu->cm), wxGetTranslation(to_wx(disp)));
 			}
 			else {
 				read_entry(item, "special", &submenu);
 				if (submenu == "automation")
-					menu->Append(new AutomationMenu(c, &menu->cm), _(to_wx(disp)));
+					menu->Append(new AutomationMenu(c, &menu->cm), wxGetTranslation(to_wx(disp)));
 			}
 		}
 


### PR DESCRIPTION
Building Aegisub against wxWidgets trunk (or 3.3.0) has been failing since https://github.com/wxWidgets/wxWidgets/commit/3dddaeb8f2bb8fcfc07d44331a8a2224e24db34a . The updated [doc](https://github.com/wxWidgets/wxWidgets/blob/6561ca020048de57ec28fec5b27f80b00d445cdd/interface/wx/translation.h#L575-L577) said:
> the `_()` macro is defined to do nearly the same thing as `wxGetTranslation()`, with the exception that the argument to `_()` must be a string literal.

Speaking of https://github.com/TypesettingTools/Aegisub/commit/2417c1f488a7fd282d1cf8e4e8966ce18e873a2e. Before applying the fix, the `COMMAND_GROUP` macro will expanded like this :
![screenshot](https://github.com/user-attachments/assets/ff2bfc0e-de61-4884-8ff4-3749df78b739)
