### PR TITLE
Improve non-perspective resampling

### DIFF
--- a/src/ass_override.cpp
+++ b/src/ass_override.cpp
@@ -181,12 +181,12 @@ static void load_protos() {
 	// Longer tag names must appear before shorter tag names
 
 	proto[0].Set("\\alpha", VariableDataType::TEXT, AssParameterClass::ALPHA); // \alpha&H<aa>&
-	proto[++i].Set("\\bord", VariableDataType::FLOAT, AssParameterClass::ABSOLUTE_SIZE); // \bord<depth>
-	proto[++i].Set("\\xbord", VariableDataType::FLOAT, AssParameterClass::ABSOLUTE_SIZE); // \xbord<depth>
-	proto[++i].Set("\\ybord", VariableDataType::FLOAT, AssParameterClass::ABSOLUTE_SIZE); // \ybord<depth>
-	proto[++i].Set("\\shad", VariableDataType::FLOAT, AssParameterClass::ABSOLUTE_SIZE); // \shad<depth>
-	proto[++i].Set("\\xshad", VariableDataType::FLOAT, AssParameterClass::ABSOLUTE_SIZE); // \xshad<depth>
-	proto[++i].Set("\\yshad", VariableDataType::FLOAT, AssParameterClass::ABSOLUTE_SIZE); // \yshad<depth>
+	proto[++i].Set("\\bord", VariableDataType::FLOAT, AssParameterClass::ABSOLUTE_SIZE_XY); // \bord<depth>
+	proto[++i].Set("\\xbord", VariableDataType::FLOAT, AssParameterClass::ABSOLUTE_SIZE_X); // \xbord<depth>
+	proto[++i].Set("\\ybord", VariableDataType::FLOAT, AssParameterClass::ABSOLUTE_SIZE_Y); // \ybord<depth>
+	proto[++i].Set("\\shad", VariableDataType::FLOAT, AssParameterClass::ABSOLUTE_SIZE_XY); // \shad<depth>
+	proto[++i].Set("\\xshad", VariableDataType::FLOAT, AssParameterClass::ABSOLUTE_SIZE_X); // \xshad<depth>
+	proto[++i].Set("\\yshad", VariableDataType::FLOAT, AssParameterClass::ABSOLUTE_SIZE_Y); // \yshad<depth>
 
 	// \fade(<a1>,<a2>,<a3>,<t1>,<t2>,<t3>,<t4>)
 	i++;
@@ -249,17 +249,17 @@ static void load_protos() {
 	// \org(<x>,<y>)
 	i++;
 	proto[i].name = "\\org";
-	proto[i].AddParam(VariableDataType::INT, AssParameterClass::ABSOLUTE_POS_X);
-	proto[i].AddParam(VariableDataType::INT, AssParameterClass::ABSOLUTE_POS_Y);
+	proto[i].AddParam(VariableDataType::FLOAT, AssParameterClass::ABSOLUTE_POS_X);
+	proto[i].AddParam(VariableDataType::FLOAT, AssParameterClass::ABSOLUTE_POS_Y);
 
-	proto[++i].Set("\\pbo", VariableDataType::INT, AssParameterClass::ABSOLUTE_POS_Y); // \pbo<y>
+	proto[++i].Set("\\pbo", VariableDataType::INT, AssParameterClass::ABSOLUTE_SIZE_Y); // \pbo<y>
 	// \fad(<t1>,<t2>)
 	i++;
 	proto[i].name = "\\fad";
 	proto[i].AddParam(VariableDataType::INT, AssParameterClass::RELATIVE_TIME_START);
 	proto[i].AddParam(VariableDataType::INT, AssParameterClass::RELATIVE_TIME_END);
 
-	proto[++i].Set("\\fsp", VariableDataType::FLOAT, AssParameterClass::ABSOLUTE_SIZE); // \fsp<pixels>
+	proto[++i].Set("\\fsp", VariableDataType::FLOAT, AssParameterClass::ABSOLUTE_SIZE_Y); // \fsp<pixels> (affected by \fscx)
 	proto[++i].Set("\\frx", VariableDataType::FLOAT); // \frx<degrees>
 	proto[++i].Set("\\fry", VariableDataType::FLOAT); // \fry<degrees>
 	proto[++i].Set("\\frz", VariableDataType::FLOAT); // \frz<degrees>
@@ -277,12 +277,12 @@ static void load_protos() {
 	proto[++i].Set("\\fe", VariableDataType::TEXT); // \fe<charset>
 	proto[++i].Set("\\ko", VariableDataType::INT, AssParameterClass::KARAOKE); // \ko<duration>
 	proto[++i].Set("\\kf", VariableDataType::INT, AssParameterClass::KARAOKE); // \kf<duration>
-	proto[++i].Set("\\be", VariableDataType::INT, AssParameterClass::ABSOLUTE_SIZE); // \be<strength>
-	proto[++i].Set("\\blur", VariableDataType::FLOAT, AssParameterClass::ABSOLUTE_SIZE); // \blur<strength>
+	proto[++i].Set("\\be", VariableDataType::INT, AssParameterClass::ABSOLUTE_SIZE_XY); // \be<strength>
+	proto[++i].Set("\\blur", VariableDataType::FLOAT, AssParameterClass::ABSOLUTE_SIZE_XY); // \blur<strength>
 	proto[++i].Set("\\fn", VariableDataType::TEXT); // \fn<name>
 	proto[++i].Set("\\fs+", VariableDataType::FLOAT); // \fs+<size>
 	proto[++i].Set("\\fs-", VariableDataType::FLOAT); // \fs-<size>
-	proto[++i].Set("\\fs", VariableDataType::FLOAT, AssParameterClass::ABSOLUTE_SIZE); // \fs<size>
+	proto[++i].Set("\\fs", VariableDataType::FLOAT, AssParameterClass::ABSOLUTE_SIZE_Y); // \fs<size>
 	proto[++i].Set("\\an", VariableDataType::INT); // \an<alignment>
 	proto[++i].Set("\\c", VariableDataType::TEXT, AssParameterClass::COLOR); // \c&H<bbggrr>&
 	proto[++i].Set("\\b", VariableDataType::INT); // \b<0/1/weight>

--- a/src/ass_override.cpp
+++ b/src/ass_override.cpp
@@ -181,10 +181,12 @@ static void load_protos() {
 	// Longer tag names must appear before shorter tag names
 
 	proto[0].Set("\\alpha", VariableDataType::TEXT, AssParameterClass::ALPHA); // \alpha&H<aa>&
-	proto[++i].Set("\\bord", VariableDataType::FLOAT, AssParameterClass::ABSOLUTE_SIZE_XY); // \bord<depth>
+
+	// FIXME: convert \bord and \shad to \xbord\ybord and \xshad\yshad during anamorphic resampling
+	proto[++i].Set("\\bord", VariableDataType::FLOAT, AssParameterClass::ABSOLUTE_SIZE_Y); // \bord<depth>
 	proto[++i].Set("\\xbord", VariableDataType::FLOAT, AssParameterClass::ABSOLUTE_SIZE_X); // \xbord<depth>
 	proto[++i].Set("\\ybord", VariableDataType::FLOAT, AssParameterClass::ABSOLUTE_SIZE_Y); // \ybord<depth>
-	proto[++i].Set("\\shad", VariableDataType::FLOAT, AssParameterClass::ABSOLUTE_SIZE_XY); // \shad<depth>
+	proto[++i].Set("\\shad", VariableDataType::FLOAT, AssParameterClass::ABSOLUTE_SIZE_Y); // \shad<depth>
 	proto[++i].Set("\\xshad", VariableDataType::FLOAT, AssParameterClass::ABSOLUTE_SIZE_X); // \xshad<depth>
 	proto[++i].Set("\\yshad", VariableDataType::FLOAT, AssParameterClass::ABSOLUTE_SIZE_Y); // \yshad<depth>
 

--- a/src/ass_override.h
+++ b/src/ass_override.h
@@ -40,7 +40,9 @@ class AssDialogueBlockOverride;
 /// Type of parameter
 enum class AssParameterClass {
 	NORMAL,
-	ABSOLUTE_SIZE,
+	ABSOLUTE_SIZE_X,
+	ABSOLUTE_SIZE_Y,
+	ABSOLUTE_SIZE_XY,
 	ABSOLUTE_POS_X,
 	ABSOLUTE_POS_Y,
 	RELATIVE_SIZE_X,

--- a/src/resolution_resampler.cpp
+++ b/src/resolution_resampler.cpp
@@ -185,8 +185,8 @@ namespace {
 
 	void resample_style(resample_state *state, AssStyle &style) {
 		style.fontsize = int(style.fontsize * state->ry + 0.5);
-		style.outline_w *= state->rm;
-		style.shadow_w *= state->rm;
+		style.outline_w *= state->ry;
+		style.shadow_w *= state->ry;
 		style.spacing *= state->ry;  // gets multiplied by scalex (and hence by ar) during rendering
 		style.scalex *= state->ar;
 		for (int i = 0; i < 3; i++)

--- a/src/resolution_resampler.cpp
+++ b/src/resolution_resampler.cpp
@@ -75,7 +75,6 @@ namespace {
 					val = (val + shift_x) * scale_x;
 				else
 					val = (val + shift_y) * scale_y;
-				val = round(val * 8) / 8.0; // round to eighth-pixels
 				final += float_to_string(val);
 				final += ' ';
 				is_x = !is_x;

--- a/src/resolution_resampler.cpp
+++ b/src/resolution_resampler.cpp
@@ -98,6 +98,7 @@ namespace {
 		const int *margin;
 		double rx;
 		double ry;
+		double rm;
 		double ar;
 		agi::ycbcr_converter conv;
 		bool convert_colors;
@@ -110,8 +111,16 @@ namespace {
 		int shift = 0;
 
 		switch (cur->classification) {
-			case AssParameterClass::ABSOLUTE_SIZE:
+			case AssParameterClass::ABSOLUTE_SIZE_X:
+				resizer = state->rx;
+				break;
+
+			case AssParameterClass::ABSOLUTE_SIZE_Y:
 				resizer = state->ry;
+				break;
+
+			case AssParameterClass::ABSOLUTE_SIZE_XY:
+				resizer = state->rm;
 				break;
 
 			case AssParameterClass::ABSOLUTE_POS_X:
@@ -176,9 +185,9 @@ namespace {
 
 	void resample_style(resample_state *state, AssStyle &style) {
 		style.fontsize = int(style.fontsize * state->ry + 0.5);
-		style.outline_w *= state->ry;
-		style.shadow_w *= state->ry;
-		style.spacing *= state->rx;
+		style.outline_w *= state->rm;
+		style.shadow_w *= state->rm;
+		style.spacing *= state->ry;  // gets multiplied by scalex (and hence by ar) during rendering
 		style.scalex *= state->ar;
 		for (int i = 0; i < 3; i++)
 			style.Margin[i] = int((style.Margin[i] + state->margin[i]) * (i < 2 ? state->rx : state->ry) + 0.5);
@@ -260,10 +269,14 @@ void ResampleResolution(AssFile *ass, ResampleSettings settings) {
 		settings.source_matrix != YCbCrMatrix::rgb &&
 		settings.dest_matrix != YCbCrMatrix::rgb;
 
+	double rx = double(settings.dest_x) / double(settings.source_x);
+	double ry = double(settings.dest_y) / double(settings.source_y);
+
 	resample_state state = {
 		settings.margin,
-		double(settings.dest_x) / double(settings.source_x),
-		double(settings.dest_y) / double(settings.source_y),
+		rx,
+		ry,
+		rx == ry ? rx : std::sqrt(rx * ry),
 		horizontal_stretch,
 		agi::ycbcr_converter{
 			matrix(settings.source_matrix),


### PR DESCRIPTION
Stuff that should be obvious from the code:

  * `\xbord`, `\xshad`, `\fsp` were scaled wrongly when changing the aspect ratio.

  * `\org` and vector drawing coordinates were rounded too coarsely.

  * `\pbo` was scaled wrongly when adding/removing margins. It’s a relative baseline offset, not an absolute screen coordinate. (It indeed accepts only integers in all current variants of VSFilter, although it accepts reals in libass.)

  * This PR makes no attempt to fix perspective transforms or to take LayoutRes into account. The Perspective Resample automation script remains compatible and remains necessary.

Extra notes:

  * `\blur` is impossible to scale perfectly when changing the aspect ratio; we’d need `\xblur` and `\yblur` for that. But this PR makes it scale less (least) badly by using a mean ratio of both sides (essentially, by preserving the area of the blur kernel even while allowing its shape to change).

  * `\be` literally can’t be scaled to other resolutions AFAIK, as its parameter has no geometric meaning at all and its operation involves tricky intermediate rounding that loses energy. This PR changes `\be` scaling for consistency with `\blur`, but it doesn’t actually make it correct.

  * I can’t decide whether it’s better, when changing the aspect ratio, to scale `\bord`, `\shad`, `Outline`, `Shadow` by the mean ratio or to keep scaling them by the height ratio for some perverse compatibility with older Aegisub’s resampler and with [even-older libass](https://github.com/libass/libass/pull/645). I’ve included a commit that reverts to Aegisub’s older (current) behaviour and propose that this commit be dropped if you think it’s unreasonable.

    Ideally, the resampler should automatically convert isotropic `\bord` and `\shad` tags to `\xtag\ytag` pairs, but this seems less trivial than I’m prepared to deal with in this PR, since AFAICT the resampler currently iterates over existing tags and modifies each tag in isolation. Even then, the biggest question is how style `Outline` and `Shadow` properties should be handled: to preserve the look of the output exactly, the style property should be scaled along one axis (e. g. height, as in current Aegisub) and an inline override tag for the other axis (`\xbord` or `\xshad`) added to the beginning each line and after each `\r`; but this may seem too intrusive.