### PR TITLE
Fix CommandRenderer text ellipsization on Hi-DPI

### DIFF
--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -526,8 +526,7 @@ public:
 	wxSize GetSize() const override {
 		if (!value.GetText().empty()) {
 			wxSize size = GetTextExtent(value.GetText());
-			// FIXME does this need to be DPI scaled? If so, where do we get the scale from?
-			size.x += icon_width;
+			size.x += GetView()->FromDIP(icon_width);
 			return size;
 		}
 		return wxSize(80,20);


### PR DESCRIPTION
too lazy to write a separate bug report and submit to issues, so I'm just pasting a screenshot of the bug here:

<img width="1524" height="1373" alt="image" src="https://github.com/user-attachments/assets/4e309dca-758f-4dfd-a8b0-742cacc0b9dc" />
