### PR TITLE
Adjust the default (=minimum) width of the style editor

### DIFF
--- a/src/dialog_style_editor.cpp
+++ b/src/dialog_style_editor.cpp
@@ -145,7 +145,7 @@ DialogStyleEditor::DialogStyleEditor(wxWindow *parent, AssStyle *style, agi::Con
 
 	auto add_with_label = [&](wxSizer *sizer, wxString const& label, wxWindow *ctrl) {
 		sizer->Add(new wxStaticText(this, -1, label), wxSizerFlags().Center().Border(wxLEFT | wxRIGHT));
-		sizer->Add(ctrl, wxSizerFlags(1).Left().Expand());
+		sizer->Add(ctrl, wxSizerFlags(ctrl->GetBestSize().GetWidth()).Left().Expand());
 	};
 
 	auto num_text_ctrl = [&](double *value, double min, double max, double step, int precision) -> wxSpinCtrlDouble * {


### PR DESCRIPTION
Before:
<img width="2323" height="821" alt="before" src="https://github.com/user-attachments/assets/09cb86e1-2c34-4776-830d-be81250904d8" />

After:
<img width="1969" height="821" alt="after" src="https://github.com/user-attachments/assets/41c3eb18-7538-48f7-ba6c-5e62bb2c7521" />
