### PR TITLE
Set correct parents for controls in wxStaticBoxSizers

### DIFF
--- a/src/ass_exporter.cpp
+++ b/src/ass_exporter.cpp
@@ -43,6 +43,7 @@
 
 #include <memory>
 #include <wx/sizer.h>
+#include <wx/statbox.h>
 
 AssExporter::AssExporter(agi::Context *c) : c(c) { }
 
@@ -52,7 +53,7 @@ void AssExporter::DrawSettings(wxWindow *parent, wxSizer *target_sizer) {
 		// Make sure to construct static box sizer first, so it won't overlap
 		// the controls on wxMac.
 		auto box = new wxStaticBoxSizer(wxVERTICAL, parent, to_wx(filter.GetName()));
-		wxWindow *window = filter.GetConfigDialogWindow(parent, c);
+		wxWindow *window = filter.GetConfigDialogWindow(box->GetStaticBox(), c);
 		if (window) {
 			box->Add(window, 0, wxEXPAND, 0);
 			target_sizer->Add(box, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);

--- a/src/dialog_autosave.cpp
+++ b/src/dialog_autosave.cpp
@@ -31,6 +31,7 @@
 #include <wx/filename.h>
 #include <wx/listbox.h>
 #include <wx/sizer.h>
+#include <wx/statbox.h>
 #include <wx/string.h>
 
 namespace {
@@ -67,13 +68,13 @@ DialogAutosave::DialogAutosave(wxWindow *parent)
 {
 	d.SetIcons(GETICONS(open_toolbutton));
 
-	wxSizer *files_box = new wxStaticBoxSizer(wxVERTICAL, &d, _("Files"));
-	file_list = new wxListBox(&d, -1);
+	wxStaticBoxSizer *files_box = new wxStaticBoxSizer(wxVERTICAL, &d, _("Files"));
+	file_list = new wxListBox(files_box->GetStaticBox(), -1);
 	file_list->Bind(wxEVT_LISTBOX, &DialogAutosave::OnSelectFile, this);
 	files_box->Add(file_list, wxSizerFlags(1).Expand().Border());
 
-	wxSizer *versions_box = new wxStaticBoxSizer(wxVERTICAL, &d, _("Versions"));
-	version_list = new wxListBox(&d, -1);
+	wxStaticBoxSizer *versions_box = new wxStaticBoxSizer(wxVERTICAL, &d, _("Versions"));
+	version_list = new wxListBox(versions_box->GetStaticBox(), -1);
 	version_list->Bind(wxEVT_LISTBOX_DCLICK, [this](wxCommandEvent&) { d.EndModal(wxID_OK); });
 	versions_box->Add(version_list, wxSizerFlags(1).Expand().Border());
 

--- a/src/dialog_colorpicker.cpp
+++ b/src/dialog_colorpicker.cpp
@@ -495,7 +495,7 @@ class DialogColorPicker final : public wxDialog {
 
 	/// Constructor helper function for making the color input box sizers
 	template<int N, class Control>
-	wxSizer *MakeColorInputSizer(wxString (&labels)[N], Control *(&inputs)[N]);
+	wxSizer *MakeColorInputSizer(wxWindow *parent, wxString (&labels)[N], Control *(&inputs)[N]);
 
 	void OnChangeMode(wxCommandEvent &evt);
 	void OnSpectrumChange(wxCommandEvent &evt);
@@ -554,35 +554,41 @@ DialogColorPicker::DialogColorPicker(wxWindow *parent, agi::Color initial_color,
 	hsv_slider = make_slider([](int y, unsigned char *rgb) { hsv_to_rgb(y, 255, 255, rgb, rgb + 1, rgb + 2); });
 
 	// Create the controls for the dialog
-	wxSizer *spectrum_box = new wxStaticBoxSizer(wxVERTICAL, this, _("Color spectrum"));
-	spectrum = new ColorPickerSpectrum(this, PickerDirection::HorzVert, wxSize(256, 256));
-	slider = new ColorPickerSpectrum(this, PickerDirection::Vert, wxSize(slider_width, 256));
-	alpha_slider = new ColorPickerSpectrum(this, PickerDirection::Vert, wxSize(slider_width, 256));
-	wxString modes[] = { _("RGB/R"), _("RGB/G"), _("RGB/B"), _("HSL/L"), _("HSV/H") };
-	colorspace_choice = new wxChoice(this, -1, wxDefaultPosition, wxDefaultSize, 5, modes);
+	wxStaticBoxSizer *spectrum_box_sizer = new wxStaticBoxSizer(wxVERTICAL, this, _("Color spectrum"));
+	wxWindow *spectrum_box = spectrum_box_sizer->GetStaticBox();
 
-	wxSizer *rgb_box = new wxStaticBoxSizer(wxHORIZONTAL, this, _("RGB color"));
-	wxSizer *hsl_box = new wxStaticBoxSizer(wxVERTICAL, this, _("HSL color"));
-	wxSizer *hsv_box = new wxStaticBoxSizer(wxVERTICAL, this, _("HSV color"));
+	spectrum = new ColorPickerSpectrum(spectrum_box, PickerDirection::HorzVert, wxSize(256, 256));
+	slider = new ColorPickerSpectrum(spectrum_box, PickerDirection::Vert, wxSize(slider_width, 256));
+	alpha_slider = new ColorPickerSpectrum(spectrum_box, PickerDirection::Vert, wxSize(slider_width, 256));
+	wxString modes[] = { _("RGB/R"), _("RGB/G"), _("RGB/B"), _("HSL/L"), _("HSV/H") };
+	colorspace_choice = new wxChoice(spectrum_box, -1, wxDefaultPosition, wxDefaultSize, 5, modes);
+
+	wxStaticBoxSizer *rgb_box_sizer = new wxStaticBoxSizer(wxHORIZONTAL, this, _("RGB color"));
+	wxStaticBoxSizer *hsl_box_sizer = new wxStaticBoxSizer(wxVERTICAL, this, _("HSL color"));
+	wxStaticBoxSizer *hsv_box_sizer = new wxStaticBoxSizer(wxVERTICAL, this, _("HSV color"));
+
+	wxWindow *rgb_box = rgb_box_sizer->GetStaticBox();
+	wxWindow *hsl_box = hsl_box_sizer->GetStaticBox();
+	wxWindow *hsv_box = hsv_box_sizer->GetStaticBox();
 
 	for (auto& elem : rgb_input)
-		elem = new wxSpinCtrl(this, -1, "", wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, 255);
+		elem = new wxSpinCtrl(rgb_box, -1, "", wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, 255);
 
 	auto dummy = new wxTextCtrl(this, -1);
 	wxSize colorinput_size = dummy->GetSizeFromText("&H000000&");
 	dummy->Destroy();
 
-	ass_input = new wxTextCtrl(this, -1, "", wxDefaultPosition, colorinput_size);
-	html_input = new wxTextCtrl(this, -1, "", wxDefaultPosition, colorinput_size);
-	alpha_input = new wxSpinCtrl(this, -1, "", wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, 255);
+	ass_input = new wxTextCtrl(rgb_box, -1, "", wxDefaultPosition, colorinput_size);
+	html_input = new wxTextCtrl(rgb_box, -1, "", wxDefaultPosition, colorinput_size);
+	alpha_input = new wxSpinCtrl(rgb_box, -1, "", wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, 255);
 
 	for (auto& elem : hsl_input)
-		elem = new wxSpinCtrl(this, -1, "", wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, 255);
+		elem = new wxSpinCtrl(hsl_box, -1, "", wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, 255);
 
 	for (auto& elem : hsv_input)
-		elem = new wxSpinCtrl(this, -1, "", wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, 255);
+		elem = new wxSpinCtrl(hsv_box, -1, "", wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, 255);
 
-	preview_box = new wxStaticBitmap(this, -1, wxBitmap(40, 40, 24), wxDefaultPosition, wxSize(40, 40), STATIC_BORDER_FLAG);
+	preview_box = new wxStaticBitmap(spectrum_box, -1, wxBitmap(40, 40, 24), wxDefaultPosition, wxSize(40, 40), STATIC_BORDER_FLAG);
 	recent_box = new ColorPickerRecent(this, 8, 4, 16);
 
 	eyedropper_bitmap = GETBUNDLE(eyedropper_tool, 24);
@@ -591,7 +597,7 @@ DialogColorPicker::DialogColorPicker(wxWindow *parent, agi::Color initial_color,
 
 	// Arrange the controls in a nice way
 	wxSizer *spectop_sizer = new wxBoxSizer(wxHORIZONTAL);
-	spectop_sizer->Add(new wxStaticText(this, -1, _("Spectrum mode:")), 0, wxALIGN_CENTER_VERTICAL|wxALIGN_LEFT|wxRIGHT, 5);
+	spectop_sizer->Add(new wxStaticText(spectrum_box, -1, _("Spectrum mode:")), 0, wxALIGN_CENTER_VERTICAL|wxALIGN_LEFT|wxRIGHT, 5);
 	spectop_sizer->Add(colorspace_choice, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_LEFT);
 	spectop_sizer->Add(5, 5, 1, wxEXPAND);
 	spectop_sizer->Add(preview_box, 0, wxALIGN_CENTER_VERTICAL);
@@ -606,28 +612,28 @@ DialogColorPicker::DialogColorPicker(wxWindow *parent, agi::Color initial_color,
 	if (!alpha)
 		spectrum_sizer->Hide(alpha_slider);
 
-	spectrum_box->Add(spectrum_sizer, 0, wxALL, 3);
+	spectrum_box_sizer->Add(spectrum_sizer, 0, wxALL, 3);
 
 	wxString rgb_labels[] = { _("Red:"), _("Green:"), _("Blue:") };
-	rgb_box->Add(MakeColorInputSizer(rgb_labels, rgb_input), 1, wxALL|wxEXPAND, 3);
+	rgb_box_sizer->Add(MakeColorInputSizer(rgb_box, rgb_labels, rgb_input), 1, wxALL|wxEXPAND, 3);
 
 	wxString ass_labels[] = { "ASS:", "HTML:", _("Alpha:") };
 	wxControl *ass_ctrls[] = { ass_input, html_input, alpha_input };
-	auto ass_colors_sizer = MakeColorInputSizer(ass_labels, ass_ctrls);
+	auto ass_colors_sizer = MakeColorInputSizer(rgb_box, ass_labels, ass_ctrls);
 	if (!alpha)
 		ass_colors_sizer->Hide(alpha_input);
-	rgb_box->Add(ass_colors_sizer, 0, wxALL|wxCENTER|wxEXPAND, 3);
+	rgb_box_sizer->Add(ass_colors_sizer, 0, wxALL|wxCENTER|wxEXPAND, 3);
 
 	wxString hsl_labels[] = { _("Hue:"), _("Sat.:"), _("Lum.:") };
-	hsl_box->Add(MakeColorInputSizer(hsl_labels, hsl_input), 0, wxALL|wxEXPAND, 3);
+	hsl_box_sizer->Add(MakeColorInputSizer(hsl_box, hsl_labels, hsl_input), 0, wxALL|wxEXPAND, 3);
 
 	wxString hsv_labels[] = { _("Hue:"), _("Sat.:"), _("Value:") };
-	hsv_box->Add(MakeColorInputSizer(hsv_labels, hsv_input), 0, wxALL|wxEXPAND, 3);
+	hsv_box_sizer->Add(MakeColorInputSizer(hsv_box, hsv_labels, hsv_input), 0, wxALL|wxEXPAND, 3);
 
 	wxSizer *hsx_sizer = new wxBoxSizer(wxHORIZONTAL);
-	hsx_sizer->Add(hsl_box);
+	hsx_sizer->Add(hsl_box_sizer);
 	hsx_sizer->AddSpacer(5);
-	hsx_sizer->Add(hsv_box);
+	hsx_sizer->Add(hsv_box_sizer);
 
 	wxSizer *picker_sizer = new wxBoxSizer(wxHORIZONTAL);
 	picker_sizer->AddStretchSpacer();
@@ -640,7 +646,7 @@ DialogColorPicker::DialogColorPicker(wxWindow *parent, agi::Color initial_color,
 	wxStdDialogButtonSizer *button_sizer = CreateStdDialogButtonSizer(wxOK | wxCANCEL | wxHELP);
 
 	wxSizer *input_sizer = new wxBoxSizer(wxVERTICAL);
-	input_sizer->Add(rgb_box, 0, wxEXPAND);
+	input_sizer->Add(rgb_box_sizer, 0, wxEXPAND);
 	input_sizer->AddSpacer(5);
 	input_sizer->Add(hsx_sizer, 0, wxEXPAND);
 	input_sizer->AddStretchSpacer(1);
@@ -649,7 +655,7 @@ DialogColorPicker::DialogColorPicker(wxWindow *parent, agi::Color initial_color,
 	input_sizer->Add(button_sizer, 0, wxALIGN_RIGHT);
 
 	wxSizer *main_sizer = new wxBoxSizer(wxHORIZONTAL);
-	main_sizer->Add(spectrum_box, 1, wxALL | wxEXPAND, 5);
+	main_sizer->Add(spectrum_box_sizer, 1, wxALL | wxEXPAND, 5);
 	main_sizer->Add(input_sizer, 0, (wxALL&~wxLEFT)|wxEXPAND, 5);
 
 	SetSizerAndFit(main_sizer);
@@ -697,10 +703,10 @@ DialogColorPicker::DialogColorPicker(wxWindow *parent, agi::Color initial_color,
 }
 
 template<int N, class Control>
-wxSizer *DialogColorPicker::MakeColorInputSizer(wxString (&labels)[N], Control *(&inputs)[N]) {
+wxSizer *DialogColorPicker::MakeColorInputSizer(wxWindow *parent, wxString (&labels)[N], Control *(&inputs)[N]) {
 	auto sizer = new wxFlexGridSizer(2, 5, 5);
 	for (int i = 0; i < N; ++i) {
-		sizer->Add(new wxStaticText(this, -1, labels[i]), wxSizerFlags(1).Center().Left());
+		sizer->Add(new wxStaticText(parent, -1, labels[i]), wxSizerFlags(1).Center().Left());
 		sizer->Add(inputs[i], wxSizerFlags().Expand());
 	}
 	sizer->AddGrowableCol(0,1);

--- a/src/dialog_export.cpp
+++ b/src/dialog_export.cpp
@@ -46,6 +46,7 @@
 #include <wx/choice.h>
 #include <wx/msgdlg.h>
 #include <wx/sizer.h>
+#include <wx/statbox.h>
 #include <wx/stattext.h>
 #include <wx/textctrl.h>
 
@@ -105,8 +106,11 @@ DialogExport::DialogExport(agi::Context *c)
 	d.SetIcons(GETICONS(export_menu));
 	d.SetExtraStyle(wxWS_EX_VALIDATE_RECURSIVELY);
 
+	wxStaticBoxSizer *top_sizer = new wxStaticBoxSizer(wxVERTICAL, &d, _("Filters"));
+	wxWindow *top_sizer_box = top_sizer->GetStaticBox();
+
 	std::vector<std::string> filters = exporter.GetAllFilterNames();
-	filter_list = new wxCheckListBox(&d, -1, wxDefaultPosition, wxSize(200, 100), to_wx(filters));
+	filter_list = new wxCheckListBox(top_sizer_box, -1, wxDefaultPosition, wxSize(200, 100), to_wx(filters));
 	filter_list->Bind(wxEVT_CHECKLISTBOX, [this](wxCommandEvent&) { RefreshOptions(); });
 	filter_list->Bind(wxEVT_LISTBOX, &DialogExport::OnChange, this);
 
@@ -118,10 +122,10 @@ DialogExport::DialogExport(agi::Context *c)
 			filter_list->Check(distance(begin(filters), it));
 	}
 
-	wxButton *btn_up = new wxButton(&d, -1, _("Move &Up"), wxDefaultPosition, wxSize(90, -1));
-	wxButton *btn_down = new wxButton(&d, -1, _("Move &Down"), wxDefaultPosition, wxSize(90, -1));
-	wxButton *btn_all = new wxButton(&d, -1, _("Select &All"), wxDefaultPosition, wxSize(80, -1));
-	wxButton *btn_none = new wxButton(&d, -1, _("Select &None"), wxDefaultPosition, wxSize(80, -1));
+	wxButton *btn_up = new wxButton(top_sizer_box, -1, _("Move &Up"), wxDefaultPosition, wxSize(90, -1));
+	wxButton *btn_down = new wxButton(top_sizer_box, -1, _("Move &Down"), wxDefaultPosition, wxSize(90, -1));
+	wxButton *btn_all = new wxButton(top_sizer_box, -1, _("Select &All"), wxDefaultPosition, wxSize(80, -1));
+	wxButton *btn_none = new wxButton(top_sizer_box, -1, _("Select &None"), wxDefaultPosition, wxSize(80, -1));
 
 	btn_up->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) { swap(filter_list, filter_list->GetSelection() - 1, 0); });
 	btn_down->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) { swap(filter_list, filter_list->GetSelection(), 1); });
@@ -134,18 +138,17 @@ DialogExport::DialogExport(agi::Context *c)
 	top_buttons->Add(btn_all, wxSizerFlags(1).Expand());
 	top_buttons->Add(btn_none, wxSizerFlags(1).Expand());
 
-	filter_description = new wxTextCtrl(&d, -1, "", wxDefaultPosition, wxSize(200, 60), wxTE_MULTILINE | wxTE_READONLY);
+	filter_description = new wxTextCtrl(top_sizer_box, -1, "", wxDefaultPosition, wxSize(200, 60), wxTE_MULTILINE | wxTE_READONLY);
 
 	// Charset dropdown list
-	wxStaticText *charset_list_label = new wxStaticText(&d, -1, _("Text encoding:"));
-	charset_list = new wxChoice(&d, -1, wxDefaultPosition, wxDefaultSize, agi::charset::GetEncodingsList<wxArrayString>());
+	wxStaticText *charset_list_label = new wxStaticText(top_sizer_box, -1, _("Text encoding:"));
+	charset_list = new wxChoice(top_sizer_box, -1, wxDefaultPosition, wxDefaultSize, agi::charset::GetEncodingsList<wxArrayString>());
 	wxSizer *charset_list_sizer = new wxBoxSizer(wxHORIZONTAL);
 	charset_list_sizer->Add(charset_list_label, wxSizerFlags().Center().Border(wxRIGHT));
 	charset_list_sizer->Add(charset_list, wxSizerFlags(1).Expand());
 	if (!charset_list->SetStringSelection(to_wx(c->ass->Properties.export_encoding)))
 		charset_list->SetStringSelection("Unicode (UTF-8)");
 
-	wxSizer *top_sizer = new wxStaticBoxSizer(wxVERTICAL, &d, _("Filters"));
 	top_sizer->Add(filter_list, wxSizerFlags(1).Expand());
 	top_sizer->Add(top_buttons, wxSizerFlags(0).Expand());
 	top_sizer->Add(filter_description, wxSizerFlags(0).Expand().Border(wxTOP));

--- a/src/dialog_export_ebu3264.cpp
+++ b/src/dialog_export_ebu3264.cpp
@@ -98,6 +98,14 @@ namespace {
 int ShowEbuExportConfigurationDialog(wxWindow *owner, EbuExportSettings &s) {
 	wxDialog d(owner, -1, _("Export to EBU STL format"));
 
+	wxStaticBoxSizer *text_formatting_sizer = new wxStaticBoxSizer(wxVERTICAL, &d, _("Text formatting"));
+	wxStaticBoxSizer *timecode_control_sizer = new wxStaticBoxSizer(wxVERTICAL, &d, _("Time codes"));
+	wxStaticBoxSizer *display_standard_sizer = new wxStaticBoxSizer(wxVERTICAL, &d, _("Display standard"));
+
+	wxWindow *text_formatting_box = text_formatting_sizer->GetStaticBox();
+	wxWindow *timecode_control_box = timecode_control_sizer->GetStaticBox();
+	wxWindow *display_standard_box = display_standard_sizer->GetStaticBox();
+
 	wxString tv_standards[] = {
 		_("23.976 fps (non-standard, STL24.01)"),
 		_("24 fps (non-standard, STL24.01)"),
@@ -108,9 +116,9 @@ int ShowEbuExportConfigurationDialog(wxWindow *owner, EbuExportSettings &s) {
 	};
 	wxRadioBox *tv_standard_box = new wxRadioBox(&d, -1, _("TV standard"), wxDefaultPosition, wxDefaultSize, 6, tv_standards, 0, wxRA_SPECIFY_ROWS);
 
-	wxTextCtrl *timecode_offset_entry = new wxTextCtrl(&d, -1, "00:00:00:00");
+	wxTextCtrl *timecode_offset_entry = new wxTextCtrl(timecode_control_box, -1, "00:00:00:00");
 	timecode_offset_entry->SetInitialSize(timecode_offset_entry->GetSizeFromText(timecode_offset_entry->GetValue()));
-	wxCheckBox *inclusive_end_times_check = new wxCheckBox(&d, -1, _("Out-times are inclusive"));
+	wxCheckBox *inclusive_end_times_check = new wxCheckBox(timecode_control_box, -1, _("Out-times are inclusive"));
 
 	wxString text_encodings[] = {
 		_("ISO 6937-2 (Latin/Western Europe)"),
@@ -129,9 +137,9 @@ int ShowEbuExportConfigurationDialog(wxWindow *owner, EbuExportSettings &s) {
 		_("Skip lines that are too long")
 	};
 
-	wxSpinCtrl *max_line_length_ctrl = new wxSpinCtrl(&d, -1, wxString(), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 10, 99);
-	wxComboBox *wrap_mode_ctrl = new wxComboBox(&d, -1, wrap_modes[0], wxDefaultPosition, wxDefaultSize, 4, wrap_modes, wxCB_DROPDOWN | wxCB_READONLY);
-	wxCheckBox *translate_alignments_check = new wxCheckBox(&d, -1, _("Translate alignments"));
+	wxSpinCtrl *max_line_length_ctrl = new wxSpinCtrl(text_formatting_box, -1, wxString(), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 10, 99);
+	wxComboBox *wrap_mode_ctrl = new wxComboBox(text_formatting_box, -1, wrap_modes[0], wxDefaultPosition, wxDefaultSize, 4, wrap_modes, wxCB_DROPDOWN | wxCB_READONLY);
+	wxCheckBox *translate_alignments_check = new wxCheckBox(text_formatting_box, -1, _("Translate alignments"));
 
 	wxString display_standards[] = {
 		_("Open subtitles"),
@@ -139,26 +147,23 @@ int ShowEbuExportConfigurationDialog(wxWindow *owner, EbuExportSettings &s) {
 		_("Level-2 teletext")
 	};
 
-	wxComboBox *display_standard_ctrl = new wxComboBox(&d, -1, "", wxDefaultPosition, wxDefaultSize, 2, display_standards, wxCB_DROPDOWN | wxCB_READONLY);
+	wxComboBox *display_standard_ctrl = new wxComboBox(display_standard_box, -1, "", wxDefaultPosition, wxDefaultSize, 2, display_standards, wxCB_DROPDOWN | wxCB_READONLY);
 
 	wxSizer *max_line_length_labelled = new wxBoxSizer(wxHORIZONTAL);
-	max_line_length_labelled->Add(new wxStaticText(&d, -1, _("Max. line length:")), 1, wxALIGN_CENTRE|wxRIGHT, 12);
+	max_line_length_labelled->Add(new wxStaticText(text_formatting_box, -1, _("Max. line length:")), 1, wxALIGN_CENTRE|wxRIGHT, 12);
 	max_line_length_labelled->Add(max_line_length_ctrl, 0, 0, 0);
 
 	wxSizer *timecode_offset_labelled = new wxBoxSizer(wxHORIZONTAL);
-	timecode_offset_labelled->Add(new wxStaticText(&d, -1, _("Time code offset:")), 1, wxALIGN_CENTRE|wxRIGHT, 12);
+	timecode_offset_labelled->Add(new wxStaticText(timecode_control_box, -1, _("Time code offset:")), 1, wxALIGN_CENTRE|wxRIGHT, 12);
 	timecode_offset_labelled->Add(timecode_offset_entry, 0, 0, 0);
 
-	wxSizer *text_formatting_sizer = new wxStaticBoxSizer(wxVERTICAL, &d, _("Text formatting"));
 	text_formatting_sizer->Add(max_line_length_labelled, 0, wxEXPAND | (wxALL & ~wxTOP), 6);
 	text_formatting_sizer->Add(wrap_mode_ctrl, 0, wxEXPAND | (wxALL & ~wxTOP), 6);
 	text_formatting_sizer->Add(translate_alignments_check, 0, wxEXPAND | (wxALL & ~wxTOP), 6);
 
-	wxSizer *timecode_control_sizer = new wxStaticBoxSizer(wxVERTICAL, &d, _("Time codes"));
 	timecode_control_sizer->Add(timecode_offset_labelled, 0, wxEXPAND | (wxALL & ~wxTOP), 6);
 	timecode_control_sizer->Add(inclusive_end_times_check, 0, wxEXPAND | (wxALL & ~wxTOP), 6);
 
-	wxSizer *display_standard_sizer = new wxStaticBoxSizer(wxVERTICAL, &d, _("Display standard"));
 	display_standard_sizer->Add(display_standard_ctrl, 0, wxEXPAND | (wxALL & ~wxTOP), 6);
 
 	wxSizer *left_column = new wxBoxSizer(wxVERTICAL);

--- a/src/dialog_fonts_collector.cpp
+++ b/src/dialog_fonts_collector.cpp
@@ -246,28 +246,30 @@ DialogFontsCollector::DialogFontsCollector(agi::Context *c)
 	if (c->path->Decode("?script") == "?script")
 		collection_mode->Enable(2, false);
 
-	wxStaticBoxSizer *destination_box = new wxStaticBoxSizer(wxVERTICAL, this, _("Destination"));
+	wxStaticBoxSizer *destination_sizer = new wxStaticBoxSizer(wxVERTICAL, this, _("Destination"));
+	wxWindow *destination_box = destination_sizer->GetStaticBox();
 
-	dest_label = new wxStaticText(this, -1, " ");
-	dest_ctrl = new wxTextCtrl(this, -1, to_wx(OPT_GET("Path/Fonts Collector Destination")->GetString()));
-	dest_browse_button = new wxButton(this, -1, _("&Browse..."));
+	dest_label = new wxStaticText(destination_box, -1, " ");
+	dest_ctrl = new wxTextCtrl(destination_box, -1, to_wx(OPT_GET("Path/Fonts Collector Destination")->GetString()));
+	dest_browse_button = new wxButton(destination_box, -1, _("&Browse..."));
 
 	wxSizer *dest_browse_sizer = new wxBoxSizer(wxHORIZONTAL);
 	dest_browse_sizer->Add(dest_ctrl, wxSizerFlags(1).Border(wxRIGHT).Align(wxALIGN_CENTER_VERTICAL));
 	dest_browse_sizer->Add(dest_browse_button, wxSizerFlags());
 
-	destination_box->Add(dest_label, wxSizerFlags().Border(wxBOTTOM));
-	destination_box->Add(dest_browse_sizer, wxSizerFlags().Expand());
+	destination_sizer->Add(dest_label, wxSizerFlags().Border(wxBOTTOM));
+	destination_sizer->Add(dest_browse_sizer, wxSizerFlags().Expand());
 
-	wxStaticBoxSizer *log_box = new wxStaticBoxSizer(wxVERTICAL, this, _("Log"));
-	collection_log = new wxStyledTextCtrl(this, -1, wxDefaultPosition, wxSize(600, 300));
+	wxStaticBoxSizer *log_sizer = new wxStaticBoxSizer(wxVERTICAL, this, _("Log"));
+	wxWindow *log_box = log_sizer->GetStaticBox();
+	collection_log = new wxStyledTextCtrl(log_box, -1, wxDefaultPosition, wxSize(600, 300));
 	collection_log->SetWrapMode(wxSTC_WRAP_WORD);
 	collection_log->SetMarginWidth(1, 0);
 	collection_log->SetReadOnly(true);
 	collection_log->StyleSetForeground(1, wxColour(0, 200, 0));
 	collection_log->StyleSetForeground(2, wxColour(200, 0, 0));
 	collection_log->StyleSetForeground(3, wxColour(200, 100, 0));
-	log_box->Add(collection_log, wxSizerFlags().Border());
+	log_sizer->Add(collection_log, wxSizerFlags().Border());
 
 	wxStdDialogButtonSizer *button_sizer = CreateStdDialogButtonSizer(wxOK | wxCANCEL | wxHELP);
 	start_btn = button_sizer->GetAffirmativeButton();
@@ -277,8 +279,8 @@ DialogFontsCollector::DialogFontsCollector(agi::Context *c)
 
 	wxSizer *main_sizer = new wxBoxSizer(wxVERTICAL);
 	main_sizer->Add(collection_mode, wxSizerFlags().Expand().Border());
-	main_sizer->Add(destination_box, wxSizerFlags().Expand().Border(wxALL & ~wxTOP));
-	main_sizer->Add(log_box, wxSizerFlags().Border(wxALL & ~wxTOP));
+	main_sizer->Add(destination_sizer, wxSizerFlags().Expand().Border(wxALL & ~wxTOP));
+	main_sizer->Add(log_sizer, wxSizerFlags().Border(wxALL & ~wxTOP));
 	main_sizer->Add(button_sizer, wxSizerFlags().Right().Border(wxALL & ~wxTOP));
 
 	SetSizerAndFit(main_sizer);

--- a/src/dialog_kara_timing_copy.cpp
+++ b/src/dialog_kara_timing_copy.cpp
@@ -51,6 +51,7 @@
 #include <wx/msgdlg.h>
 #include <wx/settings.h>
 #include <wx/sizer.h>
+#include <wx/statbox.h>
 #include <wx/stattext.h>
 #include <wx/string.h>
 
@@ -387,44 +388,49 @@ DialogKanjiTimer::DialogKanjiTimer(agi::Context *c)
 {
 	SetIcons(GETICONS(kara_timing_copier));
 
-	wxSizer *DisplayBoxSizer = new wxStaticBoxSizer(wxVERTICAL,this,_("Text"));
-	wxSizer *StylesBoxSizer = new wxStaticBoxSizer(wxVERTICAL,this,_("Styles"));
+	wxStaticBoxSizer *DisplayBoxSizer = new wxStaticBoxSizer(wxVERTICAL,this,_("Text"));
+	wxStaticBoxSizer *StylesBoxSizer = new wxStaticBoxSizer(wxVERTICAL,this,_("Styles"));
 	auto StylesGridSizer = new wxFlexGridSizer(2, 2, 6, 6);
-	wxSizer *HelpBoxSizer = new wxStaticBoxSizer(wxVERTICAL,this,_("Shortcut Keys"));
-	wxSizer *ButtonsBoxSizer = new wxStaticBoxSizer(wxVERTICAL,this,_("Commands"));
+	wxStaticBoxSizer *HelpBoxSizer = new wxStaticBoxSizer(wxVERTICAL,this,_("Shortcut Keys"));
+	wxStaticBoxSizer *ButtonsBoxSizer = new wxStaticBoxSizer(wxVERTICAL,this,_("Commands"));
 	wxSizer *MainStackSizer = new wxBoxSizer(wxVERTICAL);
 	wxSizer *BottomShelfSizer = new wxBoxSizer(wxHORIZONTAL);
 	wxSizer *BottomLeftStackSizer = new wxBoxSizer(wxVERTICAL);
 
-	display = new KaraokeLineMatchDisplay(this);
+	wxWindow *DisplayBox = DisplayBoxSizer->GetStaticBox();
+	wxWindow *StylesBox = StylesBoxSizer->GetStaticBox();
+	wxWindow *HelpBox = HelpBoxSizer->GetStaticBox();
+	wxWindow *ButtonsBox = ButtonsBoxSizer->GetStaticBox();
+
+	display = new KaraokeLineMatchDisplay(DisplayBox);
 
 	//Checkbox
-	Interpolate = new wxCheckBox(this,-1,_("Attempt to &interpolate kanji."),wxDefaultPosition,wxDefaultSize,wxALIGN_LEFT);
+	Interpolate = new wxCheckBox(DisplayBox,-1,_("Attempt to &interpolate kanji."),wxDefaultPosition,wxDefaultSize,wxALIGN_LEFT);
 	Interpolate->SetValue(OPT_GET("Tool/Kanji Timer/Interpolation")->GetBool());
 
 	wxArrayString styles = to_wx(subs->GetStyles());
-	SourceStyle = new wxComboBox(this, -1, "", wxDefaultPosition, wxSize(160, -1), styles, wxCB_READONLY);
-	DestStyle = new wxComboBox(this, -1, "", wxDefaultPosition, wxSize(160, -1), styles, wxCB_READONLY);
+	SourceStyle = new wxComboBox(StylesBox, -1, "", wxDefaultPosition, wxSize(160, -1), styles, wxCB_READONLY);
+	DestStyle = new wxComboBox(StylesBox, -1, "", wxDefaultPosition, wxSize(160, -1), styles, wxCB_READONLY);
 
-	wxStaticText *ShortcutKeys = new wxStaticText(this,-1,_("When the destination textbox has focus, use the following keys:\n\nRight Arrow: Increase dest. selection length\nLeft Arrow: Decrease dest. selection length\nUp Arrow: Increase source selection length\nDown Arrow: Decrease source selection length\nEnter: Link, accept line when done\nBackspace: Unlink last"));
+	wxStaticText *ShortcutKeys = new wxStaticText(HelpBox,-1,_("When the destination textbox has focus, use the following keys:\n\nRight Arrow: Increase dest. selection length\nLeft Arrow: Decrease dest. selection length\nUp Arrow: Increase source selection length\nDown Arrow: Decrease source selection length\nEnter: Link, accept line when done\nBackspace: Unlink last"));
 
 	//Buttons
-	wxButton *Start = new wxButton(this, -1,_("S&tart!"));
-	wxButton *Link = new wxButton(this, -1,_("&Link"));
-	wxButton *Unlink = new wxButton(this, -1,_("&Unlink"));
-	wxButton *SkipSourceLine = new wxButton(this, -1,_("Skip &Source Line"));
-	wxButton *SkipDestLine = new wxButton(this, -1,_("Skip &Dest Line"));
-	wxButton *GoBackLine = new wxButton(this, -1,_("&Go Back a Line"));
-	wxButton *AcceptLine = new wxButton(this, -1,_("&Accept Line"));
+	wxButton *Start = new wxButton(ButtonsBox, -1,_("S&tart!"));
+	wxButton *Link = new wxButton(ButtonsBox, -1,_("&Link"));
+	wxButton *Unlink = new wxButton(ButtonsBox, -1,_("&Unlink"));
+	wxButton *SkipSourceLine = new wxButton(ButtonsBox, -1,_("Skip &Source Line"));
+	wxButton *SkipDestLine = new wxButton(ButtonsBox, -1,_("Skip &Dest Line"));
+	wxButton *GoBackLine = new wxButton(ButtonsBox, -1,_("&Go Back a Line"));
+	wxButton *AcceptLine = new wxButton(ButtonsBox, -1,_("&Accept Line"));
 	wxButton *CloseKT = new wxButton(this,wxID_CLOSE,_("&Close"));
 
 	//Frame: Text
 	DisplayBoxSizer->Add(display, 0, wxEXPAND|wxALL, 6);
 	DisplayBoxSizer->Add(Interpolate, 0, wxEXPAND|wxALL, 6);
 	//Frame: Styles
-	StylesGridSizer->Add(new wxStaticText(this, -1, TEXT_LABEL_SOURCE), 0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL);
+	StylesGridSizer->Add(new wxStaticText(StylesBox, -1, TEXT_LABEL_SOURCE), 0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL);
 	StylesGridSizer->Add(SourceStyle, 1, wxEXPAND);
-	StylesGridSizer->Add(new wxStaticText(this, -1, TEXT_LABEL_DEST), 0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL);
+	StylesGridSizer->Add(new wxStaticText(StylesBox, -1, TEXT_LABEL_DEST), 0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL);
 	StylesGridSizer->Add(DestStyle, 1, wxEXPAND);
 	StylesBoxSizer->Add(StylesGridSizer, 1, wxEXPAND|wxALL, 6);
 	//Frame: Shortcut Keys

--- a/src/dialog_paste_over.cpp
+++ b/src/dialog_paste_over.cpp
@@ -35,6 +35,7 @@
 #include <wx/dialog.h>
 #include <wx/checklst.h>
 #include <wx/sizer.h>
+#include <wx/statbox.h>
 #include <wx/stattext.h>
 
 namespace {
@@ -55,8 +56,9 @@ DialogPasteOver::DialogPasteOver(wxWindow *parent)
 : d(parent, -1, _("Select Fields to Paste Over"))
 {
 	// Label and list sizer
-	wxSizer *ListSizer = new wxStaticBoxSizer(wxVERTICAL, &d, _("Fields"));
-	ListSizer->Add(new wxStaticText(&d, -1, _("Please select the fields that you want to paste over:")), wxSizerFlags());
+	wxStaticBoxSizer *ListSizer = new wxStaticBoxSizer(wxVERTICAL, &d, _("Fields"));
+	wxWindow *ListSizerBox = ListSizer->GetStaticBox();
+	ListSizer->Add(new wxStaticText(ListSizerBox, -1, _("Please select the fields that you want to paste over:")), wxSizerFlags());
 
 	// List box
 	wxArrayString choices;
@@ -71,7 +73,7 @@ DialogPasteOver::DialogPasteOver(wxWindow *parent)
 	choices.Add(_("Margin Vertical"));
 	choices.Add(_("Effect"));
 	choices.Add(_("Text"));
-	ListBox = new wxCheckListBox(&d, -1, wxDefaultPosition, wxDefaultSize, choices);
+	ListBox = new wxCheckListBox(ListSizerBox, -1, wxDefaultPosition, wxDefaultSize, choices);
 	ListSizer->Add(ListBox, wxSizerFlags(0).Expand().Border(wxTOP));
 
 	std::vector<bool> options = OPT_GET("Tool/Paste Lines Over/Fields")->GetListBool();

--- a/src/dialog_resample.cpp
+++ b/src/dialog_resample.cpp
@@ -110,25 +110,34 @@ DialogResample::DialogResample(agi::Context *c, ResampleSettings &settings)
 		video_mat = YCbCrMatrix::rgb;
 	}
 
+	// Create static box sizers
+	auto source_res_box_sizer = new wxStaticBoxSizer(wxVERTICAL, &d, _("Source Resolution"));
+	auto dest_res_box_sizer = new wxStaticBoxSizer(wxVERTICAL, &d, _("Destination Resolution"));
+	auto margin_box_sizer = new wxStaticBoxSizer(wxVERTICAL, &d, _("Margin offset"));
+
+	wxWindow *source_res_box = source_res_box_sizer->GetStaticBox();
+	wxWindow *dest_res_box = dest_res_box_sizer->GetStaticBox();
+	wxWindow *margin_box = margin_box_sizer->GetStaticBox();
+
 	// Create all controls and set validators
 	for (size_t i = 0; i < 4; ++i) {
-		margin_ctrl[i] = new wxSpinCtrl(&d, -1, "0", wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, -9999, 9999, 0);
+		margin_ctrl[i] = new wxSpinCtrl(margin_box, -1, "0", wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, -9999, 9999, 0);
 		margin_ctrl[i]->SetValidator(wxGenericValidator(&settings.margin[i]));
 	}
 
-	symmetrical = new wxCheckBox(&d, -1, _("&Symmetrical"));
+	symmetrical = new wxCheckBox(margin_box, -1, _("&Symmetrical"));
 	symmetrical->SetValue(true);
 
 	margin_ctrl[RIGHT]->Enable(false);
 	margin_ctrl[BOTTOM]->Enable(false);
 
-	source_x = new wxSpinCtrl(&d, -1, "", wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, 999999);
-	source_y = new wxSpinCtrl(&d, -1, "", wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, 999999);
-	source_matrix = new wxComboBox(&d, -1, "", wxDefaultPosition,
+	source_x = new wxSpinCtrl(source_res_box, -1, "", wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, 999999);
+	source_y = new wxSpinCtrl(source_res_box, -1, "", wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, 999999);
+	source_matrix = new wxComboBox(source_res_box, -1, "", wxDefaultPosition,
 		wxDefaultSize, to_wx(MatrixNames()), wxCB_READONLY);
-	dest_x = new wxSpinCtrl(&d, -1, "", wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, 999999);
-	dest_y = new wxSpinCtrl(&d, -1, "", wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, 999999);
-	dest_matrix = new wxComboBox(&d, -1, "", wxDefaultPosition, wxDefaultSize,
+	dest_x = new wxSpinCtrl(dest_res_box, -1, "", wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, 999999);
+	dest_y = new wxSpinCtrl(dest_res_box, -1, "", wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, 999999);
+	dest_matrix = new wxComboBox(dest_res_box, -1, "", wxDefaultPosition, wxDefaultSize,
 		to_wx(MatrixNames()), wxCB_READONLY);
 
 	source_x->SetValidator(wxGenericValidator(&settings.source_x));
@@ -138,9 +147,9 @@ DialogResample::DialogResample(agi::Context *c, ResampleSettings &settings)
 	dest_y->SetValidator(wxGenericValidator(&settings.dest_y));
 	dest_matrix->SetValidator(MakeEnumBinder(&settings.dest_matrix));
 
-	from_video = new wxButton(&d, -1, _("From &video"));
+	from_video = new wxButton(dest_res_box, -1, _("From &video"));
 	from_video->Enable(false);
-	from_script = new wxButton(&d, -1, _("From s&cript"));
+	from_script = new wxButton(source_res_box, -1, _("From s&cript"));
 	from_script->Enable(false);
 
 	wxString ar_modes[] = {_("Stretch"), _("Add borders"), _("Remove borders"), _("Manual")};
@@ -159,42 +168,39 @@ DialogResample::DialogResample(agi::Context *c, ResampleSettings &settings)
 	margin_sizer->Add(margin_ctrl[BOTTOM], wxSizerFlags(1).Expand());
 	margin_sizer->AddSpacer(1);
 
-	auto margin_box = new wxStaticBoxSizer(wxVERTICAL, &d, _("Margin offset"));
-	margin_box->Add(margin_sizer, wxSizerFlags(1).Expand().Border(wxBOTTOM));
+	margin_box_sizer->Add(margin_sizer, wxSizerFlags(1).Expand().Border(wxBOTTOM));
 
 	auto source_res_sizer = new wxBoxSizer(wxHORIZONTAL);
 	source_res_sizer->Add(source_x, wxSizerFlags(1).Border(wxRIGHT).Align(wxALIGN_CENTER_VERTICAL));
-	source_res_sizer->Add(new wxStaticText(&d, -1, _(L"\u00D7")), wxSizerFlags().Center().Border(wxRIGHT)); // U+00D7 multiplication sign
+	source_res_sizer->Add(new wxStaticText(source_res_box, -1, _(L"\u00D7")), wxSizerFlags().Center().Border(wxRIGHT)); // U+00D7 multiplication sign
 	source_res_sizer->Add(source_y, wxSizerFlags(1).Border(wxRIGHT).Align(wxALIGN_CENTER_VERTICAL));
 	source_res_sizer->Add(from_script);
 
 	auto source_matrix_sizer = new wxBoxSizer(wxHORIZONTAL);
-	source_matrix_sizer->Add(new wxStaticText(&d, -1, _("YCbCr Matrix:")), wxSizerFlags().Border(wxRIGHT).Center());
+	source_matrix_sizer->Add(new wxStaticText(source_res_box, -1, _("YCbCr Matrix:")), wxSizerFlags().Border(wxRIGHT).Center());
 	source_matrix_sizer->Add(source_matrix, wxSizerFlags(1).Center());
 
-	auto source_res_box = new wxStaticBoxSizer(wxVERTICAL, &d, _("Source Resolution"));
-	source_res_box->Add(source_res_sizer, wxSizerFlags(1).Expand().Border(wxBOTTOM));
-	source_res_box->Add(source_matrix_sizer, wxSizerFlags(1).Expand());
+	source_res_box_sizer->Add(source_res_sizer, wxSizerFlags(1).Expand().Border(wxBOTTOM));
+	source_res_box_sizer->Add(source_matrix_sizer, wxSizerFlags(1).Expand());
 
 	auto dest_res_sizer = new wxBoxSizer(wxHORIZONTAL);
 	dest_res_sizer->Add(dest_x, wxSizerFlags(1).Border(wxRIGHT).Align(wxALIGN_CENTER_VERTICAL));
-	dest_res_sizer->Add(new wxStaticText(&d, -1, _(L"\u00D7")), wxSizerFlags().Center().Border(wxRIGHT));
+	dest_res_sizer->Add(new wxStaticText(dest_res_box, -1, _(L"\u00D7")), wxSizerFlags().Center().Border(wxRIGHT));
 	dest_res_sizer->Add(dest_y, wxSizerFlags(1).Border(wxRIGHT).Align(wxALIGN_CENTER_VERTICAL));
 	dest_res_sizer->Add(from_video);
 
 	auto dest_matrix_sizer = new wxBoxSizer(wxHORIZONTAL);
-	dest_matrix_sizer->Add(new wxStaticText(&d, -1, _("YCbCr Matrix:")), wxSizerFlags().Border(wxRIGHT).Center());
+	dest_matrix_sizer->Add(new wxStaticText(dest_res_box, -1, _("YCbCr Matrix:")), wxSizerFlags().Border(wxRIGHT).Center());
 	dest_matrix_sizer->Add(dest_matrix, wxSizerFlags(1).Center());
 
-	auto dest_res_box = new wxStaticBoxSizer(wxVERTICAL, &d, _("Destination Resolution"));
-	dest_res_box->Add(dest_res_sizer, wxSizerFlags(1).Expand().Border(wxBOTTOM));
-	dest_res_box->Add(dest_matrix_sizer, wxSizerFlags(1).Expand());
+	dest_res_box_sizer->Add(dest_res_sizer, wxSizerFlags(1).Expand().Border(wxBOTTOM));
+	dest_res_box_sizer->Add(dest_matrix_sizer, wxSizerFlags(1).Expand());
 
 	auto main_sizer = new wxBoxSizer(wxVERTICAL);
-	main_sizer->Add(source_res_box, wxSizerFlags().Expand().Border());
-	main_sizer->Add(dest_res_box, wxSizerFlags().Expand().Border());
+	main_sizer->Add(source_res_box_sizer, wxSizerFlags().Expand().Border());
+	main_sizer->Add(dest_res_box_sizer, wxSizerFlags().Expand().Border());
 	main_sizer->Add(ar_mode, wxSizerFlags().Expand().Border());
-	main_sizer->Add(margin_box, wxSizerFlags(1).Expand().Border());
+	main_sizer->Add(margin_box_sizer, wxSizerFlags(1).Expand().Border());
 	main_sizer->Add(d.CreateStdDialogButtonSizer(wxOK | wxCANCEL | wxHELP), wxSizerFlags().Expand().Border(wxALL & ~wxTOP));
 	d.SetSizerAndFit(main_sizer);
 	d.CenterOnParent();

--- a/src/dialog_selection.cpp
+++ b/src/dialog_selection.cpp
@@ -36,6 +36,7 @@
 #include <wx/radiobox.h>
 #include <wx/radiobut.h>
 #include <wx/sizer.h>
+#include <wx/statbox.h>
 #include <wx/textctrl.h>
 
 namespace {
@@ -114,16 +115,17 @@ wxDialog (c->parent, -1, _("Select"), wxDefaultPosition, wxDefaultSize, wxCAPTIO
 
 	wxRadioButton *select_matching_lines = nullptr;
 	{
-		wxSizer *match_sizer = new wxStaticBoxSizer(wxVERTICAL, this, _("Match"));
+		wxStaticBoxSizer *match_sizer = new wxStaticBoxSizer(wxVERTICAL, this, _("Match"));
+		wxWindow *match_sizer_box = match_sizer->GetStaticBox();
 		{
 			wxSizerFlags radio_flags = wxSizerFlags().Border(wxLEFT | wxRIGHT);
 			wxSizer *match_radio_line = new wxBoxSizer(wxHORIZONTAL);
-			match_radio_line->Add(select_matching_lines = new wxRadioButton(this, -1, _("&Matches"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP), radio_flags);
-			match_radio_line->Add(select_unmatching_lines = new wxRadioButton(this, -1, _("&Doesn't Match")), radio_flags);
-			match_radio_line->Add(case_sensitive = new wxCheckBox(this, -1, _("Match c&ase")), radio_flags);
+			match_radio_line->Add(select_matching_lines = new wxRadioButton(match_sizer_box, -1, _("&Matches"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP), radio_flags);
+			match_radio_line->Add(select_unmatching_lines = new wxRadioButton(match_sizer_box, -1, _("&Doesn't Match")), radio_flags);
+			match_radio_line->Add(case_sensitive = new wxCheckBox(match_sizer_box, -1, _("Match c&ase")), radio_flags);
 			match_sizer->Add(match_radio_line);
 		}
-		match_sizer->Add(match_text = new wxTextCtrl(this, -1, to_wx(OPT_GET("Tool/Select Lines/Text")->GetString())), main_flags);
+		match_sizer->Add(match_text = new wxTextCtrl(match_sizer_box, -1, to_wx(OPT_GET("Tool/Select Lines/Text")->GetString())), main_flags);
 
 		main_sizer->Add(match_sizer, main_flags);
 	}
@@ -139,9 +141,10 @@ wxDialog (c->parent, -1, _("Select"), wxDefaultPosition, wxDefaultSize, wxCAPTIO
 	}
 
 	{
-		wxSizer *comment_sizer = new wxStaticBoxSizer(wxHORIZONTAL, this, _("Match dialogues/comments"));
-		comment_sizer->Add(apply_to_dialogue = new wxCheckBox(this, -1, _("D&ialogues")), wxSizerFlags().Border());
-		comment_sizer->Add(apply_to_comments = new wxCheckBox(this, -1, _("Comme&nts")), wxSizerFlags().Border());
+		wxStaticBoxSizer *comment_sizer = new wxStaticBoxSizer(wxHORIZONTAL, this, _("Match dialogues/comments"));
+		wxWindow *comment_sizer_box = comment_sizer->GetStaticBox();
+		comment_sizer->Add(apply_to_dialogue = new wxCheckBox(comment_sizer_box, -1, _("D&ialogues")), wxSizerFlags().Border());
+		comment_sizer->Add(apply_to_comments = new wxCheckBox(comment_sizer_box, -1, _("Comme&nts")), wxSizerFlags().Border());
 		main_sizer->Add(comment_sizer, main_flags);
 	}
 

--- a/src/dialog_shift_times.cpp
+++ b/src/dialog_shift_times.cpp
@@ -45,6 +45,7 @@
 #include <wx/radiobox.h>
 #include <wx/radiobut.h>
 #include <wx/sizer.h>
+#include <wx/statbox.h>
 #include <wx/textctrl.h>
 
 namespace {
@@ -139,25 +140,31 @@ DialogShiftTimes::DialogShiftTimes(agi::Context *context)
 {
 	SetIcons(GETICONS(shift_times_toolbutton));
 
+	// Create static box sizers
+	wxStaticBoxSizer *shift_by_sizer = new wxStaticBoxSizer(wxVERTICAL, this, _("Shift by"));
+	wxStaticBoxSizer *history_sizer = new wxStaticBoxSizer(wxVERTICAL, this, _("Load from history"));
+	wxWindow *shift_by_static_box = shift_by_sizer->GetStaticBox();
+	wxWindow *history_static_box = history_sizer->GetStaticBox();
+
 	// Create controls
-	shift_by_time = new wxRadioButton(this, -1, _("&Time: "), wxDefaultPosition, wxDefaultSize, wxRB_GROUP);
+	shift_by_time = new wxRadioButton(shift_by_static_box, -1, _("&Time: "), wxDefaultPosition, wxDefaultSize, wxRB_GROUP);
 	shift_by_time->SetToolTip(_("Shift by time"));
 	shift_by_time->Bind(wxEVT_RADIOBUTTON, &DialogShiftTimes::OnByTime, this);
 
-	shift_by_frames = new wxRadioButton(this, -1 , _("&Frames: "));
+	shift_by_frames = new wxRadioButton(shift_by_static_box, -1 , _("&Frames: "));
 	shift_by_frames->SetToolTip(_("Shift by frames"));
 	shift_by_frames->Bind(wxEVT_RADIOBUTTON, &DialogShiftTimes::OnByFrames, this);
 
-	shift_time = new TimeEdit(this, -1, context);
+	shift_time = new TimeEdit(shift_by_static_box, -1, context);
 	shift_time->SetToolTip(_("Enter time in h:mm:ss.cs notation"));
 
-	shift_frames = new wxTextCtrl(this, -1);
+	shift_frames = new wxTextCtrl(shift_by_static_box, -1);
 	shift_frames->SetToolTip(_("Enter number of frames to shift by"));
 
-	shift_forward = new wxRadioButton(this, -1, _("For&ward"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP);
+	shift_forward = new wxRadioButton(shift_by_static_box, -1, _("For&ward"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP);
 	shift_forward->SetToolTip(_("Shifts subs forward, making them appear later. Use if they are appearing too soon."));
 
-	shift_backward = new wxRadioButton(this, -1, _("&Backward"));
+	shift_backward = new wxRadioButton(shift_by_static_box, -1, _("&Backward"));
 	shift_backward->SetToolTip(_("Shifts subs backward, making them appear earlier. Use if they are appearing too late."));
 
 	wxString selection_mode_vals[] = { _("&All rows"), _("Selected &rows"), _("Selection &onward") };
@@ -166,9 +173,9 @@ DialogShiftTimes::DialogShiftTimes(agi::Context *context)
 	wxString time_field_vals[] = { _("Start a&nd End times"), _("&Start times only"), _("&End times only") };
 	time_fields = new wxRadioBox(this, -1, _("Times"), wxDefaultPosition, wxDefaultSize, 3, time_field_vals, 1);
 
-	history_box = new wxListBox(this, -1, wxDefaultPosition, wxSize(350, 100), 0, nullptr, wxLB_HSCROLL);
+	history_box = new wxListBox(history_static_box, -1, wxDefaultPosition, wxSize(350, 100), 0, nullptr, wxLB_HSCROLL);
 
-	wxButton *clear_button = new wxButton(this, -1, _("&Clear"));
+	wxButton *clear_button = new wxButton(history_static_box, -1, _("&Clear"));
 	clear_button->Bind(wxEVT_BUTTON, &DialogShiftTimes::OnClear, this);
 
 	// Set initial control states
@@ -200,7 +207,6 @@ DialogShiftTimes::DialogShiftTimes(agi::Context *context)
 	shift_direction_sizer->Add(shift_forward, wxSizerFlags(1).Expand());
 	shift_direction_sizer->Add(shift_backward, wxSizerFlags(1).Expand().Border(wxLEFT));
 
-	wxSizer *shift_by_sizer = new wxStaticBoxSizer(wxVERTICAL, this, _("Shift by"));
 	shift_by_sizer->Add(shift_amount_sizer, wxSizerFlags().Expand());
 	shift_by_sizer->Add(shift_direction_sizer, wxSizerFlags().Expand().Border(wxTOP));
 
@@ -209,7 +215,6 @@ DialogShiftTimes::DialogShiftTimes(agi::Context *context)
 	left_sizer->Add(selection_mode, wxSizerFlags().Expand().Border(wxBOTTOM));
 	left_sizer->Add(time_fields, wxSizerFlags().Expand());
 
-	wxSizer *history_sizer = new wxStaticBoxSizer(wxVERTICAL, this, _("Load from history"));
 	history_sizer->Add(history_box, wxSizerFlags(1).Expand());
 	history_sizer->Add(clear_button, wxSizerFlags().Expand().Border(wxTOP));
 

--- a/src/dialog_style_manager.cpp
+++ b/src/dialog_style_manager.cpp
@@ -69,6 +69,7 @@
 #include <wx/radiobox.h>
 #include <wx/sizer.h>
 #include <wx/spinctrl.h>
+#include <wx/statbox.h>
 #include <wx/textctrl.h>
 #include <wx/textdlg.h>
 #include <wx/choicdlg.h> // Keep this last so wxUSE_CHOICEDLG is set.
@@ -268,45 +269,51 @@ DialogStyleManager::DialogStyleManager(agi::Context *context)
 	using std::bind;
 	SetIcons(GETICONS(style_toolbutton));
 
+	// Static box sizers
+	wxStaticBoxSizer *CatalogSizer = new wxStaticBoxSizer(wxHORIZONTAL,this,_("Catalog of available storages"));
+	wxStaticBoxSizer *StorageSizer = new wxStaticBoxSizer(wxVERTICAL, this, _("Storage"));
+	wxStaticBoxSizer *CurrentSizer = new wxStaticBoxSizer(wxVERTICAL, this, _("Current script"));
+
+	wxWindow *CatalogSizerBox = CatalogSizer->GetStaticBox();
+	wxWindow *StorageSizerBox = StorageSizer->GetStaticBox();
+	wxWindow *CurrentSizerBox = CurrentSizer->GetStaticBox();
+
 	// Catalog
-	wxSizer *CatalogBox = new wxStaticBoxSizer(wxHORIZONTAL,this,_("Catalog of available storages"));
-	CatalogList = new wxComboBox(this,-1, "", wxDefaultPosition, wxSize(-1,-1), 0, nullptr, wxCB_READONLY);
-	wxButton *CatalogNew = new wxButton(this, -1, _("New"));
-	CatalogDelete = new wxButton(this, -1, _("Delete"));
-	CatalogBox->Add(CatalogList,1,wxEXPAND | wxRIGHT,5);
-	CatalogBox->Add(CatalogNew,0,wxRIGHT,5);
-	CatalogBox->Add(CatalogDelete,0,0,0);
+	CatalogList = new wxComboBox(CatalogSizerBox,-1, "", wxDefaultPosition, wxSize(-1,-1), 0, nullptr, wxCB_READONLY);
+	wxButton *CatalogNew = new wxButton(CatalogSizerBox, -1, _("New"));
+	CatalogDelete = new wxButton(CatalogSizerBox, -1, _("Delete"));
+	CatalogSizer->Add(CatalogList,1,wxEXPAND | wxRIGHT,5);
+	CatalogSizer->Add(CatalogNew,0,wxRIGHT,5);
+	CatalogSizer->Add(CatalogDelete,0,0,0);
 
 	// Storage styles list
-	wxSizer *StorageButtons = make_edit_buttons(this, _("Copy to &current script ->"), &MoveToLocal, &StorageNew, &StorageEdit, &StorageCopy, &StorageDelete);
+	wxSizer *StorageButtons = make_edit_buttons(StorageSizerBox, _("Copy to &current script ->"), &MoveToLocal, &StorageNew, &StorageEdit, &StorageCopy, &StorageDelete);
 
 	wxSizer *StorageListSizer = new wxBoxSizer(wxHORIZONTAL);
-	StorageList = new wxListBox(this, -1, wxDefaultPosition, wxSize(240,250), 0, nullptr, wxLB_EXTENDED);
+	StorageList = new wxListBox(StorageSizerBox, -1, wxDefaultPosition, wxSize(240,250), 0, nullptr, wxLB_EXTENDED);
 	StorageListSizer->Add(StorageList,1,wxEXPAND | wxRIGHT,0);
-	StorageListSizer->Add(make_move_buttons(this, &StorageMoveUp, &StorageMoveDown, &StorageMoveTop, &StorageMoveBottom, &StorageSort), wxSizerFlags().Expand());
+	StorageListSizer->Add(make_move_buttons(StorageSizerBox, &StorageMoveUp, &StorageMoveDown, &StorageMoveTop, &StorageMoveBottom, &StorageSort), wxSizerFlags().Expand());
 
-	wxSizer *StorageBox = new wxStaticBoxSizer(wxVERTICAL, this, _("Storage"));
-	StorageBox->Add(StorageListSizer,1,wxEXPAND | wxBOTTOM,5);
-	StorageBox->Add(MoveToLocal,0,wxEXPAND | wxBOTTOM,5);
-	StorageBox->Add(StorageButtons,0,wxEXPAND | wxBOTTOM,0);
+	StorageSizer->Add(StorageListSizer,1,wxEXPAND | wxBOTTOM,5);
+	StorageSizer->Add(MoveToLocal,0,wxEXPAND | wxBOTTOM,5);
+	StorageSizer->Add(StorageButtons,0,wxEXPAND | wxBOTTOM,0);
 
 	// Local styles list
-	wxButton *CurrentImport = new wxButton(this, -1, _("&Import from script..."));
-	wxSizer *CurrentButtons = make_edit_buttons(this, _("<- Copy to &storage"), &MoveToStorage, &CurrentNew, &CurrentEdit, &CurrentCopy, &CurrentDelete);
+	wxButton *CurrentImport = new wxButton(CurrentSizerBox, -1, _("&Import from script..."));
+	wxSizer *CurrentButtons = make_edit_buttons(CurrentSizerBox, _("<- Copy to &storage"), &MoveToStorage, &CurrentNew, &CurrentEdit, &CurrentCopy, &CurrentDelete);
 
 	wxSizer *MoveImportSizer = new wxBoxSizer(wxHORIZONTAL);
 	MoveImportSizer->Add(MoveToStorage,1,wxEXPAND | wxRIGHT,5);
 	MoveImportSizer->Add(CurrentImport,1,wxEXPAND,0);
 
 	wxSizer *CurrentListSizer = new wxBoxSizer(wxHORIZONTAL);
-	CurrentList = new wxListBox(this, -1, wxDefaultPosition, wxSize(240,250), 0, nullptr, wxLB_EXTENDED);
+	CurrentList = new wxListBox(CurrentSizerBox, -1, wxDefaultPosition, wxSize(240,250), 0, nullptr, wxLB_EXTENDED);
 	CurrentListSizer->Add(CurrentList,1,wxEXPAND | wxRIGHT,0);
-	CurrentListSizer->Add(make_move_buttons(this, &CurrentMoveUp, &CurrentMoveDown, &CurrentMoveTop, &CurrentMoveBottom, &CurrentSort), wxSizerFlags().Expand());
+	CurrentListSizer->Add(make_move_buttons(CurrentSizerBox, &CurrentMoveUp, &CurrentMoveDown, &CurrentMoveTop, &CurrentMoveBottom, &CurrentSort), wxSizerFlags().Expand());
 
-	wxSizer *CurrentBox = new wxStaticBoxSizer(wxVERTICAL, this, _("Current script"));
-	CurrentBox->Add(CurrentListSizer,1,wxEXPAND | wxBOTTOM,5);
-	CurrentBox->Add(MoveImportSizer,0,wxEXPAND | wxBOTTOM,5);
-	CurrentBox->Add(CurrentButtons,0,wxEXPAND | wxBOTTOM,0);
+	CurrentSizer->Add(CurrentListSizer,1,wxEXPAND | wxBOTTOM,5);
+	CurrentSizer->Add(MoveImportSizer,0,wxEXPAND | wxBOTTOM,5);
+	CurrentSizer->Add(CurrentButtons,0,wxEXPAND | wxBOTTOM,0);
 
 	// Buttons
 	wxStdDialogButtonSizer *buttonSizer = CreateStdDialogButtonSizer(wxCANCEL | wxHELP);
@@ -315,10 +322,10 @@ DialogStyleManager::DialogStyleManager(agi::Context *context)
 
 	// General layout
 	wxSizer *StylesSizer = new wxBoxSizer(wxHORIZONTAL);
-	StylesSizer->Add(StorageBox,0,wxRIGHT | wxEXPAND,5);
-	StylesSizer->Add(CurrentBox,0,wxLEFT | wxEXPAND,0);
+	StylesSizer->Add(StorageSizer,0,wxRIGHT | wxEXPAND,5);
+	StylesSizer->Add(CurrentSizer,0,wxLEFT | wxEXPAND,0);
 	wxSizer *MainSizer = new wxBoxSizer(wxVERTICAL);
-	MainSizer->Add(CatalogBox,0,wxEXPAND | wxLEFT | wxRIGHT | wxTOP,5);
+	MainSizer->Add(CatalogSizer,0,wxEXPAND | wxLEFT | wxRIGHT | wxTOP,5);
 	MainSizer->Add(StylesSizer,1,wxEXPAND | wxALL,5);
 	MainSizer->Add(buttonSizer,0,wxBOTTOM | wxEXPAND,5);
 

--- a/src/dialog_styling_assistant.cpp
+++ b/src/dialog_styling_assistant.cpp
@@ -41,6 +41,7 @@
 #include <wx/listbox.h>
 #include <wx/settings.h>
 #include <wx/sizer.h>
+#include <wx/statbox.h>
 #include <wx/stattext.h>
 #include <wx/textctrl.h>
 
@@ -60,59 +61,60 @@ DialogStyling::DialogStyling(agi::Context *context)
 	wxSizer *bottom_sizer = new wxBoxSizer(wxHORIZONTAL);
 
 	{
-		wxSizer *cur_line_box = new wxStaticBoxSizer(wxHORIZONTAL, this, _("Current line"));
-		current_line_text = new wxTextCtrl(this, -1, _("Current line"), wxDefaultPosition, wxSize(300, 60), wxTE_MULTILINE | wxTE_READONLY);
+		wxStaticBoxSizer *cur_line_box = new wxStaticBoxSizer(wxHORIZONTAL, this, _("Current line"));
+		current_line_text = new wxTextCtrl(cur_line_box->GetStaticBox(), -1, _("Current line"), wxDefaultPosition, wxSize(300, 60), wxTE_MULTILINE | wxTE_READONLY);
 		cur_line_box->Add(current_line_text, 1, wxEXPAND, 0);
 		main_sizer->Add(cur_line_box, 0, wxEXPAND | wxALL, 5);
 	}
 
 	{
-		wxSizer *styles_box = new wxStaticBoxSizer(wxVERTICAL, this, _("Styles available"));
-		style_list = new wxListBox(this, -1, wxDefaultPosition, wxSize(150, 180), to_wx(context->ass->GetStyles()));
+		wxStaticBoxSizer *styles_box = new wxStaticBoxSizer(wxVERTICAL, this, _("Styles available"));
+		style_list = new wxListBox(styles_box->GetStaticBox(), -1, wxDefaultPosition, wxSize(150, 180), to_wx(context->ass->GetStyles()));
 		styles_box->Add(style_list, 1, wxEXPAND, 0);
 		bottom_sizer->Add(styles_box, 1, wxEXPAND | wxRIGHT, 5);
 	}
 
 	wxSizer *right_sizer = new wxBoxSizer(wxVERTICAL);
 	{
-		wxSizer *style_text_box = new wxStaticBoxSizer(wxHORIZONTAL, this, _("Set style"));
-		style_name = new wxTextCtrl(this, -1, "", wxDefaultPosition, wxSize(180, -1), wxTE_PROCESS_ENTER);
+		wxStaticBoxSizer *style_text_box = new wxStaticBoxSizer(wxHORIZONTAL, this, _("Set style"));
+		style_name = new wxTextCtrl(style_text_box->GetStaticBox(), -1, "", wxDefaultPosition, wxSize(180, -1), wxTE_PROCESS_ENTER);
 		style_text_box->Add(style_name, 1, wxEXPAND);
 		right_sizer->Add(style_text_box, 0, wxEXPAND | wxBOTTOM, 5);
 	}
 
 	{
-		wxSizer *hotkey_box = new wxStaticBoxSizer(wxVERTICAL, this, _("Keys"));
+		wxStaticBoxSizer *hotkey_sizer = new wxStaticBoxSizer(wxVERTICAL, this, _("Keys"));
+		wxWindow *hotkey_sizer_box = hotkey_sizer->GetStaticBox();
 
 		wxSizer *hotkey_grid = new wxGridSizer(2, 0, 5);
-		add_hotkey(hotkey_grid, this, "tool/styling_assistant/commit", _("Accept changes"));
-		add_hotkey(hotkey_grid, this, "tool/styling_assistant/preview", _("Preview changes"));
-		add_hotkey(hotkey_grid, this, "grid/line/prev", _("Previous line"));
-		add_hotkey(hotkey_grid, this, "grid/line/next", _("Next line"));
-		add_hotkey(hotkey_grid, this, "video/play/line", _("Play video"));
-		add_hotkey(hotkey_grid, this, "audio/play/selection", _("Play audio"));
-		hotkey_grid->Add(new wxStaticText(this, -1, _("Click on list")));
-		hotkey_grid->Add(new wxStaticText(this, -1, _("Select style")));
+		add_hotkey(hotkey_grid, hotkey_sizer_box, "tool/styling_assistant/commit", _("Accept changes"));
+		add_hotkey(hotkey_grid, hotkey_sizer_box, "tool/styling_assistant/preview", _("Preview changes"));
+		add_hotkey(hotkey_grid, hotkey_sizer_box, "grid/line/prev", _("Previous line"));
+		add_hotkey(hotkey_grid, hotkey_sizer_box, "grid/line/next", _("Next line"));
+		add_hotkey(hotkey_grid, hotkey_sizer_box, "video/play/line", _("Play video"));
+		add_hotkey(hotkey_grid, hotkey_sizer_box, "audio/play/selection", _("Play audio"));
+		hotkey_grid->Add(new wxStaticText(hotkey_sizer_box, -1, _("Click on list")));
+		hotkey_grid->Add(new wxStaticText(hotkey_sizer_box, -1, _("Select style")));
 
-		hotkey_box->Add(hotkey_grid, 0, wxEXPAND | wxBOTTOM, 5);
+		hotkey_sizer->Add(hotkey_grid, 0, wxEXPAND | wxBOTTOM, 5);
 
-		auto_seek = new wxCheckBox(this, -1, _("&Seek video to line start time"));
+		auto_seek = new wxCheckBox(hotkey_sizer_box, -1, _("&Seek video to line start time"));
 		auto_seek->SetValue(true);
-		hotkey_box->Add(auto_seek, 0, 0, 0);
-		hotkey_box->AddStretchSpacer(1);
+		hotkey_sizer->Add(auto_seek, 0, 0, 0);
+		hotkey_sizer->AddStretchSpacer(1);
 
-		right_sizer->Add(hotkey_box, 0, wxEXPAND | wxBOTTOM, 5);
+		right_sizer->Add(hotkey_sizer, 0, wxEXPAND | wxBOTTOM, 5);
 	}
 
 	{
-		wxSizer *actions_box = new wxStaticBoxSizer(wxHORIZONTAL, this, _("Actions"));
+		wxStaticBoxSizer *actions_box = new wxStaticBoxSizer(wxHORIZONTAL, this, _("Actions"));
 		actions_box->AddStretchSpacer(1);
 
-		play_audio = new wxButton(this, -1, _("Play &Audio"));
+		play_audio = new wxButton(actions_box->GetStaticBox(), -1, _("Play &Audio"));
 		play_audio->Enable(!!c->project->AudioProvider());
 		actions_box->Add(play_audio, 0, wxLEFT | wxRIGHT | wxBOTTOM, 5);
 
-		play_video = new wxButton(this, -1, _("Play &Video"));
+		play_video = new wxButton(actions_box->GetStaticBox(), -1, _("Play &Video"));
 		play_video->Enable(!!c->project->VideoProvider());
 		actions_box->Add(play_video, 0, wxBOTTOM | wxRIGHT, 5);
 

--- a/src/dialog_timing_processor.cpp
+++ b/src/dialog_timing_processor.cpp
@@ -124,11 +124,11 @@ wxTextCtrl *make_ctrl(wxWindow *parent, wxSizer *sizer, wxString const& desc, in
 }
 
 inline wxTextCtrl *make_ctrl(wxStaticBoxSizer *sizer, wxString const& desc, int *value, wxCheckBox *cb, wxString const& tooltip) {
-	return make_ctrl(sizer->GetStaticBox()->GetParent(), sizer, desc, value, cb, tooltip);
+	return make_ctrl(sizer->GetStaticBox(), sizer, desc, value, cb, tooltip);
 }
 
 wxCheckBox *make_check(wxStaticBoxSizer *sizer, wxString const& desc, const char *opt, wxString const& tooltip) {
-	wxCheckBox *cb = new wxCheckBox(sizer->GetStaticBox()->GetParent(), -1, desc);
+	wxCheckBox *cb = new wxCheckBox(sizer->GetStaticBox(), -1, desc);
 	cb->SetToolTip(tooltip);
 	cb->SetValue(OPT_GET(opt)->GetBool());
 	sizer->Add(cb, wxSizerFlags().Border(wxRIGHT).Expand());
@@ -155,18 +155,19 @@ DialogTimingProcessor::DialogTimingProcessor(agi::Context *c)
 
 	// Styles box
 	auto LeftSizer = new wxStaticBoxSizer(wxVERTICAL,&d,_("Apply to styles"));
-	StyleList = new wxCheckListBox(&d, -1, wxDefaultPosition, wxSize(150,150), to_wx(c->ass->GetStyles()));
+	wxWindow *LeftSizerBox = LeftSizer->GetStaticBox();
+	StyleList = new wxCheckListBox(LeftSizerBox, -1, wxDefaultPosition, wxSize(150,150), to_wx(c->ass->GetStyles()));
 	StyleList->SetToolTip(_("Select styles to process. Unchecked ones will be ignored."));
 
-	auto all = new wxButton(&d,-1,_("&All"));
+	auto all = new wxButton(LeftSizerBox,-1,_("&All"));
 	all->SetToolTip(_("Select all styles"));
 
-	auto none = new wxButton(&d,-1,_("&None"));
+	auto none = new wxButton(LeftSizerBox,-1,_("&None"));
 	none->SetToolTip(_("Deselect all styles"));
 
 	// Options box
 	auto optionsSizer = new wxStaticBoxSizer(wxHORIZONTAL,&d,_("Options"));
-	onlySelection = new wxCheckBox(&d,-1,_("Affect &selection only"));
+	onlySelection = new wxCheckBox(optionsSizer->GetStaticBox(),-1,_("Affect &selection only"));
 	onlySelection->SetValue(OPT_GET("Tool/Timing Post Processor/Only Selection")->GetBool());
 	optionsSizer->Add(onlySelection,1,wxALL,0);
 
@@ -187,23 +188,24 @@ DialogTimingProcessor::DialogTimingProcessor(agi::Context *c)
 
 	// Adjacent subs sizer
 	auto AdjacentSizer = new wxStaticBoxSizer(wxHORIZONTAL, &d, _("Make adjacent subtitles continuous"));
+	wxWindow *AdjacentSizerBox = AdjacentSizer->GetStaticBox();
 	adjsEnable = make_check(AdjacentSizer, _("&Enable"),
 		"Tool/Timing Post Processor/Enable/Adjacent",
 		_("Enable snapping of subtitles together if they are within a certain distance of each other"));
 
 	auto adjBoxes = new wxBoxSizer(wxHORIZONTAL);
-	make_ctrl(&d, adjBoxes, _("Max gap:"), &adjGap, adjsEnable,
+	make_ctrl(AdjacentSizerBox, adjBoxes, _("Max gap:"), &adjGap, adjsEnable,
 		_("Maximum difference between start and end time for two subtitles to be made continuous, in milliseconds"));
-	make_ctrl(&d, adjBoxes, _("Max overlap:"), &adjOverlap, adjsEnable,
+	make_ctrl(AdjacentSizerBox, adjBoxes, _("Max overlap:"), &adjOverlap, adjsEnable,
 		_("Maximum overlap between the end and start time for two subtitles to be made continuous, in milliseconds"));
 
-	adjacentBias = new wxSlider(&d, -1, mid<int>(0, OPT_GET("Tool/Timing Post Processor/Adjacent Bias")->GetDouble() * 100, 100), 0, 100);
+	adjacentBias = new wxSlider(AdjacentSizerBox, -1, mid<int>(0, OPT_GET("Tool/Timing Post Processor/Adjacent Bias")->GetDouble() * 100, 100), 0, 100);
 	adjacentBias->SetToolTip(_("Sets how to set the adjoining of lines. If set totally to left, it will extend or shrink start time of the second line; if totally to right, it will extend or shrink the end time of the first line."));
 
 	auto adjSliderSizer = new wxBoxSizer(wxHORIZONTAL);
-	adjSliderSizer->Add(new wxStaticText(&d, -1, _("Bias: Start <- ")), wxSizerFlags().Center());
+	adjSliderSizer->Add(new wxStaticText(AdjacentSizerBox, -1, _("Bias: Start <- ")), wxSizerFlags().Center());
 	adjSliderSizer->Add(adjacentBias, wxSizerFlags(1).Center());
-	adjSliderSizer->Add(new wxStaticText(&d, -1, _(" -> End")), wxSizerFlags().Center());
+	adjSliderSizer->Add(new wxStaticText(AdjacentSizerBox, -1, _(" -> End")), wxSizerFlags().Center());
 
 	auto adjRightSizer = new wxBoxSizer(wxVERTICAL);
 	adjRightSizer->Add(adjBoxes, wxSizerFlags().Expand());
@@ -212,9 +214,10 @@ DialogTimingProcessor::DialogTimingProcessor(agi::Context *c)
 
 	// Keyframes sizer
 	auto KeyframesSizer = new wxStaticBoxSizer(wxHORIZONTAL, &d, _("Keyframe snapping"));
+	wxWindow *KeyframesSizerBox = KeyframesSizer->GetStaticBox();
 	auto KeyframesFlexSizer = new wxFlexGridSizer(2,5,5,0);
 
-	keysEnable = new wxCheckBox(&d, -1, _("E&nable"));
+	keysEnable = new wxCheckBox(KeyframesSizerBox, -1, _("E&nable"));
 	keysEnable->SetToolTip(_("Enable snapping of subtitles to nearest keyframe, if distance is within threshold"));
 	keysEnable->SetValue(OPT_GET("Tool/Timing Post Processor/Enable/Keyframe")->GetBool());
 	KeyframesFlexSizer->Add(keysEnable,0,wxRIGHT|wxEXPAND,10);
@@ -226,18 +229,18 @@ DialogTimingProcessor::DialogTimingProcessor(agi::Context *c)
 		keysEnable->Enable(false);
 	}
 
-	make_ctrl(&d, KeyframesFlexSizer, _("Starts before thres.:"), &beforeStart, keysEnable,
+	make_ctrl(KeyframesSizerBox, KeyframesFlexSizer, _("Starts before thres.:"), &beforeStart, keysEnable,
 		_("Threshold for 'before start' distance, that is, how many milliseconds a subtitle must start before a keyframe to snap to it"));
 
-	make_ctrl(&d, KeyframesFlexSizer, _("Starts after thres.:"), &afterStart, keysEnable,
+	make_ctrl(KeyframesSizerBox, KeyframesFlexSizer, _("Starts after thres.:"), &afterStart, keysEnable,
 		_("Threshold for 'after start' distance, that is, how many milliseconds a subtitle must start after a keyframe to snap to it"));
 
 	KeyframesFlexSizer->AddStretchSpacer(1);
 
-	make_ctrl(&d, KeyframesFlexSizer, _("Ends before thres.:"), &beforeEnd, keysEnable,
+	make_ctrl(KeyframesSizerBox, KeyframesFlexSizer, _("Ends before thres.:"), &beforeEnd, keysEnable,
 		_("Threshold for 'before end' distance, that is, how many milliseconds a subtitle must end before a keyframe to snap to it"));
 
-	make_ctrl(&d, KeyframesFlexSizer, _("Ends after thres.:"), &afterEnd, keysEnable,
+	make_ctrl(KeyframesSizerBox, KeyframesFlexSizer, _("Ends after thres.:"), &afterEnd, keysEnable,
 		_("Threshold for 'after end' distance, that is, how many milliseconds a subtitle must end after a keyframe to snap to it"));
 
 	KeyframesSizer->Add(KeyframesFlexSizer,0,wxEXPAND);

--- a/src/dialog_translation.cpp
+++ b/src/dialog_translation.cpp
@@ -46,6 +46,7 @@
 #include <wx/msgdlg.h>
 #include <wx/sizer.h>
 #include <wx/settings.h>
+#include <wx/statbox.h>
 #include <wx/stattext.h>
 #include <wx/stc/stc.h>
 
@@ -74,12 +75,12 @@ DialogTranslation::DialogTranslation(agi::Context *c)
 
 	wxSizer *translation_sizer = new wxBoxSizer(wxVERTICAL);
 	{
-		wxSizer *original_box = new wxStaticBoxSizer(wxVERTICAL, this, _("Original"));
+		wxStaticBoxSizer *original_box = new wxStaticBoxSizer(wxVERTICAL, this, _("Original"));
 
-		line_number_display = new wxStaticText(this, -1, "");
+		line_number_display = new wxStaticText(original_box->GetStaticBox(), -1, "");
 		original_box->Add(line_number_display, 0, wxBOTTOM, 5);
 
-		original_text = new wxStyledTextCtrl(this, -1, wxDefaultPosition, wxSize(320, 80));
+		original_text = new wxStyledTextCtrl(original_box->GetStaticBox(), -1, wxDefaultPosition, wxSize(320, 80));
 		original_text->SetWrapMode(wxSTC_WRAP_WORD);
 		original_text->SetMarginWidth(1, 0);
 		original_text->StyleSetForeground(1, wxColour(10, 60, 200));
@@ -90,14 +91,15 @@ DialogTranslation::DialogTranslation(agi::Context *c)
 	}
 
 	{
-		translated_text = new SubsTextEditCtrl(this, wxSize(320, 80), 0, nullptr);
+		wxStaticBoxSizer *translated_box = new wxStaticBoxSizer(wxVERTICAL, this, _("Translation"));
+
+		translated_text = new SubsTextEditCtrl(translated_box->GetStaticBox(), wxSize(320, 80), 0, nullptr);
 		translated_text->SetWrapMode(wxSTC_WRAP_WORD);
 		translated_text->SetMarginWidth(1, 0);
 		translated_text->SetFocus();
 		translated_text->Bind(wxEVT_CHAR_HOOK, &DialogTranslation::OnKeyDown, this);
 		translated_text->CmdKeyAssign(wxSTC_KEY_RETURN, wxSTC_KEYMOD_SHIFT, wxSTC_CMD_NEWLINE);
 
-		wxSizer *translated_box = new wxStaticBoxSizer(wxVERTICAL, this, _("Translation"));
 		translated_box->Add(translated_text, 1, wxEXPAND, 0);
 		translation_sizer->Add(translated_box, 1, wxTOP|wxEXPAND, 5);
 	}
@@ -105,35 +107,36 @@ DialogTranslation::DialogTranslation(agi::Context *c)
 
 	wxSizer *right_box = new wxBoxSizer(wxHORIZONTAL);
 	{
-		wxSizer *hotkey_box = new wxStaticBoxSizer(wxVERTICAL, this, _("Keys"));
+		wxStaticBoxSizer *hotkey_sizer = new wxStaticBoxSizer(wxVERTICAL, this, _("Keys"));
+		wxWindow *hotkey_sizer_box = hotkey_sizer->GetStaticBox();
 
 		wxSizer *hotkey_grid = new wxGridSizer(2, 0, 5);
-		add_hotkey(hotkey_grid, this, "tool/translation_assistant/commit", _("Accept changes"));
-		add_hotkey(hotkey_grid, this, "tool/translation_assistant/preview", _("Preview changes"));
-		add_hotkey(hotkey_grid, this, "tool/translation_assistant/prev", _("Previous line"));
-		add_hotkey(hotkey_grid, this, "tool/translation_assistant/next", _("Next line"));
-		add_hotkey(hotkey_grid, this, "tool/translation_assistant/insert_original", _("Insert original"));
-		add_hotkey(hotkey_grid, this, "video/play/line", _("Play video"));
-		add_hotkey(hotkey_grid, this, "audio/play/selection", _("Play audio"));
-		add_hotkey(hotkey_grid, this, "edit/line/delete", _("Delete line"));
-		hotkey_box->Add(hotkey_grid, 0, wxEXPAND, 0);
+		add_hotkey(hotkey_grid, hotkey_sizer_box, "tool/translation_assistant/commit", _("Accept changes"));
+		add_hotkey(hotkey_grid, hotkey_sizer_box, "tool/translation_assistant/preview", _("Preview changes"));
+		add_hotkey(hotkey_grid, hotkey_sizer_box, "tool/translation_assistant/prev", _("Previous line"));
+		add_hotkey(hotkey_grid, hotkey_sizer_box, "tool/translation_assistant/next", _("Next line"));
+		add_hotkey(hotkey_grid, hotkey_sizer_box, "tool/translation_assistant/insert_original", _("Insert original"));
+		add_hotkey(hotkey_grid, hotkey_sizer_box, "video/play/line", _("Play video"));
+		add_hotkey(hotkey_grid, hotkey_sizer_box, "audio/play/selection", _("Play audio"));
+		add_hotkey(hotkey_grid, hotkey_sizer_box, "edit/line/delete", _("Delete line"));
+		hotkey_sizer->Add(hotkey_grid, 0, wxEXPAND, 0);
 
-		seek_video = new wxCheckBox(this, -1, _("Enable &preview"));
+		seek_video = new wxCheckBox(hotkey_sizer_box, -1, _("Enable &preview"));
 		seek_video->SetValue(true);
-		hotkey_box->Add(seek_video, 0, wxTOP, 5);
+		hotkey_sizer->Add(seek_video, 0, wxTOP, 5);
 
-		right_box->Add(hotkey_box, 1, wxRIGHT | wxEXPAND, 5);
+		right_box->Add(hotkey_sizer, 1, wxRIGHT | wxEXPAND, 5);
 	}
 
 	{
 		wxStaticBoxSizer *actions_box = new wxStaticBoxSizer(wxVERTICAL, this, _("Actions"));
 
-		wxButton *play_audio = new wxButton(this, -1, _("Play &Audio"));
+		wxButton *play_audio = new wxButton(actions_box->GetStaticBox(), -1, _("Play &Audio"));
 		play_audio->Enable(!!c->project->AudioProvider());
 		play_audio->Bind(wxEVT_BUTTON, &DialogTranslation::OnPlayAudioButton, this);
 		actions_box->Add(play_audio, 0, wxALL, 5);
 
-		wxButton *play_video = new wxButton(this, -1, _("Play &Video"));
+		wxButton *play_video = new wxButton(actions_box->GetStaticBox(), -1, _("Play &Video"));
 		play_video->Enable(!!c->project->VideoProvider());
 		play_video->Bind(wxEVT_BUTTON, &DialogTranslation::OnPlayVideoButton, this);
 		actions_box->Add(play_video, 0, wxLEFT | wxRIGHT | wxBOTTOM, 5);

--- a/src/dialog_video_details.cpp
+++ b/src/dialog_video_details.cpp
@@ -38,6 +38,7 @@
 #include <boost/rational.hpp>
 #include <wx/dialog.h>
 #include <wx/sizer.h>
+#include <wx/statbox.h>
 #include <wx/stattext.h>
 #include <wx/textctrl.h>
 
@@ -51,10 +52,13 @@ void ShowVideoDetailsDialog(agi::Context *c) {
 	auto fps = provider->GetFPS();
 	boost::rational<int> ar(width, height);
 
+	auto video_sizer = new wxStaticBoxSizer(wxVERTICAL, &d, _("Video"));
+	wxWindow *video_sizer_box = video_sizer->GetStaticBox();
+
 	auto fg = new wxFlexGridSizer(2, 5, 10);
-	auto make_field = [&](wxString const& name, wxString const& value) {
-		fg->Add(new wxStaticText(&d, -1, name), 0, wxALIGN_CENTRE_VERTICAL);
-		fg->Add(new wxTextCtrl(&d, -1, value, wxDefaultPosition, wxSize(300,-1), wxTE_READONLY), 0, wxALIGN_CENTRE_VERTICAL | wxEXPAND);
+	auto make_field = [&, video_sizer_box](wxString const& name, wxString const& value) {
+		fg->Add(new wxStaticText(video_sizer_box, -1, name), 0, wxALIGN_CENTRE_VERTICAL);
+		fg->Add(new wxTextCtrl(video_sizer_box, -1, value, wxDefaultPosition, wxSize(300,-1), wxTE_READONLY), 0, wxALIGN_CENTRE_VERTICAL | wxEXPAND);
 	};
 	make_field(_("File name:"), c->project->VideoName().wstring());
 	make_field(_("FPS:"), fmt_wx("%.3f", fps.FPS()));
@@ -63,7 +67,6 @@ void ShowVideoDetailsDialog(agi::Context *c) {
 		framecount, agi::Time(fps.TimeAtFrame(framecount - 1)).GetAssFormatted(true)));
 	make_field(_("Decoder:"), to_wx(provider->GetDecoderName()));
 
-	auto video_sizer = new wxStaticBoxSizer(wxVERTICAL, &d, _("Video"));
 	video_sizer->Add(fg);
 
 	auto main_sizer = new wxBoxSizer(wxVERTICAL);

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -54,6 +54,7 @@
 #include <wx/srchctrl.h>
 #include <wx/sizer.h>
 #include <wx/spinctrl.h>
+#include <wx/statbox.h>
 #include <wx/stattext.h>
 #include <wx/treebook.h>
 
@@ -88,7 +89,7 @@ void General_DefaultStyles(wxTreebook *book, Preferences *parent) {
 	p->sizer->Add(staticbox, 0, wxEXPAND, 5);
 	p->sizer->AddSpacer(8);
 
-	auto instructions = new wxStaticText(p, wxID_ANY, _("The chosen style catalogs will be loaded when you start a new file or import files in the various formats.\n\nYou can set up style catalogs in the Style Manager."));
+	auto instructions = new wxStaticText(staticbox->GetStaticBox(), wxID_ANY, _("The chosen style catalogs will be loaded when you start a new file or import files in the various formats.\n\nYou can set up style catalogs in the Style Manager."));
 	p->sizer->Fit(p);
 	instructions->Wrap(400);
 	staticbox->Add(instructions, 0, wxALL, 5);
@@ -113,11 +114,13 @@ void General_DefaultStyles(wxTreebook *book, Preferences *parent) {
 		catalogs.Add(to_wx(cn));
 	catalogs.Sort();
 
-	p->OptionChoice(general, _("New files"), catalogs, "Subtitle Format/ASS/Default Style Catalog");
-	p->OptionChoice(general, _("MicroDVD import"), catalogs, "Subtitle Format/MicroDVD/Default Style Catalog");
-	p->OptionChoice(general, _("SRT import"), catalogs, "Subtitle Format/SRT/Default Style Catalog");
-	p->OptionChoice(general, _("TTXT import"), catalogs, "Subtitle Format/TTXT/Default Style Catalog");
-	p->OptionChoice(general, _("Plain text import"), catalogs, "Subtitle Format/TXT/Default Style Catalog");
+	PageSection section = {general, staticbox->GetStaticBox()};
+
+	p->OptionChoice(section, _("New files"), catalogs, "Subtitle Format/ASS/Default Style Catalog");
+	p->OptionChoice(section, _("MicroDVD import"), catalogs, "Subtitle Format/MicroDVD/Default Style Catalog");
+	p->OptionChoice(section, _("SRT import"), catalogs, "Subtitle Format/SRT/Default Style Catalog");
+	p->OptionChoice(section, _("TTXT import"), catalogs, "Subtitle Format/TTXT/Default Style Catalog");
+	p->OptionChoice(section, _("Plain text import"), catalogs, "Subtitle Format/TXT/Default Style Catalog");
 
 	p->SetSizerAndFit(p->sizer);
 }
@@ -361,13 +364,13 @@ void Advanced(wxTreebook *book, Preferences *parent) {
 
 	auto general = p->PageSizer(_("General"));
 
-	auto warning = new wxStaticText(p, wxID_ANY ,_("Changing these settings might result in bugs and/or crashes. Do not touch these unless you know what you're doing."));
+	auto warning = new wxStaticText(general.box, wxID_ANY ,_("Changing these settings might result in bugs and/or crashes. Do not touch these unless you know what you're doing."));
 	auto font = parent->GetFont().MakeBold();
 	font.SetPointSize(12);
 	warning->SetFont(font);
 	p->sizer->Fit(p);
 	warning->Wrap(400);
-	general->Add(warning, 0, wxALL, 5);
+	general.sizer->Add(warning, 0, wxALL, 5);
 
 	p->SetSizerAndFit(p->sizer);
 }

--- a/src/preferences_base.h
+++ b/src/preferences_base.h
@@ -27,9 +27,15 @@ class wxSizer;
 class wxString;
 class wxTreebook;
 
+struct PageSection {
+	// Create controls in a section with the box as a parent and add them to the sizer.
+	wxFlexGridSizer *sizer;
+	wxWindow *box;
+};
+
 class OptionPage : public wxScrolled<wxPanel> {
 	template<class T>
-	void Add(wxSizer *sizer, wxString const& label, T *control);
+	void Add(PageSection section, wxString const& label, T *control);
 public:
 	enum Style {
 		PAGE_DEFAULT    =   0x00000000,
@@ -39,13 +45,13 @@ public:
 
 	wxSizer *sizer;
 	Preferences *parent;
-	wxFlexGridSizer *PageSizer(wxString name);
+	PageSection PageSizer(wxString name);
 
-	void CellSkip(wxFlexGridSizer *flex);
-	wxControl *OptionAdd(wxFlexGridSizer *flex, const wxString &name, const char *opt_name, double min=0, double max=INT_MAX, double inc=1);
-	void OptionChoice(wxFlexGridSizer *flex, const wxString &name, const wxArrayString &choices, const char *opt_name, bool translate = false);
-	void OptionBrowse(wxFlexGridSizer *flex, const wxString &name, const char *opt_name, wxControl *enabler = nullptr, bool do_enable = false);
-	void OptionFont(wxSizer *sizer, std::string opt_prefix);
+	void CellSkip(PageSection section);
+	wxControl *OptionAdd(PageSection section, const wxString &name, const char *opt_name, double min=0, double max=INT_MAX, double inc=1);
+	void OptionChoice(PageSection section, const wxString &name, const wxArrayString &choices, const char *opt_name, bool translate = false);
+	void OptionBrowse(PageSection section, const wxString &name, const char *opt_name, wxControl *enabler = nullptr, bool do_enable = false);
+	void OptionFont(PageSection section, std::string opt_prefix);
 
 	/// Enable ctrl only when cbx is checked
 	void EnableIfChecked(wxControl *cbx, wxControl *ctrl);


### PR DESCRIPTION
Since wxWidgets 2.9.1, wxWidgets wants controls added to wxStaticBoxSizers to be created with the sizer's static box as a parent. Newer wxWidgets versions (above 3.3.0) warn when this is not the case, and can break some controls on mac.

---

PR created to test CI.