### PR TITLE
Fix timestamps

### DIFF
--- a/subprojects/ffms2.wrap
+++ b/subprojects/ffms2.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
-url = https://github.com/FFMS/ffms2.git
-revision = head
+url = https://github.com/moi15moi/ffms2.git
+revision = Add-FFMS_GetContainerFirstTimeI
 patch_directory = ffms2
 
 [provide]

--- a/tests/tests/vfr.cpp
+++ b/tests/tests/vfr.cpp
@@ -394,24 +394,6 @@ TEST(lagi_vfr, load_v1_save_v2_ovr) {
 	EXPECT_TRUE(validate_save("data/vfr/in/v2_100_frames_30_with_override.txt", "data/vfr/out/v2_100_frames_30_with_override.txt"));
 }
 
-TEST(lagi_vfr, nonzero_start_time) {
-	Framerate fps;
-
-	ASSERT_NO_THROW(fps = Framerate({ 10, 20, 30, 40, 50 }));
-	EXPECT_EQ(0, fps.TimeAtFrame(0, EXACT));
-	EXPECT_EQ(10, fps.TimeAtFrame(1, EXACT));
-	EXPECT_EQ(20, fps.TimeAtFrame(2, EXACT));
-	EXPECT_EQ(30, fps.TimeAtFrame(3, EXACT));
-	EXPECT_EQ(40, fps.TimeAtFrame(4, EXACT));
-
-	ASSERT_NO_THROW(fps = Framerate({ -10, 20, 30, 40, 50 }));
-	EXPECT_EQ(0, fps.TimeAtFrame(0, EXACT));
-	EXPECT_EQ(30, fps.TimeAtFrame(1, EXACT));
-	EXPECT_EQ(40, fps.TimeAtFrame(2, EXACT));
-	EXPECT_EQ(50, fps.TimeAtFrame(3, EXACT));
-	EXPECT_EQ(60, fps.TimeAtFrame(4, EXACT));
-}
-
 TEST(lagi_vfr, rational_timebase) {
 	Framerate fps;
 


### PR DESCRIPTION
This PR is a draft because i'm waiting for https://github.com/FFMS/ffms2/pull/472 to be merged.
As we already talk (here and in gjm discord), mpv shift the video timestamps by ``AVFormatContext::start_time``.
Fix [#172](https://github.com/arch1t3cht/Aegisub/issues/172)