### PR TITLE
ci: Add Windows ARM64 build configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - name: Windows MSVC Release
+          - name: Windows MSVC x64 Release
             os: windows-latest
+            arch: x64
             msvc: true
             buildtype: release
             args: >-
@@ -34,6 +35,25 @@ jobs:
               -Dfribidi:tests=false
               -Dfribidi:docs=false
               -Dlibass:fontconfig=disabled
+          - name: Windows MSVC ARM64 Release
+            os: windows-11-arm
+            arch: arm64
+            msvc: true
+            buildtype: release
+            args: >-
+              -Ddefault_library=static
+              --force-fallback-for=zlib,harfbuzz,freetype2,fribidi,libpng
+              -Dfreetype2:harfbuzz=disabled
+              -Dharfbuzz:freetype=disabled
+              -Dharfbuzz:cairo=disabled
+              -Dharfbuzz:glib=disabled
+              -Dharfbuzz:gobject=disabled
+              -Dharfbuzz:tests=disabled
+              -Dharfbuzz:docs=disabled
+              -Dfribidi:tests=false
+              -Dfribidi:docs=false
+              -Dlibass:fontconfig=disabled
+              -Dlibass:asm=disabled
           #- {
           #  name: Windows MinGW,
           #  os: windows-latest,
@@ -79,11 +99,13 @@ jobs:
           pip install meson==1.7.2
 
       - name: Setup MSVC
-        if: matrix.config.os == 'windows-latest' && matrix.config.msvc == true
+        if: startsWith(matrix.config.os, 'windows-') && matrix.config.msvc == true
         uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.config.arch }}
 
       - name: Install dependencies (Windows)
-        if: matrix.config.os == 'windows-latest'
+        if: startsWith(matrix.config.os, 'windows-')
         run: |
           choco install ninja innosetup
 
@@ -132,19 +154,19 @@ jobs:
 
       # Windows artifacts
       - name: Generate Windows installer
-        if: matrix.config.os == 'windows-latest'
+        if: startsWith(matrix.config.os, 'windows-')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run:
           meson compile win-installer -C build
 
       - name: Generate Windows portable installer
-        if: matrix.config.os == 'windows-latest'
+        if: startsWith(matrix.config.os, 'windows-')
         run: cd build && ninja win-portable
 
       - name: Upload artifacts - win_installer
         uses: actions/upload-artifact@v4
-        if: matrix.config.os == 'windows-latest'
+        if: startsWith(matrix.config.os, 'windows-')
         with:
           name: ${{ matrix.config.name }} - installer
           path: build/Aegisub-*.exe
@@ -152,7 +174,7 @@ jobs:
 
       - name: Upload artifacts - portable.zip
         uses: actions/upload-artifact@v4
-        if: matrix.config.os == 'windows-latest'
+        if: startsWith(matrix.config.os, 'windows-')
         with:
           name: ${{ matrix.config.name }} - portable
           path: build/aegisub-portable-64.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,19 @@ jobs:
           sudo apt-get update
           sudo apt-get install ninja-build build-essential libx11-dev libfreetype6-dev pkg-config libfontconfig1-dev libass-dev libasound2-dev libffms2-dev intltool libboost-all-dev libhunspell-dev libcurl4-openssl-dev libuchardet-dev libgtest-dev libgmock-dev libwxgtk3.2-dev
 
+      - name: Checkout gas-preprocessor (Windows ARM64)
+        if: matrix.config.os == 'windows-11-arm'
+        uses: actions/checkout@v4
+        with:
+          repository: FFmpeg/gas-preprocessor
+          ref: a120373ba30de06675d8c47617b315beef16c88e
+          path: gas-preprocessor
+
+      - name: Add gas-preprocessor to path (Windows ARM64)
+        if: matrix.config.os == 'windows-11-arm'
+        run: |
+          echo "$PWD\gas-preprocessor" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
+
       - name: Configure
         run: meson setup build ${{ matrix.config.args }} -Dbuildtype=${{ matrix.config.buildtype }} ${{ github.ref_type == 'tag' && '-Dofficial_release=true' || '' }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
           Get-Location | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           popd
 
-          $gettexturl = "https://github.com/mlocati/gettext-iconv-windows/releases/download/v0.21-v1.16/gettext0.21-iconv1.16-static-64.zip"
+          $gettexturl = "https://github.com/mlocati/gettext-iconv-windows/releases/download/v0.25-v1.17/gettext0.25-iconv1.17-static-64.zip"
           Invoke-WebRequest -Uri $gettexturl -OutFile ".\gettext.zip"
           Expand-Archive ".\gettext.zip" -DestinationPath gettext
           pushd gettext/bin


### PR DESCRIPTION
Windows ARM64 runner image has been publicly available on GitHub Actions since [mid-April](https://github.blog/changelog/2025-04-14-windows-arm64-hosted-runners-now-available-in-public-preview/).

I don't have a Win ARM device to test this build. Would expect some Win ARM users to try it out and provide feedback.