### PR TITLE
Fix build with update checker disabled

### DIFF
--- a/src/command/app.cpp
+++ b/src/command/app.cpp
@@ -320,7 +320,7 @@ namespace cmd {
 		reg(std::make_unique<app_maximize>());
 		reg(std::make_unique<app_bring_to_front>());
 #endif
-#if WITH_UPDATE_CHECKER != 0
+#if defined(WITH_UPDATE_CHECKER) && WITH_UPDATE_CHECKER != 0
 		reg(std::make_unique<app_updates>());
 #endif
 	}

--- a/src/command/app.cpp
+++ b/src/command/app.cpp
@@ -320,7 +320,7 @@ namespace cmd {
 		reg(std::make_unique<app_maximize>());
 		reg(std::make_unique<app_bring_to_front>());
 #endif
-#ifdef WITH_UPDATE_CHECKER
+#if WITH_UPDATE_CHECKER != 0
 		reg(std::make_unique<app_updates>());
 #endif
 	}

--- a/src/dialog_version_check.cpp
+++ b/src/dialog_version_check.cpp
@@ -27,7 +27,7 @@
 //
 // Aegisub Project http://www.aegisub.org/
 
-#if WITH_UPDATE_CHECKER != 0
+#if defined(WITH_UPDATE_CHECKER) && WITH_UPDATE_CHECKER != 0
 
 #include "compat.h"
 #include "format.h"

--- a/src/dialog_version_check.cpp
+++ b/src/dialog_version_check.cpp
@@ -27,7 +27,7 @@
 //
 // Aegisub Project http://www.aegisub.org/
 
-#ifdef WITH_UPDATE_CHECKER
+#if WITH_UPDATE_CHECKER != 0
 
 #include "compat.h"
 #include "format.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -269,7 +269,7 @@ bool AegisubApp::OnInit() {
 		StartupLog("Possibly perform automatic updates check");
 		if (OPT_GET("App/First Start")->GetBool()) {
 			OPT_SET("App/First Start")->SetBool(false);
-#if WITH_UPDATE_CHECKER != 0
+#if defined(WITH_UPDATE_CHECKER) && WITH_UPDATE_CHECKER != 0
 			int result = wxMessageBox(_("Do you want Aegisub to check for updates whenever it starts? You can still do it manually via the Help menu."),_("Check for updates?"), wxYES_NO | wxCENTER);
 			OPT_SET("App/Auto/Check For Updates")->SetBool(result == wxYES);
 			try {
@@ -281,7 +281,7 @@ bool AegisubApp::OnInit() {
 #endif
 		}
 
-#if WITH_UPDATE_CHECKER != 0
+#if defined(WITH_UPDATE_CHECKER) && WITH_UPDATE_CHECKER != 0
 		PerformVersionCheck(false);
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -269,7 +269,7 @@ bool AegisubApp::OnInit() {
 		StartupLog("Possibly perform automatic updates check");
 		if (OPT_GET("App/First Start")->GetBool()) {
 			OPT_SET("App/First Start")->SetBool(false);
-#ifdef WITH_UPDATE_CHECKER
+#if WITH_UPDATE_CHECKER != 0
 			int result = wxMessageBox(_("Do you want Aegisub to check for updates whenever it starts? You can still do it manually via the Help menu."),_("Check for updates?"), wxYES_NO | wxCENTER);
 			OPT_SET("App/Auto/Check For Updates")->SetBool(result == wxYES);
 			try {
@@ -281,7 +281,7 @@ bool AegisubApp::OnInit() {
 #endif
 		}
 
-#ifdef WITH_UPDATE_CHECKER
+#if WITH_UPDATE_CHECKER != 0
 		PerformVersionCheck(false);
 #endif
 


### PR DESCRIPTION
You can reproduce the issue with
```
meson setup build -Db_pch=false -Dwerror=false -Dbuildtype=plain -Denable_update_checker=false -Dffms2=enabled -Dsystem_luajit=true -Dalsa=enabled -Dfftw3=enabled -Dopenal=disabled -Dportaudio=disabled -Dlibpulse=enabled -Dhunspell=enabled -Duchardet=enabled  --libdir lib64 --localstatedir /var/lib --prefix /usr --sysconfdir /etc
```

Meson defines the DEFINE to `0` but the check assumes it will not be defined if disabled.

I'm not sure how this wasn't hit before, maybe nobody disables the update checker.