### PR TITLE
Fix util.deep_copy and table.copy_deep function circular reference issue

### DIFF
--- a/automation/include/aegisub/util.moon
+++ b/automation/include/aegisub/util.moon
@@ -34,8 +34,11 @@ deep_copy = check'table' (tbl) ->
   copy = (val) ->
     return val if type(val) != 'table'
     return seen[val] if seen[val]
-    seen[val] = val
-    {k, copy(v) for k, v in pairs val}
+    result = {}
+    seen[val] = result
+    for k, v in pairs val
+      result[k] = copy(v)
+    result
   copy tbl
 
 -- Generates ASS hexadecimal string from R, G, B integer components, in &HBBGGRR& format


### PR DESCRIPTION
Fix `util.deep_copy` and `table.copy_deep` function circular reference issue: Cache **original table → new table** mapping instead of original table.

#### Test Case Comparison (The code runs through the aegisub karaoke template)
```
_G.require("utils")
tbl = {id=11}
tbl.self = tbl
copied = _G.util.deep_copy(tbl)  -- or _G.table.copy_deep
copied.id = 22
_G.aegisub.debug.out(string.format(string.rep("%s\n", 8),
  copied.self == tbl,    -- false
  copied.self == copied,    -- true
  tbl.id,    -- 11
  tbl.self.id,    -- 11
  tbl.self.self.id,    -- 11
  copied.id,    -- 22
  copied.self.id,    -- 22
  copied.self.self.id    -- 22
))
```
In the `.ass` file as this:
```
Comment: 0,0:00:00.00,0:00:00.00,Default,,0,0,0,code once,_G.require("utils") tbl = {id=11} tbl.self = tbl copied = _G.util.deep_copy(tbl)   copied.id = 22 _G.aegisub.debug.out(string.format(string.rep("%s\n", 8), copied.self == tbl,     copied.self == copied,     tbl.id,     tbl.self.id,     tbl.self.self.id,     copied.id,     copied.self.id,     copied.self.self.id     ))
Comment: 0,0:00:00.00,0:00:05.00,Default,,0,0,0,template,
```

#### Before Fix Results:
> true
> false
> 11
> 11
> 11
> 22
> 11
> 11

#### After Fix Results:
> false
> true
> 11
> 11
> 11
> 22
> 22
> 22