### PR TITLE
meson: fully require boost>=1.83.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -106,7 +106,7 @@ deps += dependency('libass', version: '>=0.9.7',
 
 boost_modules = ['chrono', 'thread', 'locale']
 if not get_option('local_boost')
-    boost_dep = dependency('boost', version: '>=1.70.0',
+    boost_dep = dependency('boost', version: '>=1.83.0',
                             modules: boost_modules,
                             required: false,
                             static: get_option('default_library') == 'static')


### PR DESCRIPTION
Fixes #343. 1.83 was already set in the subproject, but >=1.70.0 was allowed, which caused build issues.