### PR TITLE
ci: Don't install lua modules on mac

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,9 +109,7 @@ jobs:
           export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
           # Skip brew update for now, see https://github.com/actions/setup-python/issues/577
           # brew update
-          brew install luarocks ninja
-          sudo luarocks install luafilesystem 1.8.0
-          sudo luarocks install moonscript --dev
+          brew install ninja
           brew install libass zlib ffms2 fftw hunspell
           brew install pulseaudio  # NO OpenAL in github CI
 


### PR DESCRIPTION
These are the cause of the latest macos CI breakage and aren't actually needed for the CI build.

---
PR created to test CI.