### PR TITLE
readme: add Quick Links section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
-# Aegisub
+# Aegisub - Advanced Subtitle Editor
+## Quick Links
+[Homepage](https://aegisub.org/)\
+[Binaries](https://aegisub.org/downloads/)\
+[Bug tracker](https://github.com/TypesettingTools/Aegisub/issues)\
+[Discord](https://discord.com/invite/AZaVyPr)\
+IRC: irc://irc.rizon.net/aegisub
+<!-- Markdown only allows HTTP links, so the IRC isn't clickable. -->
 
-For binaries and general information [see the homepage](http://aegisub.org).
-
-The bug tracker can be found at https://github.com/TypesettingTools/Aegisub/issues.
-
-Support is available on [Discord](https://discord.com/invite/AZaVyPr) or [IRC](irc://irc.rizon.net/aegisub).
+Support is available on Discord or IRC.
 
 ## Building Aegisub
 


### PR DESCRIPTION
Most importantly, the IRC link wasn't visible or clickable before because Markdown can only link HTTP, now the link is visible.