### PR TITLE
Make karaskel aware of style change when templating syllables

### DIFF
--- a/automation/include/karaskel-auto4.lua
+++ b/automation/include/karaskel-auto4.lua
@@ -278,13 +278,17 @@ function karaskel.preproc_line_size(meta, styles, line)
 	for s = 0, line.kara.n do
 		local syl = line.kara[s]
 
+		syl.style = cur_style
 		-- Detect any reset style tags
-		local style_reset_name = syl.text:match("%{.*\\%r([^}\\]+)")
+		local _, reset_end, style_reset_name = syl.text:find("%{.*\\%r([^}\\]+)")
 		if style_reset_name and styles[style_reset_name] then
 			cur_style = styles[style_reset_name]
+			-- match does not include final }
+			if reset_end + 1 < #syl.text then
+				syl.style = cur_style
+			end
 		end
 
-		syl.style = cur_style
 		syl.width, syl.height = aegisub.text_extents(syl.style, syl.text_spacestripped)
 		syl.width = syl.width * meta.video_x_correct_factor
 		syl.prespacewidth = aegisub.text_extents(syl.style, syl.prespace) * meta.video_x_correct_factor

--- a/automation/include/karaskel-auto4.lua
+++ b/automation/include/karaskel-auto4.lua
@@ -272,10 +272,19 @@ function karaskel.preproc_line_size(meta, styles, line)
 	line.width, line.height, line.descent, line.extlead = aegisub.text_extents(line.styleref, line.text_stripped)
 	line.width = line.width * meta.video_x_correct_factor
 
+	local cur_style = line.styleref
+
 	-- Calculate syllable sizing
 	for s = 0, line.kara.n do
 		local syl = line.kara[s]
-		syl.style = line.styleref
+
+		-- Detect any reset style tags
+		local style_reset_name = syl.text:match("%{.*\\%r([^}\\]+)")
+		if style_reset_name and styles[style_reset_name] then
+			cur_style = styles[style_reset_name]
+		end
+		
+		syl.style = cur_style
 		syl.width, syl.height = aegisub.text_extents(syl.style, syl.text_spacestripped)
 		syl.width = syl.width * meta.video_x_correct_factor
 		syl.prespacewidth = aegisub.text_extents(syl.style, syl.prespace) * meta.video_x_correct_factor

--- a/automation/include/karaskel-auto4.lua
+++ b/automation/include/karaskel-auto4.lua
@@ -283,7 +283,7 @@ function karaskel.preproc_line_size(meta, styles, line)
 		if style_reset_name and styles[style_reset_name] then
 			cur_style = styles[style_reset_name]
 		end
-		
+
 		syl.style = cur_style
 		syl.width, syl.height = aegisub.text_extents(syl.style, syl.text_spacestripped)
 		syl.width = syl.width * meta.video_x_correct_factor
@@ -302,6 +302,9 @@ function karaskel.preproc_line_size(meta, styles, line)
 		for f = 1, line.furi.n do
 			local furi = line.furi[f]
 			furi.style = line.furistyle
+			if styles[furi.syl.style.name .. "-furigana"] then
+				furi.style = styles[furi.syl.style.name .. "-furigana"]
+			end
 			furi.width, furi.height = aegisub.text_extents(furi.style, furi.text)
 			furi.width = furi.width * meta.video_x_correct_factor
 			furi.prespacewidth = 0


### PR DESCRIPTION
For #312 with current caveat that it works only if the reset style tag is placed after the `\k` (ex: `{\k20\rStyle Name}`.

If the tags are placed in the other order (`\rStyle Name\k20`), then the reset style tag goes into the `syl.text` of the syllable preceding the style change, therefore giving incorrect style to the previous syllable.