### PR TITLE
Add Support for newer mkv display units

### DIFF
--- a/src/MatroskaParser.c
+++ b/src/MatroskaParser.c
@@ -1169,7 +1169,7 @@ static void parseVideoInfo(MatroskaFile *mf,uint64_t toplen,struct TrackInfo *ti
       break;
     case 0x54b2: // DisplayUnit
       v = readUInt(mf,(unsigned)len);
-      if (v>2)
+      if (v>4)
 	errorjmp(mf,"Invalid DisplayUnit: %d",(int)v);
       ti->AV.Video.DisplayUnit = (unsigned char)v;
       break;


### PR DESCRIPTION
Added support for newer display units
The mkv specification was updated at some point to include two more display units in addition to "0" (pixels), "1" (centimeters) and "2" (inches)
check the new specification here:
https://datatracker.ietf.org/doc/rfc9559/
27.9.  Matroska Display Units Registry
Two other values where added, 3 for display aspect ratio and 4 for unkown
Currently Aegisub is unable to open subtitle from files which have these newer values for display unit.
This pr fixes that issue, but I'm not aware if just increasing the number will cause issues else where, but I did not find any other mention of DisplayUnit in the code base other than MatroskaParser.cpp
