### PR TITLE
Allow building without PCHs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,25 +43,25 @@ jobs:
             name: Ubuntu 22 Debug,
             os: ubuntu-22.04,
             buildtype: debugoptimized,
-            args: ''
+            args: -Db_pch=false
           }
           - {
             name: Ubuntu 22 Release,
             os: ubuntu-22.04,
             buildtype: release,
-            args: ''
+            args: -Db_pch=false
           }
           - {
             name: Ubuntu 24 Debug,
             os: ubuntu-24.04,
             buildtype: debugoptimized,
-            args: ''
+            args: -Db_pch=false
           }
           - {
             name: Ubuntu 24 Release,
             os: ubuntu-24.04,
             buildtype: release,
-            args: ''
+            args: -Db_pch=false
           }
           - {
             name: macOS Debug,

--- a/libaegisub/ass/uuencode.cpp
+++ b/libaegisub/ass/uuencode.cpp
@@ -17,6 +17,7 @@
 #include <libaegisub/ass/uuencode.h>
 
 #include <algorithm>
+#include <cstring>
 
 // Despite being called uuencoding by ass_specs.doc, the format is actually
 // somewhat different from real uuencoding.  Each 3-byte chunk is split into 4

--- a/libaegisub/audio/provider_dummy.cpp
+++ b/libaegisub/audio/provider_dummy.cpp
@@ -18,6 +18,7 @@
 
 #include "libaegisub/fs.h"
 
+#include <cstring>
 #include <random>
 
 /*

--- a/libaegisub/common/cajun/reader.cpp
+++ b/libaegisub/common/cajun/reader.cpp
@@ -8,6 +8,7 @@ Author: Terry Caton
 
 #include "libaegisub/cajun/reader.h"
 
+#include <algorithm>
 #include <boost/interprocess/streams/bufferstream.hpp>
 #include <cassert>
 

--- a/libaegisub/common/calltip_provider.cpp
+++ b/libaegisub/common/calltip_provider.cpp
@@ -19,6 +19,7 @@
 #include "libaegisub/ass/dialogue_parser.h"
 
 #include <algorithm>
+#include <cstring>
 
 namespace {
 struct proto_lit {

--- a/libaegisub/common/mru.cpp
+++ b/libaegisub/common/mru.cpp
@@ -22,6 +22,8 @@
 #include "libaegisub/option.h"
 #include "libaegisub/option_value.h"
 
+#include <algorithm>
+
 namespace {
 std::string_view mru_names[] = {
 	"Audio",

--- a/libaegisub/common/option.cpp
+++ b/libaegisub/common/option.cpp
@@ -25,6 +25,7 @@
 #include "libaegisub/log.h"
 #include "libaegisub/option_value.h"
 
+#include <algorithm>
 #include <boost/interprocess/streams/bufferstream.hpp>
 #include <cassert>
 #include <memory>

--- a/libaegisub/common/thesaurus.cpp
+++ b/libaegisub/common/thesaurus.cpp
@@ -19,6 +19,7 @@
 #include "libaegisub/line_iterator.h"
 #include "libaegisub/split.h"
 
+#include <algorithm>
 #include <boost/interprocess/streams/bufferstream.hpp>
 
 namespace agi {

--- a/libaegisub/include/libaegisub/lua/ffi.h
+++ b/libaegisub/include/libaegisub/lua/ffi.h
@@ -17,6 +17,7 @@
 #include <libaegisub/type_name.h>
 
 #include <cstdlib>
+#include <cstring>
 #include <lua.hpp>
 
 namespace agi::lua {

--- a/libaegisub/lua/modules/unicode.cpp
+++ b/libaegisub/lua/modules/unicode.cpp
@@ -18,6 +18,8 @@
 
 #include <unicode/unistr.h>
 
+#include <cstring>
+
 namespace {
 char *wrap(void (*fn)(icu::UnicodeString&), const char *str, char **err) {
 	auto ustr = icu::UnicodeString::fromUTF8(str);

--- a/libaegisub/meson.build
+++ b/libaegisub/meson.build
@@ -86,7 +86,9 @@ libaegisub_c_pch = ['include/lagi_pre_c.h']
 
 libaegisub_inc = include_directories('include')
 
-libaegisub = static_library('aegisub', libaegisub_src, acconf,
+libaegisub = static_library('aegisub', libaegisub_src, aegisub_order_dep,
+                            c_args: aegisub_defines,
+                            cpp_args: aegisub_defines,
                             include_directories: [libaegisub_inc, deps_inc],
                             cpp_pch: libaegisub_cpp_pch,
                             c_pch: libaegisub_c_pch,

--- a/meson.build
+++ b/meson.build
@@ -375,7 +375,23 @@ elif cc.has_header_symbol('malloc.h', 'alloca', prefix: '#include <stdlib.h>')
     conf.set('HAVE_MALLOC_H', true)
 endif
 
-acconf = configure_file(output: 'acconf.h', configuration: conf)
+aegisub_order_dep = []
+aegisub_defines = []
+
+if get_option('b_pch')
+    # Write the feature flags into a configure_file to not bloat the compiler args too much
+    aegisub_order_dep += configure_file(output: 'acconf.h', configuration: conf)
+else
+    # Manually pass the feature flags as compiler args
+    foreach key : conf.keys()
+        aegisub_defines += '-D@0@=@1@'.format(key, conf.get(key))
+    endforeach
+
+    if host_machine.system() == 'windows'
+        # This is also part of all the PCHs
+        aegisub_defines += '-DWIN32_LEAN_AND_MEAN'
+    endif
+endif
 
 subdir('automation')
 subdir('libaegisub')
@@ -387,7 +403,9 @@ subdir('tests')
 aegisub_cpp_pch = ['src/include/agi_pre.h']
 aegisub_c_pch = ['src/include/agi_pre_c.h']
 
-aegisub = executable('aegisub', aegisub_src, version_h, acconf, resrc,
+aegisub = executable('aegisub', aegisub_src, version_h, resrc, aegisub_order_dep,
+                     c_args: aegisub_defines,
+                     cpp_args: aegisub_defines,
                      link_with: [libresrc, libaegisub],
                      include_directories: [libaegisub_inc, libresrc_inc, version_inc, deps_inc, include_directories('src')],
                      cpp_pch: aegisub_cpp_pch,

--- a/src/MatroskaParser.c
+++ b/src/MatroskaParser.c
@@ -50,7 +50,6 @@
 #define	EVCBUG
 #endif
 
-#include "acconf.h"
 #include "MatroskaParser.h"
 
 #ifdef HAVE_ALLOCA_H

--- a/src/ass_parser.h
+++ b/src/ass_parser.h
@@ -13,6 +13,7 @@
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #include <memory>
+#include <string>
 
 class AssAttachment;
 class AssFile;

--- a/src/ass_style.cpp
+++ b/src/ass_style.cpp
@@ -40,6 +40,7 @@
 #include <libaegisub/format.h>
 #include <libaegisub/split.h>
 
+#include <algorithm>
 #include <boost/lexical_cast.hpp>
 #include <wx/intl.h>
 

--- a/src/audio_timing_dialogue.cpp
+++ b/src/audio_timing_dialogue.cpp
@@ -39,9 +39,12 @@
 #include "selection_controller.h"
 #include "utils.h"
 
+#include <list>
+
 #include <libaegisub/ass/time.h>
 
 #include <boost/range/algorithm.hpp>
+
 #include <wx/pen.h>
 
 namespace {

--- a/src/base_grid.h
+++ b/src/base_grid.h
@@ -32,6 +32,8 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <wx/brush.h>
+#include <wx/scrolbar.h>
 #include <wx/window.h>
 
 namespace agi {

--- a/src/command/command.h
+++ b/src/command/command.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/src/dialog_colorpicker.cpp
+++ b/src/dialog_colorpicker.cpp
@@ -38,6 +38,7 @@
 
 #include <libaegisub/scoped_ptr.h>
 
+#include <algorithm>
 #include <memory>
 #include <vector>
 

--- a/src/frame_main.cpp
+++ b/src/frame_main.cpp
@@ -67,6 +67,7 @@
 #include <wx/sizer.h>
 #include <wx/statline.h>
 #include <wx/sysopt.h>
+#include <wx/toolbar.h>
 
 enum {
 	ID_APP_TIMER_STATUSCLEAR = 12002

--- a/src/main.h
+++ b/src/main.h
@@ -31,6 +31,8 @@
 
 #include "aegisublocale.h"
 
+#include <vector>
+
 #ifndef wxUSE_EXCEPTIONS
 #error wxWidgets is compiled without exceptions support. Aegisub requires exceptions support in wxWidgets to run safely.
 #endif

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -47,6 +47,7 @@
 
 #include <wx/checkbox.h>
 #include <wx/combobox.h>
+#include <wx/dc.h>
 #include <wx/event.h>
 #include <wx/listctrl.h>
 #include <wx/msgdlg.h>

--- a/src/spline_curve.cpp
+++ b/src/spline_curve.cpp
@@ -35,6 +35,7 @@
 #include "spline_curve.h"
 #include "utils.h"
 
+#include <algorithm>
 #include <limits>
 
 SplineCurve::SplineCurve(Vector2D p1) : p1(p1), type(POINT) { }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -41,6 +41,7 @@
 #ifdef __UNIX__
 #include <unistd.h>
 #endif
+#include <algorithm>
 #include <map>
 #include <unicode/locid.h>
 #include <unicode/unistr.h>

--- a/src/video_frame.h
+++ b/src/video_frame.h
@@ -14,6 +14,7 @@
 //
 // Aegisub Project http://www.aegisub.org/
 
+#include <stddef.h>
 #include <vector>
 
 class wxImage;


### PR DESCRIPTION
PR created to test CI. Commit message below.

----

It seems that Aegisub used to be able to be built without precompiled headers, but this broke with the meson port since there the PCHs are needed to include acconf.h. (On the old build system(s), the feature flags were passed directly as defines to the compiler on Visual Studio, and acconf.h was forcibly included via -include acconf.h with autoconf.)

Some distributions (gentoo in particular) disable PCHs by default for meson due to various bugs, and PCHs can also be quite a headache with language servers (I ended up running an sed one-liner after every configure to replace -include-pch in my compile_commands.json with the respective -include).

Since meson doesn't seem to be able to forcibly include headers for every source file, just pass the config as a set of preprocessor defines.

Disable b_pch on most of the CI lanes to catch missing includes but keep it enabled on one of the Ubuntu lanes just in cases something breaks with PCH enabled.