### PR TITLE
bump minimum Meson to 0.60.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('Aegisub', ['c', 'cpp'],
         license: 'BSD-3-Clause',
-        meson_version: '>=0.57.0',
+        meson_version: '>=0.60.0',
         default_options: [
             'b_ndebug=if-release',
             'cpp_std=c++20',
@@ -99,16 +99,7 @@ cc = meson.get_compiler('c')
 deps += cc.find_library('m', required: false)
 deps += cc.find_library('dl', required: false)
 
-if meson.version().version_compare('>=0.60.0')
-  iconv_dep = dependency('iconv', fallback: ['iconv', 'libiconv_dep'])
-else
-  iconv_dep = cc.find_library('iconv', required: false)
-  if not (iconv_dep.found() or cc.has_function('iconv_open'))
-      iconv_sp = subproject('iconv') # this really needs to be replaced with a proper port
-      iconv_dep = iconv_sp.get_variable('libiconv_dep')
-  endif
-endif
-deps += iconv_dep
+deps += dependency('iconv', fallback: ['iconv', 'libiconv_dep'])
 
 deps += dependency('libass', version: '>=0.9.7',
                    fallback: ['libass', 'libass_dep'])


### PR DESCRIPTION
Meson 0.60.0 was tagged Oct 24, 2021, 4 years ago. This allows us to delete some code.

A quick look at https://repology.org/project/meson/versions says the following maintained systems have a version of Meson older than 0.60.0:
- AlmaLinux 8
- OpenWRT 21.02
- Debian 11

None of these distro releases are the latest, and only Debian packages Aegisub.