### PR TITLE
Store original line texts on file load for split view

### DIFF
--- a/src/initial_line_state.cpp
+++ b/src/initial_line_state.cpp
@@ -15,20 +15,49 @@
 #include "initial_line_state.h"
 
 #include "ass_dialogue.h"
+#include "ass_file.h"
 #include "include/aegisub/context.h"
 #include "selection_controller.h"
+#include "subs_controller.h"
 
 InitialLineState::InitialLineState(agi::Context *c)
-: active_line_connection(c->selectionController->AddActiveLineListener(&InitialLineState::OnActiveLineChanged, this))
+: context(c)
+, active_line_connection(c->selectionController->AddActiveLineListener(&InitialLineState::OnActiveLineChanged, this))
+, file_open_connection(c->subsController->AddFileOpenListener(&InitialLineState::OnFileOpen, this))
 {
 	OnActiveLineChanged(c->selectionController->GetActiveLine());
+}
+
+void InitialLineState::OnFileOpen(agi::fs::path const&) {
+	SaveAllInitialTexts(context->ass.get());
+	AssDialogue *active_line = context->selectionController->GetActiveLine();
+	if (active_line) {
+		auto it = initial_texts_map.find(active_line->Id);
+		if (it != initial_texts_map.end()) {
+			initial_text = it->second;
+			line_id = active_line->Id;
+			InitialStateChanged(initial_text);
+		}
+	}
+}
+
+void InitialLineState::SaveAllInitialTexts(AssFile *ass) {
+	initial_texts_map.clear();
+	for (auto const& line : ass->Events) {
+		initial_texts_map[line.Id] = line.Text;
+	}
 }
 
 void InitialLineState::OnActiveLineChanged(AssDialogue *new_line) {
 	if (new_line) {
 		if (new_line->Id == line_id) return;
 		line_id = new_line->Id;
-		initial_text = new_line->Text;
+		auto it = initial_texts_map.find(new_line->Id);
+		if (it != initial_texts_map.end()) {
+			initial_text = it->second;
+		} else {
+			initial_text = new_line->Text;
+		}
 	}
 	else {
 		line_id = 0;
@@ -36,4 +65,8 @@ void InitialLineState::OnActiveLineChanged(AssDialogue *new_line) {
 	}
 
 	InitialStateChanged(initial_text);
+}
+
+std::string const& InitialLineState::GetInitialText() const {
+	return initial_text;
 }

--- a/src/initial_line_state.h
+++ b/src/initial_line_state.h
@@ -15,21 +15,31 @@
 #include <libaegisub/signal.h>
 
 #include <string>
+#include <map>
 
-namespace agi { struct Context; }
+namespace agi { 
+	struct Context;
+	namespace fs { class path; }
+}
 class AssDialogue;
+class AssFile;
 
 class InitialLineState {
+	agi::Context *context;
 	agi::signal::Connection active_line_connection;
+	agi::signal::Connection file_open_connection;
 	std::string initial_text;
 	int line_id;
+	std::map<int, std::string> initial_texts_map;
 
 	agi::signal::Signal<std::string const&> InitialStateChanged;
 	void OnActiveLineChanged(AssDialogue *new_line);
+	void OnFileOpen(agi::fs::path const&);
 
 public:
 	InitialLineState(agi::Context *c);
 
-	std::string const& GetInitialText() const { return initial_text; }
+	std::string const& GetInitialText() const;
+	void SaveAllInitialTexts(AssFile *ass);
 	DEFINE_SIGNAL_ADDERS(InitialStateChanged, AddChangeListener)
 };

--- a/src/subs_edit_box.cpp
+++ b/src/subs_edit_box.cpp
@@ -187,7 +187,7 @@ SubsEditBox::SubsEditBox(wxWindow *parent, agi::Context *context)
 	by_frame->Enable(false);
 
 	split_box = new wxCheckBox(this,-1,_("Show Original"));
-	split_box->SetToolTip(_("Show the contents of the subtitle line when it was first selected above the edit box. This is sometimes useful when editing subtitles or translating subtitles into another language."));
+	split_box->SetToolTip(_("Show the contents of the subtitle line when the file was loaded. This is useful when translating subtitles into another language."));
 	split_box->Bind(wxEVT_CHECKBOX, &SubsEditBox::OnSplit, this);
 	middle_right_sizer->Add(split_box, wxSizerFlags().Center().Left());
 


### PR DESCRIPTION
This PR changes the behavior of the "Show Original" split view feature. Previously, the original text was captured when a line was first selected. Now, all original texts are stored when the file is loaded, and the split view always shows the text as it was at file load time, regardless of subsequent edits.

## Changes

- Added `std::map<int, std::string> initial_texts_map` to store all original texts by line ID
- Added `OnFileOpen()` handler that saves all original texts when file is loaded
- Modified `OnActiveLineChanged()` to retrieve original text from map instead of current line text
- Updated tooltip text to reflect new behavior

## Benefits

1. **Consistent original text**: The split view now always shows the text as it was when the file was loaded
2. **Better for translation**: Translators can see the original text even after making edits to the line