### PR TITLE
Add CFBundleSupportedPlatforms to Info.plist

### DIFF
--- a/packages/osx_bundle/Contents/Info.plist
+++ b/packages/osx_bundle/Contents/Info.plist
@@ -42,6 +42,12 @@
         <string>i386</string>
     </array>
 
+	<!-- Target platform -->
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+
     <!-- Displayed in the 'Get Info' context menu dialogue -->
     <key>CFBundleGetInfoString</key>
     <string>aegisub version @PLIST_VERSION@ built on @PLIST_BUILD_DATE@ https://aegisub.org/</string>


### PR DESCRIPTION
Without it, arm64 Aegisub is identified as an iOS app in System Info, rather than Apple Silicon

Before:
<img width="741" height="46" alt="image" src="https://github.com/user-attachments/assets/71b782e5-ca10-4fb6-9824-1f1cd1a7c38d" />

After manually adding to Info.plist:
<img width="751" height="45" alt="image" src="https://github.com/user-attachments/assets/96ba09db-accf-4109-845d-25b62ce71b6a" />
