### PR TITLE
Add language/title in track selection

### DIFF
--- a/src/ffmpegsource_common.cpp
+++ b/src/ffmpegsource_common.cpp
@@ -109,8 +109,33 @@ std::map<int, std::string> FFmpegSourceProvider::GetTracksOfType(FFMS_Indexer *I
 
 	for (int i=0; i<NumTracks; i++) {
 		if (FFMS_GetTrackTypeI(Indexer, i) == Type) {
-			if (auto CodecName = FFMS_GetCodecNameI(Indexer, i))
-				TrackList[i] = CodecName;
+			std::string TrackDescription = "";
+
+			bool FirstEntry = true;
+			auto Append = [&](const std::string& part) {
+				if (!FirstEntry)
+					TrackDescription += " - ";
+				TrackDescription += part;
+				FirstEntry = false;
+			};
+
+			const char* CodecName = FFMS_GetCodecNameI(Indexer, i);
+			const char* Language = NULL;
+			const char* Title = NULL;
+
+#if FFMS_VERSION >= 0x5010200
+			Language = FFMS_GetTrackMetadataI(Indexer, i, "language");
+			Title = FFMS_GetTrackMetadataI(Indexer, i, "title");
+#endif
+
+			if (CodecName)
+				Append(CodecName);
+			if (Language)
+				Append("[" + std::string(Language) + "]");
+			if (Title)
+				Append(Title);
+
+			TrackList[i] = TrackDescription;
 		}
 	}
 	return TrackList;


### PR DESCRIPTION
This PR is a draft because i'm waiting for https://github.com/FFMS/ffms2/pull/467 to be merged.
Note that ffmpeg doesn't expose the BCP language of mkv file (see: https://code.ffmpeg.org/FFmpeg/FFmpeg/issues/21257). There might be a day a new field named `language_bcp`.

## Before
**Video track**
<img width="240" height="175" alt="image" src="https://github.com/user-attachments/assets/b200f066-6dea-42f9-81fe-60a3bd87aa4c" />

**Audio track**
<img width="240" height="137" alt="image" src="https://github.com/user-attachments/assets/a970d736-b66a-40f1-bde7-f3760adc9bdd" />

## Now
**Video track**
<img width="305" height="175" alt="image" src="https://github.com/user-attachments/assets/1aa0a029-01de-494f-bcb9-f419800954fe" />

**Audio track**
<img width="306" height="136" alt="image" src="https://github.com/user-attachments/assets/1a217b3f-43f3-449f-b4ec-e77902f077f1" />
