### PR TITLE
Add missing include header 'wx/valtext.h' for wxTextValidator

### DIFF
--- a/src/dialog_dummy_video.cpp
+++ b/src/dialog_dummy_video.cpp
@@ -36,6 +36,7 @@
 #include <wx/string.h>
 #include <wx/textctrl.h>
 #include <wx/valgen.h>
+#include <wx/valtext.h>
 
 namespace {
 struct DialogDummyVideo {


### PR DESCRIPTION
Hello,

This is a trivial fix.

The use of `wxTextValidator` was introduced by upstream commit https://github.com/TypesettingTools/Aegisub/commit/5eb5d1a3391449309c6030c31113082ac80c9945, but w/o the proper include header, i.e. `#include <wx/valtext.h>`.

Error reported on Gentoo GNU/Linux amd64:
```
../aegisub-9999/src/dialog_dummy_video.cpp: In constructor ‘{anonymous}::DialogDummyVideo::DialogDummyVideo(wxWindow*)’: ../aegisub-9999/src/dialog_dummy_video.cpp:120:9: error: ‘wxTextValidator’ was not declared in this scope; did you mean ‘wxValidator’?
  120 |         wxTextValidator fpsVal(wxFILTER_INCLUDE_CHAR_LIST, &fps);
      |         ^~~~~~~~~~~~~~~
      |         wxValidator
../aegisub-9999/src/dialog_dummy_video.cpp:121:9: error: ‘fpsVal’ was not declared in this scope
  121 |         fpsVal.SetCharIncludes("0123456789./");
      |         ^~~~~~
```

References:
 - https://docs.wxwidgets.org/3.2.5/classwx_text_validator.html

Thank you ;)