### PR TITLE
Workaround build error with clang/libc++ in agi::fs::path

### DIFF
--- a/libaegisub/common/io.cpp
+++ b/libaegisub/common/io.cpp
@@ -27,7 +27,7 @@ using namespace agi::fs;
 std::unique_ptr<std::istream> Open(path const& file, bool binary) {
 	LOG_D("agi/io/open/file") << file;
 
-	auto stream = std::make_unique<std::ifstream>(file, (binary ? std::ios::binary : std::ios::in));
+	auto stream = std::make_unique<std::ifstream>(file.string(), (binary ? std::ios::binary : std::ios::in));
 	if (stream->fail()) {
 		acs::CheckFileRead(file);
 		throw IOFatal("Unknown fatal error occurred opening " + file.string());
@@ -42,7 +42,7 @@ Save::Save(path const& file, bool binary)
 {
 	LOG_D("agi/io/save/file") << file;
 
-	fp = std::make_unique<std::ofstream>(tmp_name, binary ? std::ios::binary : std::ios::out);
+	fp = std::make_unique<std::ofstream>(tmp_name.string(), binary ? std::ios::binary : std::ios::out);
 	if (!fp->good()) {
 		acs::CheckDirWrite(file.parent_path());
 		acs::CheckFileWrite(file);

--- a/libaegisub/common/log.cpp
+++ b/libaegisub/common/log.cpp
@@ -98,7 +98,7 @@ Message::~Message() {
 }
 
 JsonEmitter::JsonEmitter(agi::fs::path const& directory)
-: fp(new std::ofstream(directory/util::strftime("%Y-%m-%d-%H-%M-%S.json")))
+: fp(new std::ofstream((directory/util::strftime("%Y-%m-%d-%H-%M-%S.json")).string()))
 {
 }
 

--- a/src/crash_writer_minidump.cpp
+++ b/src/crash_writer_minidump.cpp
@@ -139,7 +139,7 @@ void Write() {
 }
 
 void Write(std::string const& error) {
-	std::ofstream file(crashlog_path, std::ios::app);
+	std::ofstream file(crashlog_path.string(), std::ios::app);
 	if (file.is_open()) {
 		file << agi::util::strftime("--- %y-%m-%d %H:%M:%S ------------------\n");
 		agi::format(file, "VER - %s\n", GetAegisubLongVersionString());


### PR DESCRIPTION
The `std::basic_fstream` implementation in libc++ does not allow constructing with a derived class of `std::filesystem::path` like `agi::fs::path`. (There is a `is_same_v` constraint.)

Workaround by getting its underly string manually. Fixes building with LLVM based MinGW environments, including Windows on ARM.

This kind of defeat the purpose of `agi::fs::path`, therefore currently sent as draft.