### PR TITLE
WIP: Adapt controls to Hi-DPI

### DIFF
--- a/src/ass_exporter.cpp
+++ b/src/ass_exporter.cpp
@@ -55,8 +55,8 @@ void AssExporter::DrawSettings(wxWindow *parent, wxSizer *target_sizer) {
 		auto box = new wxStaticBoxSizer(wxVERTICAL, parent, to_wx(filter.GetName()));
 		wxWindow *window = filter.GetConfigDialogWindow(box->GetStaticBox(), c);
 		if (window) {
-			box->Add(window, 0, wxEXPAND, 0);
-			target_sizer->Add(box, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
+			box->Add(window, wxSizerFlags().Expand());
+			target_sizer->Add(box, wxSizerFlags().Expand().Border(wxALL & ~wxTOP));
 			target_sizer->Show(box, false);
 			Sizers[filter.GetName()] = box;
 		}

--- a/src/audio_box.cpp
+++ b/src/audio_box.cpp
@@ -82,34 +82,34 @@ AudioBox::AudioBox(wxWindow *parent, agi::Context *context)
 
 	// VertVol sider
 	wxSizer *VertVol = new wxBoxSizer(wxHORIZONTAL);
-	VertVol->Add(VerticalZoom,1,wxEXPAND,0);
-	VertVol->Add(VolumeBar,1,wxEXPAND,0);
+	VertVol->Add(VerticalZoom, wxSizerFlags(1).Expand());
+	VertVol->Add(VolumeBar, wxSizerFlags(1).Expand());
 	wxSizer *VertVolArea = new wxBoxSizer(wxVERTICAL);
-	VertVolArea->Add(VertVol,1,wxEXPAND,0);
+	VertVolArea->Add(VertVol, wxSizerFlags(1).Expand());
 
 	auto link_btn = new ToggleBitmap(panel, context, "audio/opt/vertical_link", 16, "Audio", FromDIP(wxSize(20, -1)));
 	link_btn->SetMaxSize(wxDefaultSize);
-	VertVolArea->Add(link_btn, 0, wxEXPAND, 0);
+	VertVolArea->Add(link_btn, wxSizerFlags().Expand());
 	BindConnection(OPT_SUB("Audio/Link", &AudioBox::OnVerticalLink, this));
 
 	// Top sizer
 	wxSizer *TopSizer = new wxBoxSizer(wxHORIZONTAL);
-	TopSizer->Add(audioDisplay,1,wxEXPAND,0);
-	TopSizer->Add(HorizontalZoom,0,wxEXPAND,0);
-	TopSizer->Add(VertVolArea,0,wxEXPAND,0);
+	TopSizer->Add(audioDisplay, wxSizerFlags(1).Expand());
+	TopSizer->Add(HorizontalZoom, wxSizerFlags().Expand());
+	TopSizer->Add(VertVolArea, wxSizerFlags().Expand());
 
 	context->karaoke = new AudioKaraoke(panel, context);
 
 	// Main sizer
 	auto MainSizer = new wxBoxSizer(wxVERTICAL);
-	MainSizer->Add(TopSizer,1,wxEXPAND|wxALL,3);
-	MainSizer->Add(toolbar::GetToolbar(panel, "audio", context, "Audio"),0,wxEXPAND|wxLEFT|wxRIGHT,3);
-	MainSizer->Add(context->karaoke,0,wxEXPAND|wxALL,3);
+	MainSizer->Add(TopSizer, wxSizerFlags(1).Expand().Border(wxALL, 3));
+	MainSizer->Add(toolbar::GetToolbar(panel, "audio", context, "Audio"), wxSizerFlags().Expand().Border(wxLEFT | wxRIGHT, 3));
+	MainSizer->Add(context->karaoke, wxSizerFlags().Expand().Border(wxALL, 3));
 	MainSizer->Show(context->karaoke, false);
 	panel->SetSizer(MainSizer);
 
 	wxSizer *audioSashSizer = new wxBoxSizer(wxHORIZONTAL);
-	audioSashSizer->Add(panel, 1, wxEXPAND);
+	audioSashSizer->Add(panel, wxSizerFlags(1).Expand());
 	SetSizerAndFit(audioSashSizer);
 	SetMinSize(wxSize(-1, OPT_GET("Audio/Display Height")->GetInt()));
 	SetMinimumSizeY(panel->GetSize().GetHeight());

--- a/src/audio_display.cpp
+++ b/src/audio_display.cpp
@@ -586,7 +586,7 @@ AudioDisplay::AudioDisplay(wxWindow *parent, AudioController *controller, agi::C
 	audio_renderer->SetAmplitudeScale(scale_amplitude);
 	SetZoomLevel(0);
 
-	SetMinClientSize(wxSize(-1, 70));
+	SetMinClientSize(FromDIP(wxSize(-1, 70)));
 	SetBackgroundStyle(wxBG_STYLE_PAINT);
 	SetThemeEnabled(false);
 

--- a/src/auto4_base.cpp
+++ b/src/auto4_base.cpp
@@ -215,7 +215,7 @@ namespace Automation4 {
 			w.Create(bsr->GetParentWindow(), -1, to_wx(bsr->GetTitle()));
 			auto s = new wxBoxSizer(wxHORIZONTAL); // sizer for putting contents in
 			wxWindow *ww = config_dialog->CreateWindow(&w); // generate actual dialog contents
-			s->Add(ww, 0, wxALL, 5); // add contents to dialog
+			s->Add(ww, wxSizerFlags().Border()); // add contents to dialog
 			w.SetSizerAndFit(s);
 			w.SetLayoutAdaptationMode(wxDIALOG_ADAPTATION_MODE_ENABLED);
 			w.CenterOnParent();

--- a/src/auto4_lua_dialog.cpp
+++ b/src/auto4_lua_dialog.cpp
@@ -505,7 +505,7 @@ namespace Automation4 {
 		}
 
 		auto ms = new wxBoxSizer(wxVERTICAL);
-		ms->Add(s, 0, wxBOTTOM, 5);
+		ms->Add(s, wxSizerFlags().Border(wxBOTTOM));
 		ms->Add(bs);
 		window->SetSizerAndFit(ms);
 

--- a/src/auto4_lua_dialog.cpp
+++ b/src/auto4_lua_dialog.cpp
@@ -225,7 +225,7 @@ namespace Automation4 {
 			// Same serialisation interface as single-line edit
 			wxControl *Create(wxWindow *parent) override {
 				cw = new wxTextCtrl(parent, -1, "", wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE, StringBinder(&text));
-				cw->SetMinSize(wxSize(0, 30));
+				cw->SetMinSize(parent->FromDIP(wxSize(0, 30)));
 				cw->SetToolTip(to_wx(hint));
 				return cw;
 			}

--- a/src/base_grid.cpp
+++ b/src/base_grid.cpp
@@ -181,7 +181,7 @@ void BaseGrid::UpdateStyle() {
 	dc.SetFont(font);
 
 	// Set line height
-	lineHeight = dc.GetCharHeight() + 4;
+	lineHeight = dc.GetCharHeight() + FromDIP(4);
 
 	// Set row brushes
 	row_colors.Default.SetColour(to_wx(OPT_GET("Colour/Subtitle Grid/Background/Background")->GetColor()));
@@ -319,13 +319,13 @@ void BaseGrid::OnPaint(wxPaintEvent &) {
 	dc.SetPen(*wxTRANSPARENT_PEN);
 
 	auto paint_text = [&](wxString const& str, int x, int y, int col) {
-		int left = x + 4;
+		int left = x + FromDIP(4);
 		if (columns[col]->Centered()) {
 			wxSize ext = dc.GetTextExtent(str);
-			left += (columns[col]->Width() - 6 - ext.GetWidth()) / 2;
+			left += (columns[col]->Width() - FromDIP(6) - ext.GetWidth()) / 2;
 		}
 
-		dc.DrawText(str, left, y + 2);
+		dc.DrawText(str, left, y + FromDIP(2));
 	};
 
 	// Paint header

--- a/src/base_grid.cpp
+++ b/src/base_grid.cpp
@@ -72,7 +72,7 @@ BaseGrid::BaseGrid(wxWindow* parent, agi::Context *context)
 
 	auto scrollbarpositioner = new wxBoxSizer(wxHORIZONTAL);
 	scrollbarpositioner->AddStretchSpacer();
-	scrollbarpositioner->Add(scrollBar, 0, wxEXPAND, 0);
+	scrollbarpositioner->Add(scrollBar, wxSizerFlags().Expand());
 
 	SetSizerAndFit(scrollbarpositioner);
 

--- a/src/dialog_about.cpp
+++ b/src/dialog_about.cpp
@@ -141,11 +141,11 @@ void ShowAboutDialog(wxWindow *parent) {
 	wxTextCtrl *textctrl = new wxTextCtrl(&d, -1, aboutString, wxDefaultPosition, wxSize(-1, 200), wxTE_MULTILINE | wxTE_READONLY | wxBORDER_NONE);
 
 	wxSizer *MainSizer = new wxBoxSizer(wxVERTICAL);
-	MainSizer->Add(new wxStaticBitmap(&d, -1, GETIMAGE(splash)), 0, wxCENTER, 0);
-	MainSizer->Add(new wxStaticLine(&d, wxID_ANY), 0, wxEXPAND, 0);
-	MainSizer->Add(textctrl, 0, wxEXPAND, 0);
-	MainSizer->Add(new wxStaticLine(&d, wxID_ANY), 0, wxEXPAND, 0);
-	MainSizer->Add(d.CreateButtonSizer(wxOK), 0, wxEXPAND | wxALL, 6);
+	MainSizer->Add(new wxStaticBitmap(&d, -1, GETIMAGE(splash)), wxSizerFlags().Center());
+	MainSizer->Add(new wxStaticLine(&d, wxID_ANY), wxSizerFlags().Expand());
+	MainSizer->Add(textctrl, wxSizerFlags().Expand());
+	MainSizer->Add(new wxStaticLine(&d, wxID_ANY), wxSizerFlags().Expand());
+	MainSizer->Add(d.CreateButtonSizer(wxOK), wxSizerFlags().Expand().Border(wxALL, 6));
 
 	d.SetSizerAndFit(MainSizer);
 	d.CentreOnParent();

--- a/src/dialog_about.cpp
+++ b/src/dialog_about.cpp
@@ -145,7 +145,7 @@ void ShowAboutDialog(wxWindow *parent) {
 	MainSizer->Add(new wxStaticLine(&d, wxID_ANY), wxSizerFlags().Expand());
 	MainSizer->Add(textctrl, wxSizerFlags().Expand());
 	MainSizer->Add(new wxStaticLine(&d, wxID_ANY), wxSizerFlags().Expand());
-	MainSizer->Add(d.CreateButtonSizer(wxOK), wxSizerFlags().Expand().Border(wxALL, 6));
+	MainSizer->Add(d.CreateButtonSizer(wxOK), wxSizerFlags().Expand().Border());
 
 	d.SetSizerAndFit(MainSizer);
 	d.CentreOnParent();

--- a/src/dialog_attachments.cpp
+++ b/src/dialog_attachments.cpp
@@ -107,9 +107,9 @@ DialogAttachments::DialogAttachments(wxWindow *parent, AssFile *ass)
 void DialogAttachments::UpdateList() {
 	listView->ClearAll();
 
-	listView->InsertColumn(0, _("Attachment name"), wxLIST_FORMAT_LEFT, 280);
-	listView->InsertColumn(1, _("Size"), wxLIST_FORMAT_LEFT, 100);
-	listView->InsertColumn(2, _("Group"), wxLIST_FORMAT_LEFT, 100);
+	listView->InsertColumn(0, _("Attachment name"), wxLIST_FORMAT_LEFT, d.FromDIP(280));
+	listView->InsertColumn(1, _("Size"), wxLIST_FORMAT_LEFT, d.FromDIP(100));
+	listView->InsertColumn(2, _("Group"), wxLIST_FORMAT_LEFT, d.FromDIP(100));
 
 	for (auto& attach : ass->Attachments) {
 		int row = listView->GetItemCount();

--- a/src/dialog_attachments.cpp
+++ b/src/dialog_attachments.cpp
@@ -85,12 +85,12 @@ DialogAttachments::DialogAttachments(wxWindow *parent, AssFile *ass)
 	buttonSizer->Add(attachGraphics, 1);
 	buttonSizer->Add(extractButton, 1);
 	buttonSizer->Add(deleteButton, 1);
-	buttonSizer->Add(new HelpButton(&d, "Attachment Manager"), 1, wxLEFT, 5);
+	buttonSizer->Add(new HelpButton(&d, "Attachment Manager"), wxSizerFlags(1).Border(wxLEFT));
 	buttonSizer->Add(new wxButton(&d, wxID_CANCEL, _("&Close")), 1);
 
 	auto mainSizer = new wxBoxSizer(wxVERTICAL);
-	mainSizer->Add(listView, 1, wxTOP | wxLEFT | wxRIGHT | wxEXPAND, 5);
-	mainSizer->Add(buttonSizer, 0, wxALL | wxEXPAND, 5);
+	mainSizer->Add(listView, wxSizerFlags(1).Expand().Border(wxALL & ~wxBOTTOM));
+	mainSizer->Add(buttonSizer, wxSizerFlags().Expand().Border());
 	d.SetSizerAndFit(mainSizer);
 	d.CenterOnParent();
 

--- a/src/dialog_automation.cpp
+++ b/src/dialog_automation.cpp
@@ -110,6 +110,7 @@ DialogAutomation::DialogAutomation(agi::Context *c)
 , global_manager(config::global_scripts)
 , global_scripts_changed(global_manager->AddScriptChangeListener(&DialogAutomation::RebuildList, this))
 {
+	int gap = wxSizerFlags::GetDefaultBorder();
 	SetIcons(GETICONS(automation_toolbutton));
 
 	// create main controls
@@ -140,12 +141,12 @@ DialogAutomation::DialogAutomation(agi::Context *c)
 	button_box->AddStretchSpacer(2);
 	button_box->Add(add_button);
 	button_box->Add(remove_button);
-	button_box->AddSpacer(10);
+	button_box->AddSpacer(2 * gap);
 	button_box->Add(reload_button);
 	button_box->Add(info_button);
-	button_box->AddSpacer(10);
+	button_box->AddSpacer(2 * gap);
 	button_box->Add(reload_autoload_button);
-	button_box->AddSpacer(10);
+	button_box->AddSpacer(2 * gap);
 	button_box->Add(new HelpButton(this,"Automation Manager"));
 	button_box->Add(close_button);
 	button_box->AddStretchSpacer(2);

--- a/src/dialog_automation.cpp
+++ b/src/dialog_automation.cpp
@@ -138,16 +138,16 @@ DialogAutomation::DialogAutomation(agi::Context *c)
 	// button layout
 	wxSizer *button_box = new wxBoxSizer(wxHORIZONTAL);
 	button_box->AddStretchSpacer(2);
-	button_box->Add(add_button, 0);
-	button_box->Add(remove_button, 0);
+	button_box->Add(add_button);
+	button_box->Add(remove_button);
 	button_box->AddSpacer(10);
-	button_box->Add(reload_button, 0);
-	button_box->Add(info_button, 0);
+	button_box->Add(reload_button);
+	button_box->Add(info_button);
 	button_box->AddSpacer(10);
-	button_box->Add(reload_autoload_button, 0);
+	button_box->Add(reload_autoload_button);
 	button_box->AddSpacer(10);
-	button_box->Add(new HelpButton(this,"Automation Manager"), 0);
-	button_box->Add(close_button, 0);
+	button_box->Add(new HelpButton(this,"Automation Manager"));
+	button_box->Add(close_button);
 	button_box->AddStretchSpacer(2);
 
 	// main layout

--- a/src/dialog_automation.cpp
+++ b/src/dialog_automation.cpp
@@ -114,7 +114,7 @@ DialogAutomation::DialogAutomation(agi::Context *c)
 	SetIcons(GETICONS(automation_toolbutton));
 
 	// create main controls
-	list = new wxListView(this, -1, wxDefaultPosition, wxSize(600, 175), wxLC_REPORT|wxLC_SINGLE_SEL);
+	list = new wxListView(this, -1, wxDefaultPosition, FromDIP(wxSize(600, 175)), wxLC_REPORT|wxLC_SINGLE_SEL);
 	wxButton *add_button = new wxButton(this, -1, _("&Add"));
 	remove_button = new wxButton(this, -1, _("&Remove"));
 	reload_button = new wxButton(this, -1, _("Re&load"));
@@ -131,10 +131,10 @@ DialogAutomation::DialogAutomation(agi::Context *c)
 	reload_autoload_button->Bind(wxEVT_BUTTON, &DialogAutomation::OnReloadAutoload, this);
 
 	// add headers to list view
-	list->InsertColumn(0, "", wxLIST_FORMAT_CENTER, 20);
-	list->InsertColumn(1, _("Name"), wxLIST_FORMAT_LEFT, 140);
-	list->InsertColumn(2, _("Filename"), wxLIST_FORMAT_LEFT, 90);
-	list->InsertColumn(3, _("Description"), wxLIST_FORMAT_LEFT, 330);
+	list->InsertColumn(0, "", wxLIST_FORMAT_CENTER, FromDIP(20));
+	list->InsertColumn(1, _("Name"), wxLIST_FORMAT_LEFT, FromDIP(140));
+	list->InsertColumn(2, _("Filename"), wxLIST_FORMAT_LEFT, FromDIP(90));
+	list->InsertColumn(3, _("Description"), wxLIST_FORMAT_LEFT, FromDIP(330));
 
 	// button layout
 	wxSizer *button_box = new wxBoxSizer(wxHORIZONTAL);

--- a/src/dialog_colorpicker.cpp
+++ b/src/dialog_colorpicker.cpp
@@ -586,13 +586,13 @@ DialogColorPicker::DialogColorPicker(wxWindow *parent, agi::Color initial_color,
 
 	// Arrange the controls in a nice way
 	wxSizer *spectop_sizer = new wxBoxSizer(wxHORIZONTAL);
-	spectop_sizer->Add(new wxStaticText(spectrum_box, -1, _("Spectrum mode:")), 0, wxALIGN_CENTER_VERTICAL|wxALIGN_LEFT|wxRIGHT, 5);
-	spectop_sizer->Add(colorspace_choice, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_LEFT);
-	spectop_sizer->Add(5, 5, 1, wxEXPAND);
-	spectop_sizer->Add(preview_box, 0, wxALIGN_CENTER_VERTICAL);
+	spectop_sizer->Add(new wxStaticText(spectrum_box, -1, _("Spectrum mode:")), wxSizerFlags().CenterVertical().Left().Border(wxRIGHT));
+	spectop_sizer->Add(colorspace_choice, wxSizerFlags().CenterVertical().Left());
+	spectop_sizer->Add(5, 5, wxSizerFlags(1).Expand());
+	spectop_sizer->Add(preview_box, wxSizerFlags().CenterVertical());
 
 	wxSizer *spectrum_sizer = new wxFlexGridSizer(3, 5, 5);
-	spectrum_sizer->Add(spectop_sizer, wxEXPAND);
+	spectrum_sizer->Add(spectop_sizer, wxSizerFlags().Expand());
 	spectrum_sizer->AddStretchSpacer(1);
 	spectrum_sizer->AddStretchSpacer(1);
 	spectrum_sizer->Add(spectrum);
@@ -601,23 +601,23 @@ DialogColorPicker::DialogColorPicker(wxWindow *parent, agi::Color initial_color,
 	if (!alpha)
 		spectrum_sizer->Hide(alpha_slider);
 
-	spectrum_box_sizer->Add(spectrum_sizer, 0, wxALL, 3);
+	spectrum_box_sizer->Add(spectrum_sizer, wxSizerFlags().Border(wxALL, 3));
 
 	wxString rgb_labels[] = { _("Red:"), _("Green:"), _("Blue:") };
-	rgb_box_sizer->Add(MakeColorInputSizer(rgb_box, rgb_labels, rgb_input), 1, wxALL|wxEXPAND, 3);
+	rgb_box_sizer->Add(MakeColorInputSizer(rgb_box, rgb_labels, rgb_input), wxSizerFlags(1).Expand().Border(wxALL, 3));
 
 	wxString ass_labels[] = { "ASS:", "HTML:", _("Alpha:") };
 	wxControl *ass_ctrls[] = { ass_input, html_input, alpha_input };
 	auto ass_colors_sizer = MakeColorInputSizer(rgb_box, ass_labels, ass_ctrls);
 	if (!alpha)
 		ass_colors_sizer->Hide(alpha_input);
-	rgb_box_sizer->Add(ass_colors_sizer, 0, wxALL|wxEXPAND, 3);
+	rgb_box_sizer->Add(ass_colors_sizer, wxSizerFlags().Expand().Border(wxALL, 3));
 
 	wxString hsl_labels[] = { _("Hue:"), _("Sat.:"), _("Lum.:") };
-	hsl_box_sizer->Add(MakeColorInputSizer(hsl_box, hsl_labels, hsl_input), 0, wxALL|wxEXPAND, 3);
+	hsl_box_sizer->Add(MakeColorInputSizer(hsl_box, hsl_labels, hsl_input), wxSizerFlags().Expand().Border(wxALL, 3));
 
 	wxString hsv_labels[] = { _("Hue:"), _("Sat.:"), _("Value:") };
-	hsv_box_sizer->Add(MakeColorInputSizer(hsv_box, hsv_labels, hsv_input), 0, wxALL|wxEXPAND, 3);
+	hsv_box_sizer->Add(MakeColorInputSizer(hsv_box, hsv_labels, hsv_input), wxSizerFlags().Expand().Border(wxALL, 3));
 
 	wxSizer *hsx_sizer = new wxBoxSizer(wxHORIZONTAL);
 	hsx_sizer->Add(hsl_box_sizer);
@@ -627,31 +627,31 @@ DialogColorPicker::DialogColorPicker(wxWindow *parent, agi::Color initial_color,
 	wxSizer *picker_sizer = new wxBoxSizer(wxHORIZONTAL);
 	picker_sizer->AddStretchSpacer();
 	if (os_screen_dropper_button) {
-		picker_sizer->Add(os_screen_dropper_button, 0, wxALIGN_CENTER);
+		picker_sizer->Add(os_screen_dropper_button, wxSizerFlags().Center());
 		picker_sizer->AddStretchSpacer();
 	}
 	if (screenshot_screen_dropper) {
-		picker_sizer->Add(screenshot_screen_dropper_icon, 0, wxALIGN_CENTER|wxRIGHT, 5);
-		picker_sizer->Add(screenshot_screen_dropper, 0, wxALIGN_CENTER);
+		picker_sizer->Add(screenshot_screen_dropper_icon, wxSizerFlags().Center().Border(wxRIGHT));
+		picker_sizer->Add(screenshot_screen_dropper, wxSizerFlags().Center());
 		picker_sizer->AddStretchSpacer();
 	}
-	picker_sizer->Add(recent_box, 0, wxALIGN_CENTER);
+	picker_sizer->Add(recent_box, wxSizerFlags().Center());
 	picker_sizer->AddStretchSpacer();
 
 	wxStdDialogButtonSizer *button_sizer = CreateStdDialogButtonSizer(wxOK | wxCANCEL | wxHELP);
 
 	wxSizer *input_sizer = new wxBoxSizer(wxVERTICAL);
-	input_sizer->Add(rgb_box_sizer, 0, wxEXPAND);
+	input_sizer->Add(rgb_box_sizer, wxSizerFlags().Expand());
 	input_sizer->AddSpacer(5);
-	input_sizer->Add(hsx_sizer, 0, wxEXPAND);
+	input_sizer->Add(hsx_sizer, wxSizerFlags().Expand());
 	input_sizer->AddStretchSpacer(1);
-	input_sizer->Add(picker_sizer, 0, wxEXPAND);
+	input_sizer->Add(picker_sizer, wxSizerFlags().Expand());
 	input_sizer->AddStretchSpacer(2);
-	input_sizer->Add(button_sizer, 0, wxALIGN_RIGHT);
+	input_sizer->Add(button_sizer, wxSizerFlags().Right());
 
 	wxSizer *main_sizer = new wxBoxSizer(wxHORIZONTAL);
-	main_sizer->Add(spectrum_box_sizer, 1, wxALL | wxEXPAND, 5);
-	main_sizer->Add(input_sizer, 0, (wxALL&~wxLEFT)|wxEXPAND, 5);
+	main_sizer->Add(spectrum_box_sizer, wxSizerFlags(1).Expand().Border());
+	main_sizer->Add(input_sizer, wxSizerFlags().Expand().Border(wxALL & ~wxLEFT));
 
 	SetSizerAndFit(main_sizer);
 

--- a/src/dialog_colorpicker.cpp
+++ b/src/dialog_colorpicker.cpp
@@ -588,10 +588,11 @@ DialogColorPicker::DialogColorPicker(wxWindow *parent, agi::Color initial_color,
 	wxSizer *spectop_sizer = new wxBoxSizer(wxHORIZONTAL);
 	spectop_sizer->Add(new wxStaticText(spectrum_box, -1, _("Spectrum mode:")), wxSizerFlags().CenterVertical().Left().Border(wxRIGHT));
 	spectop_sizer->Add(colorspace_choice, wxSizerFlags().CenterVertical().Left());
-	spectop_sizer->Add(5, 5, wxSizerFlags(1).Expand());
+	int gap = wxSizerFlags::GetDefaultBorder();
+	spectop_sizer->Add(gap, gap, wxSizerFlags(1).Expand());
 	spectop_sizer->Add(preview_box, wxSizerFlags().CenterVertical());
 
-	wxSizer *spectrum_sizer = new wxFlexGridSizer(3, 5, 5);
+	wxSizer *spectrum_sizer = new wxFlexGridSizer(3, gap, gap);
 	spectrum_sizer->Add(spectop_sizer, wxSizerFlags().Expand());
 	spectrum_sizer->AddStretchSpacer(1);
 	spectrum_sizer->AddStretchSpacer(1);
@@ -621,7 +622,7 @@ DialogColorPicker::DialogColorPicker(wxWindow *parent, agi::Color initial_color,
 
 	wxSizer *hsx_sizer = new wxBoxSizer(wxHORIZONTAL);
 	hsx_sizer->Add(hsl_box_sizer);
-	hsx_sizer->AddSpacer(5);
+	hsx_sizer->AddSpacer(gap);
 	hsx_sizer->Add(hsv_box_sizer);
 
 	wxSizer *picker_sizer = new wxBoxSizer(wxHORIZONTAL);
@@ -642,7 +643,7 @@ DialogColorPicker::DialogColorPicker(wxWindow *parent, agi::Color initial_color,
 
 	wxSizer *input_sizer = new wxBoxSizer(wxVERTICAL);
 	input_sizer->Add(rgb_box_sizer, wxSizerFlags().Expand());
-	input_sizer->AddSpacer(5);
+	input_sizer->AddSpacer(gap);
 	input_sizer->Add(hsx_sizer, wxSizerFlags().Expand());
 	input_sizer->AddStretchSpacer(1);
 	input_sizer->Add(picker_sizer, wxSizerFlags().Expand());
@@ -706,7 +707,8 @@ DialogColorPicker::DialogColorPicker(wxWindow *parent, agi::Color initial_color,
 
 template<int N, class Control>
 wxSizer *DialogColorPicker::MakeColorInputSizer(wxWindow *parent, wxString (&labels)[N], Control *(&inputs)[N]) {
-	auto sizer = new wxFlexGridSizer(2, 5, 5);
+	int gap = wxSizerFlags::GetDefaultBorder();
+	auto sizer = new wxFlexGridSizer(2, gap, gap);
 	for (int i = 0; i < N; ++i) {
 		sizer->Add(new wxStaticText(parent, -1, labels[i]), wxSizerFlags(1).Center().Left());
 		sizer->Add(inputs[i], wxSizerFlags().Expand());

--- a/src/dialog_detached_video.cpp
+++ b/src/dialog_detached_video.cpp
@@ -51,7 +51,7 @@
 #include <wx/display.h> /// Must be included last.
 
 DialogDetachedVideo::DialogDetachedVideo(agi::Context *context)
-: wxDialog(context->parent, -1, "Detached Video", wxDefaultPosition, wxSize(400,300), wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxMAXIMIZE_BOX | wxMINIMIZE_BOX | wxWANTS_CHARS)
+: wxDialog(context->parent, -1, "Detached Video", wxDefaultPosition, FromDIP(wxSize(400,300)), wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxMAXIMIZE_BOX | wxMINIMIZE_BOX | wxWANTS_CHARS)
 , context(context)
 , old_display(context->videoDisplay)
 , old_slider(context->videoSlider)
@@ -91,9 +91,9 @@ DialogDetachedVideo::DialogDetachedVideo(agi::Context *context)
 		// so wait for the next iteration of the main loop
 		if (evt.IsShown()) CallAfter([this, videoBox]() {
 			// Without these, the window is locked to at least the initial size
-			this->context->videoDisplay->SetMinSize(wxSize(1,1));
-			videoBox->SetMinSize(wxSize(1,1));
-			SetMinSize(wxSize(1,1));
+			this->context->videoDisplay->SetMinSize(wxSize(1, 1));
+			videoBox->SetMinSize(wxSize(1, 1));
+			SetMinSize(wxSize(1, 1));
 		});
 	});
 

--- a/src/dialog_detached_video.cpp
+++ b/src/dialog_detached_video.cpp
@@ -71,7 +71,7 @@ DialogDetachedVideo::DialogDetachedVideo(agi::Context *context)
 
 	// Set sizer
 	wxSizer *mainSizer = new wxBoxSizer(wxVERTICAL);
-	mainSizer->Add(videoBox,1,wxEXPAND);
+	mainSizer->Add(videoBox, wxSizerFlags(1).Expand());
 	SetSizerAndFit(mainSizer);
 
 

--- a/src/dialog_dummy_video.cpp
+++ b/src/dialog_dummy_video.cpp
@@ -115,7 +115,8 @@ DialogDummyVideo::DialogDummyVideo(wxWindow *parent)
 	color_sizer->Add(color_btn, wxSizerFlags().DoubleBorder(wxRIGHT));
 	color_sizer->Add(new wxCheckBox(&d, -1, _("Checkerboard &pattern"), wxDefaultPosition, wxDefaultSize, 0, wxGenericValidator(&pattern)), wxSizerFlags(1).Center());
 
-	sizer = new wxFlexGridSizer(2, 5, 5);
+	int gap = wxSizerFlags::GetDefaultBorder();
+	sizer = new wxFlexGridSizer(2, gap, gap);
 	AddCtrl(_("Video resolution:"), resolution_shortcuts(&d, width, height));
 	AddCtrl("", res_sizer);
 	AddCtrl(_("Color:"), color_sizer);

--- a/src/dialog_dummy_video.cpp
+++ b/src/dialog_dummy_video.cpp
@@ -111,7 +111,7 @@ DialogDummyVideo::DialogDummyVideo(wxWindow *parent)
 	res_sizer->Add(spin_ctrl(&d, 1, 10000, &height), wxSizerFlags(1).Expand());
 
 	auto color_sizer = new wxBoxSizer(wxHORIZONTAL);
-	auto color_btn = new ColourButton(&d, wxSize(30, 17), false, color);
+	auto color_btn = new ColourButton(&d, d.FromDIP(wxSize(30, 17)), false, color);
 	color_sizer->Add(color_btn, wxSizerFlags().DoubleBorder(wxRIGHT));
 	color_sizer->Add(new wxCheckBox(&d, -1, _("Checkerboard &pattern"), wxDefaultPosition, wxDefaultSize, 0, wxGenericValidator(&pattern)), wxSizerFlags(1).Center());
 

--- a/src/dialog_export.cpp
+++ b/src/dialog_export.cpp
@@ -99,10 +99,11 @@ void swap(wxCheckListBox *list, int idx, int sel_dir) {
 }
 
 DialogExport::DialogExport(agi::Context *c)
-: d(c->parent, -1, _("Export"), wxDefaultPosition, wxSize(200, 100), wxCAPTION | wxCLOSE_BOX)
+: d(c->parent, -1, _("Export"), wxDefaultPosition, wxDefaultSize, wxCAPTION | wxCLOSE_BOX)
 , c(c)
 , exporter(c)
 {
+	d.SetSize(d.FromDIP(wxSize(200, 100)));
 	d.SetIcons(GETICONS(export_menu));
 	d.SetExtraStyle(wxWS_EX_VALIDATE_RECURSIVELY);
 
@@ -110,7 +111,7 @@ DialogExport::DialogExport(agi::Context *c)
 	wxWindow *top_sizer_box = top_sizer->GetStaticBox();
 
 	std::vector<std::string> filters = exporter.GetAllFilterNames();
-	filter_list = new wxCheckListBox(top_sizer_box, -1, wxDefaultPosition, wxSize(200, 100), to_wx(filters));
+	filter_list = new wxCheckListBox(top_sizer_box, -1, wxDefaultPosition, d.FromDIP(wxSize(200, 100)), to_wx(filters));
 	filter_list->Bind(wxEVT_CHECKLISTBOX, [this](wxCommandEvent&) { RefreshOptions(); });
 	filter_list->Bind(wxEVT_LISTBOX, &DialogExport::OnChange, this);
 
@@ -122,10 +123,10 @@ DialogExport::DialogExport(agi::Context *c)
 			filter_list->Check(distance(begin(filters), it));
 	}
 
-	wxButton *btn_up = new wxButton(top_sizer_box, -1, _("Move &Up"), wxDefaultPosition, wxSize(90, -1));
-	wxButton *btn_down = new wxButton(top_sizer_box, -1, _("Move &Down"), wxDefaultPosition, wxSize(90, -1));
-	wxButton *btn_all = new wxButton(top_sizer_box, -1, _("Select &All"), wxDefaultPosition, wxSize(80, -1));
-	wxButton *btn_none = new wxButton(top_sizer_box, -1, _("Select &None"), wxDefaultPosition, wxSize(80, -1));
+	wxButton *btn_up = new wxButton(top_sizer_box, -1, _("Move &Up"), wxDefaultPosition, d.FromDIP(wxSize(90, -1)));
+	wxButton *btn_down = new wxButton(top_sizer_box, -1, _("Move &Down"), wxDefaultPosition, d.FromDIP(wxSize(90, -1)));
+	wxButton *btn_all = new wxButton(top_sizer_box, -1, _("Select &All"), wxDefaultPosition, d.FromDIP(wxSize(80, -1)));
+	wxButton *btn_none = new wxButton(top_sizer_box, -1, _("Select &None"), wxDefaultPosition, d.FromDIP(wxSize(80, -1)));
 
 	btn_up->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) { swap(filter_list, filter_list->GetSelection() - 1, 0); });
 	btn_down->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) { swap(filter_list, filter_list->GetSelection(), 1); });
@@ -138,7 +139,7 @@ DialogExport::DialogExport(agi::Context *c)
 	top_buttons->Add(btn_all, wxSizerFlags(1).Expand());
 	top_buttons->Add(btn_none, wxSizerFlags(1).Expand());
 
-	filter_description = new wxTextCtrl(top_sizer_box, -1, "", wxDefaultPosition, wxSize(200, 60), wxTE_MULTILINE | wxTE_READONLY);
+	filter_description = new wxTextCtrl(top_sizer_box, -1, "", wxDefaultPosition, d.FromDIP(wxSize(200, 60)), wxTE_MULTILINE | wxTE_READONLY);
 
 	// Charset dropdown list
 	wxStaticText *charset_list_label = new wxStaticText(top_sizer_box, -1, _("Text encoding:"));

--- a/src/dialog_export.cpp
+++ b/src/dialog_export.cpp
@@ -150,9 +150,9 @@ DialogExport::DialogExport(agi::Context *c)
 		charset_list->SetStringSelection("Unicode (UTF-8)");
 
 	top_sizer->Add(filter_list, wxSizerFlags(1).Expand());
-	top_sizer->Add(top_buttons, wxSizerFlags(0).Expand());
-	top_sizer->Add(filter_description, wxSizerFlags(0).Expand().Border(wxTOP));
-	top_sizer->Add(charset_list_sizer, wxSizerFlags(0).Expand().Border(wxTOP));
+	top_sizer->Add(top_buttons, wxSizerFlags().Expand());
+	top_sizer->Add(filter_description, wxSizerFlags().Expand().Border(wxTOP));
+	top_sizer->Add(charset_list_sizer, wxSizerFlags().Expand().Border(wxTOP));
 
 	auto btn_sizer = d.CreateStdDialogButtonSizer(wxOK | wxCANCEL | wxHELP);
 	btn_sizer->GetAffirmativeButton()->SetLabelText(_("Export..."));

--- a/src/dialog_export_ebu3264.cpp
+++ b/src/dialog_export_ebu3264.cpp
@@ -150,33 +150,33 @@ int ShowEbuExportConfigurationDialog(wxWindow *owner, EbuExportSettings &s) {
 	wxComboBox *display_standard_ctrl = new wxComboBox(display_standard_box, -1, "", wxDefaultPosition, wxDefaultSize, 2, display_standards, wxCB_DROPDOWN | wxCB_READONLY);
 
 	wxSizer *max_line_length_labelled = new wxBoxSizer(wxHORIZONTAL);
-	max_line_length_labelled->Add(new wxStaticText(text_formatting_box, -1, _("Max. line length:")), wxSizerFlags(1).Center().Border(wxRIGHT, 12));
+	max_line_length_labelled->Add(new wxStaticText(text_formatting_box, -1, _("Max. line length:")), wxSizerFlags(1).Center().DoubleBorder(wxRIGHT));
 	max_line_length_labelled->Add(max_line_length_ctrl);
 
 	wxSizer *timecode_offset_labelled = new wxBoxSizer(wxHORIZONTAL);
-	timecode_offset_labelled->Add(new wxStaticText(timecode_control_box, -1, _("Time code offset:")), wxSizerFlags(1).Center().Border(wxRIGHT, 12));
+	timecode_offset_labelled->Add(new wxStaticText(timecode_control_box, -1, _("Time code offset:")), wxSizerFlags(1).Center().DoubleBorder(wxRIGHT));
 	timecode_offset_labelled->Add(timecode_offset_entry);
 
-	text_formatting_sizer->Add(max_line_length_labelled, wxSizerFlags().Expand().Border(wxALL & ~wxTOP, 6));
-	text_formatting_sizer->Add(wrap_mode_ctrl, wxSizerFlags().Expand().Border(wxALL & ~wxTOP, 6));
-	text_formatting_sizer->Add(translate_alignments_check, wxSizerFlags().Expand().Border(wxALL & ~wxTOP, 6));
+	text_formatting_sizer->Add(max_line_length_labelled, wxSizerFlags().Expand().Border(wxALL & ~wxTOP));
+	text_formatting_sizer->Add(wrap_mode_ctrl, wxSizerFlags().Expand().Border(wxALL & ~wxTOP));
+	text_formatting_sizer->Add(translate_alignments_check, wxSizerFlags().Expand().Border(wxALL & ~wxTOP));
 
-	timecode_control_sizer->Add(timecode_offset_labelled, wxSizerFlags().Expand().Border(wxALL & ~wxTOP, 6));
-	timecode_control_sizer->Add(inclusive_end_times_check, wxSizerFlags().Expand().Border(wxALL & ~wxTOP, 6));
+	timecode_control_sizer->Add(timecode_offset_labelled, wxSizerFlags().Expand().Border(wxALL & ~wxTOP));
+	timecode_control_sizer->Add(inclusive_end_times_check, wxSizerFlags().Expand().Border(wxALL & ~wxTOP));
 
-	display_standard_sizer->Add(display_standard_ctrl, wxSizerFlags().Expand().Border(wxALL & ~wxTOP, 6));
+	display_standard_sizer->Add(display_standard_ctrl, wxSizerFlags().Expand().Border(wxALL & ~wxTOP));
 
 	wxSizer *left_column = new wxBoxSizer(wxVERTICAL);
-	left_column->Add(tv_standard_box, wxSizerFlags().Expand().Border(wxBOTTOM, 6));
-	left_column->Add(timecode_control_sizer, wxSizerFlags().Expand().Border(wxBOTTOM, 6));
+	left_column->Add(tv_standard_box, wxSizerFlags().Expand().Border(wxBOTTOM));
+	left_column->Add(timecode_control_sizer, wxSizerFlags().Expand().Border(wxBOTTOM));
 	left_column->Add(display_standard_sizer, wxSizerFlags().Expand());
 
 	wxSizer *right_column = new wxBoxSizer(wxVERTICAL);
-	right_column->Add(text_encoding_box, wxSizerFlags().Expand().Border(wxBOTTOM, 6));
+	right_column->Add(text_encoding_box, wxSizerFlags().Expand().Border(wxBOTTOM));
 	right_column->Add(text_formatting_sizer, wxSizerFlags().Expand());
 
 	wxSizer *vertical_split_sizer = new wxBoxSizer(wxHORIZONTAL);
-	vertical_split_sizer->Add(left_column, wxSizerFlags().Border(wxRIGHT, 6));
+	vertical_split_sizer->Add(left_column, wxSizerFlags().Border(wxRIGHT));
 	vertical_split_sizer->Add(right_column);
 
 	wxSizer *buttons_sizer = new wxBoxSizer(wxHORIZONTAL);
@@ -184,11 +184,11 @@ int ShowEbuExportConfigurationDialog(wxWindow *owner, EbuExportSettings &s) {
 	wxStaticText *sponsor_label = new wxStaticText(&d, -1, "EBU STL format writing sponsored by Bandai");
 	sponsor_label->Enable(false);
 	buttons_sizer->Add(sponsor_label, wxSizerFlags(1).Bottom());
-	buttons_sizer->Add(d.CreateStdDialogButtonSizer(wxOK | wxCANCEL), wxSizerFlags().Border(wxLEFT, 6));
+	buttons_sizer->Add(d.CreateStdDialogButtonSizer(wxOK | wxCANCEL), wxSizerFlags().Border(wxLEFT));
 
 	wxSizer *main_sizer = new wxBoxSizer(wxVERTICAL);
-	main_sizer->Add(vertical_split_sizer, wxSizerFlags().Expand().Border(wxALL, 12));
-	main_sizer->Add(buttons_sizer, wxSizerFlags().Expand().Border(wxALL & ~wxTOP, 12));
+	main_sizer->Add(vertical_split_sizer, wxSizerFlags().Expand().DoubleBorder());
+	main_sizer->Add(buttons_sizer, wxSizerFlags().Expand().DoubleBorder(wxALL & ~wxTOP));
 
 	d.SetSizerAndFit(main_sizer);
 	d.CenterOnParent();

--- a/src/dialog_export_ebu3264.cpp
+++ b/src/dialog_export_ebu3264.cpp
@@ -150,45 +150,45 @@ int ShowEbuExportConfigurationDialog(wxWindow *owner, EbuExportSettings &s) {
 	wxComboBox *display_standard_ctrl = new wxComboBox(display_standard_box, -1, "", wxDefaultPosition, wxDefaultSize, 2, display_standards, wxCB_DROPDOWN | wxCB_READONLY);
 
 	wxSizer *max_line_length_labelled = new wxBoxSizer(wxHORIZONTAL);
-	max_line_length_labelled->Add(new wxStaticText(text_formatting_box, -1, _("Max. line length:")), 1, wxALIGN_CENTRE|wxRIGHT, 12);
-	max_line_length_labelled->Add(max_line_length_ctrl, 0, 0, 0);
+	max_line_length_labelled->Add(new wxStaticText(text_formatting_box, -1, _("Max. line length:")), wxSizerFlags(1).Center().Border(wxRIGHT, 12));
+	max_line_length_labelled->Add(max_line_length_ctrl);
 
 	wxSizer *timecode_offset_labelled = new wxBoxSizer(wxHORIZONTAL);
-	timecode_offset_labelled->Add(new wxStaticText(timecode_control_box, -1, _("Time code offset:")), 1, wxALIGN_CENTRE|wxRIGHT, 12);
-	timecode_offset_labelled->Add(timecode_offset_entry, 0, 0, 0);
+	timecode_offset_labelled->Add(new wxStaticText(timecode_control_box, -1, _("Time code offset:")), wxSizerFlags(1).Center().Border(wxRIGHT, 12));
+	timecode_offset_labelled->Add(timecode_offset_entry);
 
-	text_formatting_sizer->Add(max_line_length_labelled, 0, wxEXPAND | (wxALL & ~wxTOP), 6);
-	text_formatting_sizer->Add(wrap_mode_ctrl, 0, wxEXPAND | (wxALL & ~wxTOP), 6);
-	text_formatting_sizer->Add(translate_alignments_check, 0, wxEXPAND | (wxALL & ~wxTOP), 6);
+	text_formatting_sizer->Add(max_line_length_labelled, wxSizerFlags().Expand().Border(wxALL & ~wxTOP, 6));
+	text_formatting_sizer->Add(wrap_mode_ctrl, wxSizerFlags().Expand().Border(wxALL & ~wxTOP, 6));
+	text_formatting_sizer->Add(translate_alignments_check, wxSizerFlags().Expand().Border(wxALL & ~wxTOP, 6));
 
-	timecode_control_sizer->Add(timecode_offset_labelled, 0, wxEXPAND | (wxALL & ~wxTOP), 6);
-	timecode_control_sizer->Add(inclusive_end_times_check, 0, wxEXPAND | (wxALL & ~wxTOP), 6);
+	timecode_control_sizer->Add(timecode_offset_labelled, wxSizerFlags().Expand().Border(wxALL & ~wxTOP, 6));
+	timecode_control_sizer->Add(inclusive_end_times_check, wxSizerFlags().Expand().Border(wxALL & ~wxTOP, 6));
 
-	display_standard_sizer->Add(display_standard_ctrl, 0, wxEXPAND | (wxALL & ~wxTOP), 6);
+	display_standard_sizer->Add(display_standard_ctrl, wxSizerFlags().Expand().Border(wxALL & ~wxTOP, 6));
 
 	wxSizer *left_column = new wxBoxSizer(wxVERTICAL);
-	left_column->Add(tv_standard_box, 0, wxEXPAND | wxBOTTOM, 6);
-	left_column->Add(timecode_control_sizer, 0, wxEXPAND | wxBOTTOM, 6);
-	left_column->Add(display_standard_sizer, 0, wxEXPAND, 0);
+	left_column->Add(tv_standard_box, wxSizerFlags().Expand().Border(wxBOTTOM, 6));
+	left_column->Add(timecode_control_sizer, wxSizerFlags().Expand().Border(wxBOTTOM, 6));
+	left_column->Add(display_standard_sizer, wxSizerFlags().Expand());
 
 	wxSizer *right_column = new wxBoxSizer(wxVERTICAL);
-	right_column->Add(text_encoding_box, 0, wxEXPAND|wxBOTTOM, 6);
-	right_column->Add(text_formatting_sizer, 0, wxEXPAND, 0);
+	right_column->Add(text_encoding_box, wxSizerFlags().Expand().Border(wxBOTTOM, 6));
+	right_column->Add(text_formatting_sizer, wxSizerFlags().Expand());
 
 	wxSizer *vertical_split_sizer = new wxBoxSizer(wxHORIZONTAL);
-	vertical_split_sizer->Add(left_column, 0, wxRIGHT, 6);
-	vertical_split_sizer->Add(right_column, 0, 0, 0);
+	vertical_split_sizer->Add(left_column, wxSizerFlags().Border(wxRIGHT, 6));
+	vertical_split_sizer->Add(right_column);
 
 	wxSizer *buttons_sizer = new wxBoxSizer(wxHORIZONTAL);
 	// Developers are requested to leave &d message in! Intentionally not translatable.
 	wxStaticText *sponsor_label = new wxStaticText(&d, -1, "EBU STL format writing sponsored by Bandai");
 	sponsor_label->Enable(false);
-	buttons_sizer->Add(sponsor_label, 1, wxALIGN_BOTTOM, 0);
-	buttons_sizer->Add(d.CreateStdDialogButtonSizer(wxOK | wxCANCEL), 0, wxLEFT, 6);
+	buttons_sizer->Add(sponsor_label, wxSizerFlags(1).Bottom());
+	buttons_sizer->Add(d.CreateStdDialogButtonSizer(wxOK | wxCANCEL), wxSizerFlags().Border(wxLEFT, 6));
 
 	wxSizer *main_sizer = new wxBoxSizer(wxVERTICAL);
-	main_sizer->Add(vertical_split_sizer, 0, wxEXPAND|wxALL, 12);
-	main_sizer->Add(buttons_sizer, 0, wxEXPAND | (wxALL & ~wxTOP), 12);
+	main_sizer->Add(vertical_split_sizer, wxSizerFlags().Expand().Border(wxALL, 12));
+	main_sizer->Add(buttons_sizer, wxSizerFlags().Expand().Border(wxALL & ~wxTOP, 12));
 
 	d.SetSizerAndFit(main_sizer);
 	d.CenterOnParent();

--- a/src/dialog_fonts_collector.cpp
+++ b/src/dialog_fonts_collector.cpp
@@ -262,7 +262,7 @@ DialogFontsCollector::DialogFontsCollector(agi::Context *c)
 
 	wxStaticBoxSizer *log_sizer = new wxStaticBoxSizer(wxVERTICAL, this, _("Log"));
 	wxWindow *log_box = log_sizer->GetStaticBox();
-	collection_log = new wxStyledTextCtrl(log_box, -1, wxDefaultPosition, wxSize(600, 300));
+	collection_log = new wxStyledTextCtrl(log_box, -1, wxDefaultPosition, FromDIP(wxSize(600, 300)));
 	collection_log->SetWrapMode(wxSTC_WRAP_WORD);
 	collection_log->SetMarginWidth(1, 0);
 	collection_log->SetReadOnly(true);

--- a/src/dialog_fonts_collector.cpp
+++ b/src/dialog_fonts_collector.cpp
@@ -254,8 +254,8 @@ DialogFontsCollector::DialogFontsCollector(agi::Context *c)
 	dest_browse_button = new wxButton(destination_box, -1, _("&Browse..."));
 
 	wxSizer *dest_browse_sizer = new wxBoxSizer(wxHORIZONTAL);
-	dest_browse_sizer->Add(dest_ctrl, wxSizerFlags(1).Border(wxRIGHT).Align(wxALIGN_CENTER_VERTICAL));
-	dest_browse_sizer->Add(dest_browse_button, wxSizerFlags());
+	dest_browse_sizer->Add(dest_ctrl, wxSizerFlags(1).Border(wxRIGHT).CenterVertical());
+	dest_browse_sizer->Add(dest_browse_button);
 
 	destination_sizer->Add(dest_label, wxSizerFlags().Border(wxBOTTOM));
 	destination_sizer->Add(dest_browse_sizer, wxSizerFlags().Expand());

--- a/src/dialog_jumpto.cpp
+++ b/src/dialog_jumpto.cpp
@@ -80,12 +80,12 @@ DialogJumpTo::DialogJumpTo(agi::Context *c)
 	JumpTime = new TimeEdit(&d, -1, c, agi::Time(c->videoController->TimeAtFrame(jumpframe)).GetAssFormatted(), wxSize(-1,-1));
 
 	int gap = wxSizerFlags::GetDefaultBorder();
-	auto TimesSizer = new wxGridSizer(2, gap, gap);
+	auto TimesSizer = new wxFlexGridSizer(2, gap, gap);
 
-	TimesSizer->Add(LabelFrame, wxSizerFlags(1).CenterVertical());
+	TimesSizer->Add(LabelFrame, wxSizerFlags().CenterVertical());
 	TimesSizer->Add(JumpFrame, wxSizerFlags().Expand());
 
-	TimesSizer->Add(LabelTime, wxSizerFlags(1).CenterVertical());
+	TimesSizer->Add(LabelTime, wxSizerFlags().CenterVertical());
 	TimesSizer->Add(JumpTime, wxSizerFlags().Expand());
 
 	auto ButtonSizer = d.CreateStdDialogButtonSizer(wxOK | wxCANCEL);

--- a/src/dialog_jumpto.cpp
+++ b/src/dialog_jumpto.cpp
@@ -74,7 +74,7 @@ DialogJumpTo::DialogJumpTo(agi::Context *c)
 	auto LabelTime = new wxStaticText(&d, -1, _("Time: "));
 
 	int JumpFrameSize = std::to_string(c->project->VideoProvider()->GetFrameCount() - 1).size();
-	JumpFrame = new wxTextCtrl(&d,-1,"",wxDefaultPosition,wxSize(-1,-1),wxTE_PROCESS_ENTER, IntValidator((int)jumpframe));
+	JumpFrame = new wxTextCtrl(&d,-1,"",wxDefaultPosition,wxDefaultSize,wxTE_PROCESS_ENTER, IntValidator((int)jumpframe));
 	JumpFrame->SetInitialSize(JumpFrame->GetSizeFromText(wxString(JumpFrameSize, '0')));
 	JumpFrame->SetMaxLength(JumpFrameSize);
 	JumpTime = new TimeEdit(&d, -1, c, agi::Time(c->videoController->TimeAtFrame(jumpframe)).GetAssFormatted(), wxSize(-1,-1));

--- a/src/dialog_jumpto.cpp
+++ b/src/dialog_jumpto.cpp
@@ -79,7 +79,8 @@ DialogJumpTo::DialogJumpTo(agi::Context *c)
 	JumpFrame->SetMaxLength(JumpFrameSize);
 	JumpTime = new TimeEdit(&d, -1, c, agi::Time(c->videoController->TimeAtFrame(jumpframe)).GetAssFormatted(), wxSize(-1,-1));
 
-	auto TimesSizer = new wxFlexGridSizer(2, 5, 5);
+	int gap = wxSizerFlags::GetDefaultBorder();
+	auto TimesSizer = new wxGridSizer(2, gap, gap);
 
 	TimesSizer->Add(LabelFrame, wxSizerFlags(1).CenterVertical());
 	TimesSizer->Add(JumpFrame, wxSizerFlags().Expand());

--- a/src/dialog_jumpto.cpp
+++ b/src/dialog_jumpto.cpp
@@ -81,18 +81,18 @@ DialogJumpTo::DialogJumpTo(agi::Context *c)
 
 	auto TimesSizer = new wxFlexGridSizer(2, 5, 5);
 
-	TimesSizer->Add(LabelFrame, wxSizerFlags().CenterVertical());
-	TimesSizer->Add(JumpFrame);
+	TimesSizer->Add(LabelFrame, wxSizerFlags(1).CenterVertical());
+	TimesSizer->Add(JumpFrame, wxSizerFlags().Expand());
 
-	TimesSizer->Add(LabelTime, wxSizerFlags().CenterVertical());
-	TimesSizer->Add(JumpTime);
+	TimesSizer->Add(LabelTime, wxSizerFlags(1).CenterVertical());
+	TimesSizer->Add(JumpTime, wxSizerFlags().Expand());
 
 	auto ButtonSizer = d.CreateStdDialogButtonSizer(wxOK | wxCANCEL);
 
 	// General layout
 	auto MainSizer = new wxBoxSizer(wxVERTICAL);
-	MainSizer->Add(TimesSizer, 0, wxALL | wxALIGN_CENTER, 5);
-	MainSizer->Add(ButtonSizer, 0, wxEXPAND | wxLEFT | wxBOTTOM | wxRIGHT, 5);
+	MainSizer->Add(TimesSizer, wxSizerFlags().Center().Border());
+	MainSizer->Add(ButtonSizer, wxSizerFlags().Expand().Border(wxALL & ~wxTOP));
 	d.SetSizerAndFit(MainSizer);
 	d.CenterOnParent();
 

--- a/src/dialog_kara_timing_copy.cpp
+++ b/src/dialog_kara_timing_copy.cpp
@@ -425,25 +425,25 @@ DialogKanjiTimer::DialogKanjiTimer(agi::Context *c)
 	wxButton *CloseKT = new wxButton(this,wxID_CLOSE,_("&Close"));
 
 	//Frame: Text
-	DisplayBoxSizer->Add(display, wxSizerFlags().Expand().Border(wxALL, 6));
-	DisplayBoxSizer->Add(Interpolate, wxSizerFlags().Expand().Border(wxALL, 6));
+	DisplayBoxSizer->Add(display, wxSizerFlags().Expand().Border());
+	DisplayBoxSizer->Add(Interpolate, wxSizerFlags().Expand().Border());
 	//Frame: Styles
 	StylesGridSizer->Add(new wxStaticText(StylesBox, -1, TEXT_LABEL_SOURCE), wxSizerFlags().Left().CenterVertical());
 	StylesGridSizer->Add(SourceStyle, wxSizerFlags(1).Expand());
 	StylesGridSizer->Add(new wxStaticText(StylesBox, -1, TEXT_LABEL_DEST), wxSizerFlags().Left().CenterVertical());
 	StylesGridSizer->Add(DestStyle, wxSizerFlags(1).Expand());
-	StylesBoxSizer->Add(StylesGridSizer, wxSizerFlags(1).Expand().Border(wxALL, 6));
+	StylesBoxSizer->Add(StylesGridSizer, wxSizerFlags(1).Expand().Border());
 	//Frame: Shortcut Keys
-	HelpBoxSizer->Add(ShortcutKeys, wxSizerFlags(1).CenterHorizontal().Border(wxRIGHT, 6));
+	HelpBoxSizer->Add(ShortcutKeys, wxSizerFlags(1).CenterHorizontal().Border(wxRIGHT));
 	//Frame: Commands
 	ButtonsBoxSizer->AddStretchSpacer(1);
-	ButtonsBoxSizer->Add(Start, wxSizerFlags().Expand().Border(wxALL, 6));
-	ButtonsBoxSizer->Add(Link, wxSizerFlags().Expand().Border(wxALL&~wxTOP, 6));
-	ButtonsBoxSizer->Add(Unlink, wxSizerFlags().Expand().Border(wxALL&~wxTOP, 6));
-	ButtonsBoxSizer->Add(SkipSourceLine, wxSizerFlags().Expand().Border(wxALL&~wxTOP, 6));
-	ButtonsBoxSizer->Add(SkipDestLine, wxSizerFlags().Expand().Border(wxALL&~wxTOP, 6));
-	ButtonsBoxSizer->Add(GoBackLine, wxSizerFlags().Expand().Border(wxALL&~wxTOP, 6));
-	ButtonsBoxSizer->Add(AcceptLine, wxSizerFlags().Expand().Border(wxALL&~wxTOP, 6));
+	ButtonsBoxSizer->Add(Start, wxSizerFlags().Expand().Border());
+	ButtonsBoxSizer->Add(Link, wxSizerFlags().Expand().Border(wxALL&~wxTOP));
+	ButtonsBoxSizer->Add(Unlink, wxSizerFlags().Expand().Border(wxALL&~wxTOP));
+	ButtonsBoxSizer->Add(SkipSourceLine, wxSizerFlags().Expand().Border(wxALL&~wxTOP));
+	ButtonsBoxSizer->Add(SkipDestLine, wxSizerFlags().Expand().Border(wxALL&~wxTOP));
+	ButtonsBoxSizer->Add(GoBackLine, wxSizerFlags().Expand().Border(wxALL&~wxTOP));
+	ButtonsBoxSizer->Add(AcceptLine, wxSizerFlags().Expand().Border(wxALL&~wxTOP));
 	ButtonsBoxSizer->AddStretchSpacer(1);
 
 	// Button sizer
@@ -453,13 +453,13 @@ DialogKanjiTimer::DialogKanjiTimer(agi::Context *c)
 	buttonSizer->Realize();
 
 	// Layout it all
-	BottomLeftStackSizer->Add(StylesBoxSizer, wxSizerFlags().Expand().Border(wxBOTTOM, 6));
+	BottomLeftStackSizer->Add(StylesBoxSizer, wxSizerFlags().Expand().Border(wxBOTTOM));
 	BottomLeftStackSizer->Add(HelpBoxSizer, wxSizerFlags(1).Expand());
-	BottomShelfSizer->Add(BottomLeftStackSizer, wxSizerFlags(1).Expand().Border(wxRIGHT, 6));
+	BottomShelfSizer->Add(BottomLeftStackSizer, wxSizerFlags(1).Expand().Border(wxRIGHT));
 	BottomShelfSizer->Add(ButtonsBoxSizer, wxSizerFlags().Expand());
-	MainStackSizer->Add(DisplayBoxSizer, wxSizerFlags().Expand().Border(wxALL, 6));
-	MainStackSizer->Add(BottomShelfSizer, wxSizerFlags(1).Expand().Border(wxLEFT|wxRIGHT, 6));
-	MainStackSizer->Add(buttonSizer, wxSizerFlags().Expand().Border(wxALL, 6));
+	MainStackSizer->Add(DisplayBoxSizer, wxSizerFlags().Expand().Border());
+	MainStackSizer->Add(BottomShelfSizer, wxSizerFlags(1).Expand().HorzBorder());
+	MainStackSizer->Add(buttonSizer, wxSizerFlags().Expand().Border());
 
 	SetSizerAndFit(MainStackSizer);
 	CenterOnParent();

--- a/src/dialog_kara_timing_copy.cpp
+++ b/src/dialog_kara_timing_copy.cpp
@@ -390,7 +390,8 @@ DialogKanjiTimer::DialogKanjiTimer(agi::Context *c)
 
 	wxStaticBoxSizer *DisplayBoxSizer = new wxStaticBoxSizer(wxVERTICAL,this,_("Text"));
 	wxStaticBoxSizer *StylesBoxSizer = new wxStaticBoxSizer(wxVERTICAL,this,_("Styles"));
-	auto StylesGridSizer = new wxFlexGridSizer(2, 2, 6, 6);
+	int gap = wxSizerFlags::GetDefaultBorder();
+	auto StylesGridSizer = new wxFlexGridSizer(2, 2, gap, gap);
 	wxStaticBoxSizer *HelpBoxSizer = new wxStaticBoxSizer(wxVERTICAL,this,_("Shortcut Keys"));
 	wxStaticBoxSizer *ButtonsBoxSizer = new wxStaticBoxSizer(wxVERTICAL,this,_("Commands"));
 	wxSizer *MainStackSizer = new wxBoxSizer(wxVERTICAL);

--- a/src/dialog_kara_timing_copy.cpp
+++ b/src/dialog_kara_timing_copy.cpp
@@ -410,8 +410,8 @@ DialogKanjiTimer::DialogKanjiTimer(agi::Context *c)
 	Interpolate->SetValue(OPT_GET("Tool/Kanji Timer/Interpolation")->GetBool());
 
 	wxArrayString styles = to_wx(subs->GetStyles());
-	SourceStyle = new wxComboBox(StylesBox, -1, "", wxDefaultPosition, wxSize(160, -1), styles, wxCB_READONLY);
-	DestStyle = new wxComboBox(StylesBox, -1, "", wxDefaultPosition, wxSize(160, -1), styles, wxCB_READONLY);
+	SourceStyle = new wxComboBox(StylesBox, -1, "", wxDefaultPosition, FromDIP(wxSize(160, -1)), styles, wxCB_READONLY);
+	DestStyle = new wxComboBox(StylesBox, -1, "", wxDefaultPosition, FromDIP(wxSize(160, -1)), styles, wxCB_READONLY);
 
 	wxStaticText *ShortcutKeys = new wxStaticText(HelpBox,-1,_("When the destination textbox has focus, use the following keys:\n\nRight Arrow: Increase dest. selection length\nLeft Arrow: Decrease dest. selection length\nUp Arrow: Increase source selection length\nDown Arrow: Decrease source selection length\nEnter: Link, accept line when done\nBackspace: Unlink last"));
 

--- a/src/dialog_kara_timing_copy.cpp
+++ b/src/dialog_kara_timing_copy.cpp
@@ -425,25 +425,25 @@ DialogKanjiTimer::DialogKanjiTimer(agi::Context *c)
 	wxButton *CloseKT = new wxButton(this,wxID_CLOSE,_("&Close"));
 
 	//Frame: Text
-	DisplayBoxSizer->Add(display, 0, wxEXPAND|wxALL, 6);
-	DisplayBoxSizer->Add(Interpolate, 0, wxEXPAND|wxALL, 6);
+	DisplayBoxSizer->Add(display, wxSizerFlags().Expand().Border(wxALL, 6));
+	DisplayBoxSizer->Add(Interpolate, wxSizerFlags().Expand().Border(wxALL, 6));
 	//Frame: Styles
-	StylesGridSizer->Add(new wxStaticText(StylesBox, -1, TEXT_LABEL_SOURCE), 0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL);
-	StylesGridSizer->Add(SourceStyle, 1, wxEXPAND);
-	StylesGridSizer->Add(new wxStaticText(StylesBox, -1, TEXT_LABEL_DEST), 0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL);
-	StylesGridSizer->Add(DestStyle, 1, wxEXPAND);
-	StylesBoxSizer->Add(StylesGridSizer, 1, wxEXPAND|wxALL, 6);
+	StylesGridSizer->Add(new wxStaticText(StylesBox, -1, TEXT_LABEL_SOURCE), wxSizerFlags().Left().CenterVertical());
+	StylesGridSizer->Add(SourceStyle, wxSizerFlags(1).Expand());
+	StylesGridSizer->Add(new wxStaticText(StylesBox, -1, TEXT_LABEL_DEST), wxSizerFlags().Left().CenterVertical());
+	StylesGridSizer->Add(DestStyle, wxSizerFlags(1).Expand());
+	StylesBoxSizer->Add(StylesGridSizer, wxSizerFlags(1).Expand().Border(wxALL, 6));
 	//Frame: Shortcut Keys
-	HelpBoxSizer->Add(ShortcutKeys, 1, wxALIGN_CENTER_HORIZONTAL|wxRIGHT, 6);
+	HelpBoxSizer->Add(ShortcutKeys, wxSizerFlags(1).CenterHorizontal().Border(wxRIGHT, 6));
 	//Frame: Commands
 	ButtonsBoxSizer->AddStretchSpacer(1);
-	ButtonsBoxSizer->Add(Start, 0, wxEXPAND|wxALL, 6);
-	ButtonsBoxSizer->Add(Link, 0, wxEXPAND|(wxALL&~wxTOP), 6);
-	ButtonsBoxSizer->Add(Unlink, 0, wxEXPAND|(wxALL&~wxTOP), 6);
-	ButtonsBoxSizer->Add(SkipSourceLine, 0, wxEXPAND|(wxALL&~wxTOP), 6);
-	ButtonsBoxSizer->Add(SkipDestLine, 0, wxEXPAND|(wxALL&~wxTOP), 6);
-	ButtonsBoxSizer->Add(GoBackLine, 0, wxEXPAND|(wxALL&~wxTOP), 6);
-	ButtonsBoxSizer->Add(AcceptLine, 0, wxEXPAND|(wxALL&~wxTOP), 6);
+	ButtonsBoxSizer->Add(Start, wxSizerFlags().Expand().Border(wxALL, 6));
+	ButtonsBoxSizer->Add(Link, wxSizerFlags().Expand().Border(wxALL&~wxTOP, 6));
+	ButtonsBoxSizer->Add(Unlink, wxSizerFlags().Expand().Border(wxALL&~wxTOP, 6));
+	ButtonsBoxSizer->Add(SkipSourceLine, wxSizerFlags().Expand().Border(wxALL&~wxTOP, 6));
+	ButtonsBoxSizer->Add(SkipDestLine, wxSizerFlags().Expand().Border(wxALL&~wxTOP, 6));
+	ButtonsBoxSizer->Add(GoBackLine, wxSizerFlags().Expand().Border(wxALL&~wxTOP, 6));
+	ButtonsBoxSizer->Add(AcceptLine, wxSizerFlags().Expand().Border(wxALL&~wxTOP, 6));
 	ButtonsBoxSizer->AddStretchSpacer(1);
 
 	// Button sizer
@@ -453,13 +453,13 @@ DialogKanjiTimer::DialogKanjiTimer(agi::Context *c)
 	buttonSizer->Realize();
 
 	// Layout it all
-	BottomLeftStackSizer->Add(StylesBoxSizer, 0, wxEXPAND|wxBOTTOM, 6);
-	BottomLeftStackSizer->Add(HelpBoxSizer, 1, wxEXPAND, 0);
-	BottomShelfSizer->Add(BottomLeftStackSizer, 1, wxEXPAND|wxRIGHT, 6);
-	BottomShelfSizer->Add(ButtonsBoxSizer, 0, wxEXPAND, 0);
-	MainStackSizer->Add(DisplayBoxSizer, 0, wxEXPAND|wxALL, 6);
-	MainStackSizer->Add(BottomShelfSizer, 1, wxEXPAND|wxLEFT|wxRIGHT, 6);
-	MainStackSizer->Add(buttonSizer, 0, wxEXPAND|wxALL, 6);
+	BottomLeftStackSizer->Add(StylesBoxSizer, wxSizerFlags().Expand().Border(wxBOTTOM, 6));
+	BottomLeftStackSizer->Add(HelpBoxSizer, wxSizerFlags(1).Expand());
+	BottomShelfSizer->Add(BottomLeftStackSizer, wxSizerFlags(1).Expand().Border(wxRIGHT, 6));
+	BottomShelfSizer->Add(ButtonsBoxSizer, wxSizerFlags().Expand());
+	MainStackSizer->Add(DisplayBoxSizer, wxSizerFlags().Expand().Border(wxALL, 6));
+	MainStackSizer->Add(BottomShelfSizer, wxSizerFlags(1).Expand().Border(wxLEFT|wxRIGHT, 6));
+	MainStackSizer->Add(buttonSizer, wxSizerFlags().Expand().Border(wxALL, 6));
 
 	SetSizerAndFit(MainStackSizer);
 	CenterOnParent();

--- a/src/dialog_log.cpp
+++ b/src/dialog_log.cpp
@@ -104,7 +104,7 @@ LogWindow::LogWindow(agi::Context *c)
 
 	wxSizer *sizer = new wxBoxSizer(wxVERTICAL);
 	sizer->Add(text_ctrl, wxSizerFlags(1).Expand().Border());
-	sizer->Add(new wxButton(this, wxID_OK), wxSizerFlags(0).Border().Right());
+	sizer->Add(new wxButton(this, wxID_OK), wxSizerFlags().Border().Right());
 	SetSizerAndFit(sizer);
 
 	agi::log::log->Subscribe(std::unique_ptr<agi::log::Emitter>(emit_log = new EmitLog(text_ctrl)));

--- a/src/dialog_log.cpp
+++ b/src/dialog_log.cpp
@@ -99,7 +99,7 @@ public:
 LogWindow::LogWindow(agi::Context *c)
 : wxDialog(c->parent, -1, _("Log window"), wxDefaultPosition, wxDefaultSize, wxCAPTION | wxCLOSE_BOX | wxRESIZE_BORDER)
 {
-	wxTextCtrl *text_ctrl = new wxTextCtrl(this, -1, "", wxDefaultPosition, wxSize(700,300), wxTE_MULTILINE|wxTE_READONLY);
+	wxTextCtrl *text_ctrl = new wxTextCtrl(this, -1, "", wxDefaultPosition, FromDIP(wxSize(700,300)), wxTE_MULTILINE|wxTE_READONLY);
 	text_ctrl->SetDefaultStyle(wxTextAttr(wxNullColour, wxNullColour, wxFont(8, wxFONTFAMILY_MODERN, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL)));
 
 	wxSizer *sizer = new wxBoxSizer(wxVERTICAL);

--- a/src/dialog_paste_over.cpp
+++ b/src/dialog_paste_over.cpp
@@ -58,7 +58,7 @@ DialogPasteOver::DialogPasteOver(wxWindow *parent)
 	// Label and list sizer
 	wxStaticBoxSizer *ListSizer = new wxStaticBoxSizer(wxVERTICAL, &d, _("Fields"));
 	wxWindow *ListSizerBox = ListSizer->GetStaticBox();
-	ListSizer->Add(new wxStaticText(ListSizerBox, -1, _("Please select the fields that you want to paste over:")), wxSizerFlags());
+	ListSizer->Add(new wxStaticText(ListSizerBox, -1, _("Please select the fields that you want to paste over:")));
 
 	// List box
 	wxArrayString choices;
@@ -74,7 +74,7 @@ DialogPasteOver::DialogPasteOver(wxWindow *parent)
 	choices.Add(_("Effect"));
 	choices.Add(_("Text"));
 	ListBox = new wxCheckListBox(ListSizerBox, -1, wxDefaultPosition, wxDefaultSize, choices);
-	ListSizer->Add(ListBox, wxSizerFlags(0).Expand().Border(wxTOP));
+	ListSizer->Add(ListBox, wxSizerFlags().Expand().Border(wxTOP));
 
 	std::vector<bool> options = OPT_GET("Tool/Paste Lines Over/Fields")->GetListBool();
 	if (options.size() != choices.size())
@@ -87,13 +87,13 @@ DialogPasteOver::DialogPasteOver(wxWindow *parent)
 	wxButton *btn;
 	wxSizer *TopButtonSizer = new wxBoxSizer(wxHORIZONTAL);
 
-	TopButtonSizer->Add(btn = new wxButton(&d, -1, _("&All")), wxSizerFlags(1));
+	TopButtonSizer->Add(btn = new wxButton(&d, -1, _("&All")), 1);
 	btn->Bind(wxEVT_BUTTON, std::bind(&DialogPasteOver::CheckAll, this, true));
-	TopButtonSizer->Add(btn = new wxButton(&d, -1, _("&None")), wxSizerFlags(1));
+	TopButtonSizer->Add(btn = new wxButton(&d, -1, _("&None")), 1);
 	btn->Bind(wxEVT_BUTTON, std::bind(&DialogPasteOver::CheckAll, this, false));
-	TopButtonSizer->Add(btn = new wxButton(&d, -1, _("&Times")), wxSizerFlags(1));
+	TopButtonSizer->Add(btn = new wxButton(&d, -1, _("&Times")), 1);
 	btn->Bind(wxEVT_BUTTON, &DialogPasteOver::OnTimes, this);
-	TopButtonSizer->Add(btn = new wxButton(&d, -1, _("T&ext")), wxSizerFlags(1));
+	TopButtonSizer->Add(btn = new wxButton(&d, -1, _("T&ext")), 1);
 	btn->Bind(wxEVT_BUTTON, &DialogPasteOver::OnText, this);
 
 	// Buttons
@@ -103,9 +103,9 @@ DialogPasteOver::DialogPasteOver(wxWindow *parent)
 
 	// Main sizer
 	wxSizer *MainSizer = new wxBoxSizer(wxVERTICAL);
-	MainSizer->Add(ListSizer,0,wxEXPAND | wxLEFT | wxRIGHT,5);
-	MainSizer->Add(TopButtonSizer,0,wxLEFT | wxRIGHT | wxEXPAND,5);
-	MainSizer->Add(ButtonSizer,0,wxALL | wxEXPAND,5);
+	MainSizer->Add(ListSizer, wxSizerFlags().Expand().HorzBorder());
+	MainSizer->Add(TopButtonSizer, wxSizerFlags().Expand().HorzBorder());
+	MainSizer->Add(ButtonSizer, wxSizerFlags().Expand().Border());
 	d.SetSizerAndFit(MainSizer);
 	d.CenterOnParent();
 }

--- a/src/dialog_progress.cpp
+++ b/src/dialog_progress.cpp
@@ -112,10 +112,10 @@ DialogProgress::DialogProgress(wxWindow *parent, wxString const& title_text, wxS
 , pulse_timer(GetEventHandler())
 {
 	title = new wxStaticText(this, -1, title_text, wxDefaultPosition, wxDefaultSize, wxALIGN_CENTRE | wxST_NO_AUTORESIZE);
-	gauge = new wxGauge(this, -1, 300, wxDefaultPosition, wxSize(300,20));
+	gauge = new wxGauge(this, -1, 300, wxDefaultPosition, FromDIP(wxSize(300,20)));
 	text = new wxStaticText(this, -1, message, wxDefaultPosition, wxDefaultSize, wxALIGN_CENTRE | wxST_NO_AUTORESIZE);
 	cancel_button = new wxButton(this, wxID_CANCEL);
-	log_output = new wxTextCtrl(this, -1, "", wxDefaultPosition, wxSize(600, 240), wxTE_MULTILINE | wxTE_READONLY);
+	log_output = new wxTextCtrl(this, -1, "", wxDefaultPosition, FromDIP(wxSize(600, 240)), wxTE_MULTILINE | wxTE_READONLY);
 
 	// make the title a slightly larger font
 	wxFont title_font = title->GetFont();

--- a/src/dialog_properties.cpp
+++ b/src/dialog_properties.cpp
@@ -162,7 +162,7 @@ DialogProperties::DialogProperties(agi::Context *c)
 	res_sizer->Add(LayoutResX, wxGBPosition(1, 1), wxGBSpan(1, 1), wxSizerFlags().Expand().CenterVertical().Border(wxRIGHT, 2).GetFlags());
 	res_sizer->Add(new wxStaticText(res_box, -1, _(L"\u00D7")), wxGBPosition(1, 2), wxGBSpan(1, 1), wxSizerFlags().Center().Border(wxRIGHT, 2).GetFlags()); // U+00D7 multiplication sign
 	res_sizer->Add(LayoutResY, wxGBPosition(1, 3), wxGBSpan(1, 1), wxSizerFlags().Expand().CenterVertical().Border(wxRIGHT, 2).GetFlags());
-	res_sizer->Add(LayoutResFromVideo, wxGBPosition(1, 4), wxGBSpan(1, 1));
+	res_sizer->Add(LayoutResFromVideo, wxGBPosition(1, 4), wxGBSpan(1, 1), wxSizerFlags().Expand().GetFlags());
 
 	YCbCrMatrix = new wxComboBox(res_box, -1, to_wx(c->ass->GetScriptInfo("YCbCr Matrix")),
 		 wxDefaultPosition, wxDefaultSize, to_wx(agi::ycbcr::valid_header_strings), wxCB_READONLY);
@@ -174,7 +174,7 @@ DialogProperties::DialogProperties(agi::Context *c)
 		YCbCrMatrixFromVideo->Bind(wxEVT_BUTTON, &DialogProperties::OnSetYCbCrMatrixFromVideo, this);
 
 	res_sizer->Add(new wxStaticText(res_box, -1, _("YCbCr Matrix:")), wxGBPosition(2, 0), wxGBSpan(1, 1), wxSizerFlags().Center().GetFlags());
-	res_sizer->Add(YCbCrMatrix, wxGBPosition(2, 1), wxGBSpan(1, 3), wxSizerFlags(1).Expand().Border(wxLEFT).GetFlags());
+	res_sizer->Add(YCbCrMatrix, wxGBPosition(2, 1), wxGBSpan(1, 3), wxSizerFlags(1).Expand().CenterVertical().Border(wxLEFT).GetFlags());
 	res_sizer->Add(YCbCrMatrixFromVideo, wxGBPosition(2, 4), wxGBSpan(1, 1), wxSizerFlags().Expand().GetFlags());
 
 	res_box_sizer->Add(res_sizer, wxSizerFlags().Expand());

--- a/src/dialog_properties.cpp
+++ b/src/dialog_properties.cpp
@@ -111,7 +111,8 @@ DialogProperties::DialogProperties(agi::Context *c)
 	// Script details crap
 	wxStaticBoxSizer *TopSizer = new wxStaticBoxSizer(wxHORIZONTAL,&d,_("Script"));
 	wxWindow *TopSizerBox = TopSizer->GetStaticBox();
-	auto TopSizerGrid = new wxFlexGridSizer(0,2,5,5);
+	int gap = wxSizerFlags::GetDefaultBorder();
+	auto TopSizerGrid = new wxFlexGridSizer(0, 2, gap, gap);
 
 	AddProperty(TopSizerBox, TopSizerGrid, _("Title:"), "Title");
 	AddProperty(TopSizerBox, TopSizerGrid, _("Original script:"), "Original Script");
@@ -181,7 +182,7 @@ DialogProperties::DialogProperties(agi::Context *c)
 	// Options
 	wxStaticBoxSizer *optionsSizer = new wxStaticBoxSizer(wxHORIZONTAL,&d,_("Options"));
 	wxWindow *optionsBox = optionsSizer->GetStaticBox();
-	auto optionsGrid = new wxFlexGridSizer(3,2,5,5);
+	auto optionsGrid = new wxFlexGridSizer(3, 2, gap, gap);
 	wxString wrap_opts[] = {
 		_("0: Smart wrapping, top line is wider"),
 		_("1: End-of-line word wrapping, only \\N breaks"),
@@ -196,7 +197,6 @@ DialogProperties::DialogProperties(agi::Context *c)
 	ScaleBorder = new wxCheckBox(optionsBox,-1,_("Scale Border and Shadow"));
 	ScaleBorder->SetToolTip(_("Scale border and shadow together with script/render resolution. If this is unchecked, relative border and shadow size will depend on renderer."));
 	ScaleBorder->SetValue(boost::iequals(c->ass->GetScriptInfo("ScaledBorderAndShadow"), "yes"));
-	optionsGrid->AddSpacer(0);
 	optionsGrid->Add(ScaleBorder, wxSizerFlags(1).Expand());
 	optionsGrid->AddGrowableCol(1,1);
 	optionsSizer->Add(optionsGrid, wxSizerFlags(1).Expand());

--- a/src/dialog_properties.cpp
+++ b/src/dialog_properties.cpp
@@ -123,7 +123,7 @@ DialogProperties::DialogProperties(agi::Context *c)
 	AddProperty(TopSizerBox, TopSizerGrid, _("Update details:"), "Update Details");
 
 	TopSizerGrid->AddGrowableCol(1,1);
-	TopSizer->Add(TopSizerGrid,1,wxEXPAND,0);
+	TopSizer->Add(TopSizerGrid, wxSizerFlags(1).Expand());
 
 	// Resolution box
 	wxStaticBoxSizer *res_box_sizer = new wxStaticBoxSizer(wxVERTICAL, &d, _("Resolution"));
@@ -146,9 +146,9 @@ DialogProperties::DialogProperties(agi::Context *c)
 	res_sizer->AddGrowableCol(1, 1);
 	res_sizer->AddGrowableCol(3, 1);
 	res_sizer->Add(new wxStaticText(res_box, -1, _("Script: ")), wxGBPosition(0, 0), wxGBSpan(1, 1), wxSizerFlags().Center().Left().GetFlags());
-	res_sizer->Add(ResX, wxGBPosition(0, 1), wxGBSpan(1, 1), wxRIGHT | wxALIGN_CENTER_VERTICAL | wxEXPAND, 2);
-	res_sizer->Add(new wxStaticText(res_box, -1, _(L"\u00D7")), wxGBPosition(0, 2), wxGBSpan(1, 1), wxALIGN_CENTER | wxRIGHT, 2); // U+00D7 multiplication sign
-	res_sizer->Add(ResY, wxGBPosition(0, 3), wxGBSpan(1, 1), wxRIGHT | wxALIGN_CENTER_VERTICAL | wxEXPAND, 2);
+	res_sizer->Add(ResX, wxGBPosition(0, 1), wxGBSpan(1, 1), wxSizerFlags().Expand().CenterVertical().Border(wxRIGHT, 2).GetFlags());
+	res_sizer->Add(new wxStaticText(res_box, -1, _(L"\u00D7")), wxGBPosition(0, 2), wxGBSpan(1, 1), wxSizerFlags().Center().Border(wxRIGHT, 2).GetFlags()); // U+00D7 multiplication sign
+	res_sizer->Add(ResY, wxGBPosition(0, 3), wxGBSpan(1, 1), wxSizerFlags().Expand().CenterVertical().Border(wxRIGHT, 2).GetFlags());
 	res_sizer->Add(FromVideo, wxGBPosition(0, 4), wxGBSpan(1, 1));
 
 	wxButton *LayoutResFromVideo = new wxButton(res_box,-1,_("From video"));
@@ -158,9 +158,9 @@ DialogProperties::DialogProperties(agi::Context *c)
 		LayoutResFromVideo->Bind(wxEVT_BUTTON, &DialogProperties::OnSetLayoutResFromVideo, this);
 
 	res_sizer->Add(new wxStaticText(res_box, -1, _("Layout: ")), wxGBPosition(1, 0), wxGBSpan(1, 1), wxSizerFlags().Center().Left().GetFlags());
-	res_sizer->Add(LayoutResX, wxGBPosition(1, 1), wxGBSpan(1, 1), wxRIGHT | wxALIGN_CENTER_VERTICAL | wxEXPAND, 2);
-	res_sizer->Add(new wxStaticText(res_box, -1, _(L"\u00D7")), wxGBPosition(1, 2), wxGBSpan(1, 1), wxALIGN_CENTER | wxRIGHT, 2); // U+00D7 multiplication sign
-	res_sizer->Add(LayoutResY, wxGBPosition(1, 3), wxGBSpan(1, 1), wxRIGHT | wxALIGN_CENTER_VERTICAL | wxEXPAND, 2);
+	res_sizer->Add(LayoutResX, wxGBPosition(1, 1), wxGBSpan(1, 1), wxSizerFlags().Expand().CenterVertical().Border(wxRIGHT, 2).GetFlags());
+	res_sizer->Add(new wxStaticText(res_box, -1, _(L"\u00D7")), wxGBPosition(1, 2), wxGBSpan(1, 1), wxSizerFlags().Center().Border(wxRIGHT, 2).GetFlags()); // U+00D7 multiplication sign
+	res_sizer->Add(LayoutResY, wxGBPosition(1, 3), wxGBSpan(1, 1), wxSizerFlags().Expand().CenterVertical().Border(wxRIGHT, 2).GetFlags());
 	res_sizer->Add(LayoutResFromVideo, wxGBPosition(1, 4), wxGBSpan(1, 1));
 
 	YCbCrMatrix = new wxComboBox(res_box, -1, to_wx(c->ass->GetScriptInfo("YCbCr Matrix")),
@@ -190,23 +190,23 @@ DialogProperties::DialogProperties(agi::Context *c)
 	};
 	WrapStyle = new wxComboBox(optionsBox, -1, "", wxDefaultPosition, wxDefaultSize, 4, wrap_opts, wxCB_READONLY);
 	WrapStyle->SetSelection(c->ass->GetScriptInfoAsInt("WrapStyle"));
-	optionsGrid->Add(new wxStaticText(optionsBox,-1,_("Wrap Style: ")),0,wxALIGN_CENTER_VERTICAL,0);
-	optionsGrid->Add(WrapStyle,1,wxEXPAND,0);
+	optionsGrid->Add(new wxStaticText(optionsBox,-1,_("Wrap Style: ")), wxSizerFlags().CenterVertical());
+	optionsGrid->Add(WrapStyle, wxSizerFlags(1).Expand());
 
 	ScaleBorder = new wxCheckBox(optionsBox,-1,_("Scale Border and Shadow"));
 	ScaleBorder->SetToolTip(_("Scale border and shadow together with script/render resolution. If this is unchecked, relative border and shadow size will depend on renderer."));
 	ScaleBorder->SetValue(boost::iequals(c->ass->GetScriptInfo("ScaledBorderAndShadow"), "yes"));
 	optionsGrid->AddSpacer(0);
-	optionsGrid->Add(ScaleBorder,1,wxEXPAND,0);
+	optionsGrid->Add(ScaleBorder, wxSizerFlags(1).Expand());
 	optionsGrid->AddGrowableCol(1,1);
-	optionsSizer->Add(optionsGrid,1,wxEXPAND,0);
+	optionsSizer->Add(optionsGrid, wxSizerFlags(1).Expand());
 
 	// MainSizer
 	wxSizer *MainSizer = new wxBoxSizer(wxVERTICAL);
-	MainSizer->Add(TopSizer,0,wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND,5);
-	MainSizer->Add(res_box_sizer,0,wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND,5);
-	MainSizer->Add(optionsSizer,0,wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND,5);
-	MainSizer->Add(ButtonSizer,0,wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND,5);
+	MainSizer->Add(TopSizer, wxSizerFlags().Expand().Border(wxALL & ~wxTOP));
+	MainSizer->Add(res_box_sizer, wxSizerFlags().Expand().Border(wxALL & ~wxTOP));
+	MainSizer->Add(optionsSizer, wxSizerFlags().Expand().Border(wxALL & ~wxTOP));
+	MainSizer->Add(ButtonSizer, wxSizerFlags().Expand().Border(wxALL & ~wxTOP));
 
 	d.SetSizerAndFit(MainSizer);
 	d.CenterOnParent();

--- a/src/dialog_resample.cpp
+++ b/src/dialog_resample.cpp
@@ -177,7 +177,8 @@ DialogResample::DialogResample(agi::Context *c, ResampleSettings &settings)
 		wxDefaultSize, std::size(ar_modes), ar_modes, 1, 4, MakeEnumBinder(&settings.ar_mode));
 
 	// Position the controls
-	auto margin_sizer = new wxGridSizer(3, 3, 5, 5);
+	int gap = wxSizerFlags::GetDefaultBorder();
+	auto margin_sizer = new wxGridSizer(3, 3, gap, gap);
 	margin_sizer->AddSpacer(1);
 	margin_sizer->Add(margin_ctrl[TOP], wxSizerFlags(1).Expand());
 	margin_sizer->AddSpacer(1);

--- a/src/dialog_resample.cpp
+++ b/src/dialog_resample.cpp
@@ -191,9 +191,9 @@ DialogResample::DialogResample(agi::Context *c, ResampleSettings &settings)
 	margin_box_sizer->Add(margin_sizer, wxSizerFlags(1).Expand().Border(wxBOTTOM));
 
 	auto source_res_sizer = new wxBoxSizer(wxHORIZONTAL);
-	source_res_sizer->Add(source_x, wxSizerFlags(1).Border(wxRIGHT).Align(wxALIGN_CENTER_VERTICAL));
+	source_res_sizer->Add(source_x, wxSizerFlags(1).Border(wxRIGHT).CenterVertical());
 	source_res_sizer->Add(new wxStaticText(source_res_box, -1, _(L"\u00D7")), wxSizerFlags().Center().Border(wxRIGHT)); // U+00D7 multiplication sign
-	source_res_sizer->Add(source_y, wxSizerFlags(1).Border(wxRIGHT).Align(wxALIGN_CENTER_VERTICAL));
+	source_res_sizer->Add(source_y, wxSizerFlags(1).Border(wxRIGHT).CenterVertical());
 	source_res_sizer->Add(from_script);
 
 	auto source_matrix_sizer = new wxBoxSizer(wxHORIZONTAL);
@@ -204,9 +204,9 @@ DialogResample::DialogResample(agi::Context *c, ResampleSettings &settings)
 	source_res_box_sizer->Add(source_matrix_sizer, wxSizerFlags(1).Expand());
 
 	auto dest_res_sizer = new wxBoxSizer(wxHORIZONTAL);
-	dest_res_sizer->Add(dest_x, wxSizerFlags(1).Border(wxRIGHT).Align(wxALIGN_CENTER_VERTICAL));
+	dest_res_sizer->Add(dest_x, wxSizerFlags(1).Border(wxRIGHT).CenterVertical());
 	dest_res_sizer->Add(new wxStaticText(dest_res_box, -1, _(L"\u00D7")), wxSizerFlags().Center().Border(wxRIGHT));
-	dest_res_sizer->Add(dest_y, wxSizerFlags(1).Border(wxRIGHT).Align(wxALIGN_CENTER_VERTICAL));
+	dest_res_sizer->Add(dest_y, wxSizerFlags(1).Border(wxRIGHT).CenterVertical());
 	dest_res_sizer->Add(from_video);
 
 	auto dest_matrix_sizer = new wxBoxSizer(wxHORIZONTAL);

--- a/src/dialog_search_replace.cpp
+++ b/src/dialog_search_replace.cpp
@@ -61,7 +61,8 @@ DialogSearchReplace<has_replace>::DialogSearchReplace(agi::Context* c)
 	settings->skip_tags = OPT_GET("Tool/Search Replace/Skip Tags")->GetBool();
 	settings->exact_match = false;
 
-	auto find_sizer = new wxFlexGridSizer(2, 2, 5, 15);
+	int gap = wxSizerFlags::GetDefaultBorder();
+	auto find_sizer = new wxFlexGridSizer(2, 2, gap, wxRound(3 * wxSizerFlags::GetDefaultBorderFractional()));
 	find_edit = new wxComboBox(this, -1, "", wxDefaultPosition, wxSize(300, -1), recent_find, wxCB_DROPDOWN | wxTE_PROCESS_ENTER, StringBinder(&settings->find));
 	find_edit->SetMaxLength(0);
 	find_sizer->Add(new wxStaticText(this, -1, _("Find what:")), wxSizerFlags().Center().Left());

--- a/src/dialog_search_replace.cpp
+++ b/src/dialog_search_replace.cpp
@@ -63,13 +63,13 @@ DialogSearchReplace<has_replace>::DialogSearchReplace(agi::Context* c)
 
 	int gap = wxSizerFlags::GetDefaultBorder();
 	auto find_sizer = new wxFlexGridSizer(2, 2, gap, wxRound(3 * wxSizerFlags::GetDefaultBorderFractional()));
-	find_edit = new wxComboBox(this, -1, "", wxDefaultPosition, wxSize(300, -1), recent_find, wxCB_DROPDOWN | wxTE_PROCESS_ENTER, StringBinder(&settings->find));
+	find_edit = new wxComboBox(this, -1, "", wxDefaultPosition, FromDIP(wxSize(300, -1)), recent_find, wxCB_DROPDOWN | wxTE_PROCESS_ENTER, StringBinder(&settings->find));
 	find_edit->SetMaxLength(0);
 	find_sizer->Add(new wxStaticText(this, -1, _("Find what:")), wxSizerFlags().Center().Left());
 	find_sizer->Add(find_edit);
 
 	if (has_replace) {
-		replace_edit = new wxComboBox(this, -1, "", wxDefaultPosition, wxSize(300, -1), lagi_MRU_wxAS("Replace"), wxCB_DROPDOWN | wxTE_PROCESS_ENTER, StringBinder(&settings->replace_with));
+		replace_edit = new wxComboBox(this, -1, "", wxDefaultPosition, FromDIP(wxSize(300, -1)), lagi_MRU_wxAS("Replace"), wxCB_DROPDOWN | wxTE_PROCESS_ENTER, StringBinder(&settings->replace_with));
 		replace_edit->SetMaxLength(0);
 		find_sizer->Add(new wxStaticText(this, -1, _("Replace with:")), wxSizerFlags().Center().Left());
 		find_sizer->Add(replace_edit);

--- a/src/dialog_search_replace.cpp
+++ b/src/dialog_search_replace.cpp
@@ -62,44 +62,68 @@ DialogSearchReplace<has_replace>::DialogSearchReplace(agi::Context* c)
 	settings->exact_match = false;
 
 	int gap = wxSizerFlags::GetDefaultBorder();
-	auto find_sizer = new wxFlexGridSizer(2, 2, gap, wxRound(3 * wxSizerFlags::GetDefaultBorderFractional()));
-	find_edit = new wxComboBox(this, -1, "", wxDefaultPosition, FromDIP(wxSize(300, -1)), recent_find, wxCB_DROPDOWN | wxTE_PROCESS_ENTER, StringBinder(&settings->find));
+	
+	// Find/Replace inputs
+	auto find_sizer = new wxFlexGridSizer(2, 2, 
+		gap, wxRound(3 * wxSizerFlags::GetDefaultBorderFractional()));
+	find_sizer->AddGrowableCol(1, 1);
+	find_edit = new wxComboBox(this, -1, "", wxDefaultPosition,
+		wxDefaultSize,
+		recent_find, 
+		wxCB_DROPDOWN | wxTE_PROCESS_ENTER, 
+		StringBinder(&settings->find));
 	find_edit->SetMaxLength(0);
 	find_sizer->Add(new wxStaticText(this, -1, _("Find what:")), wxSizerFlags().Center().Left());
-	find_sizer->Add(find_edit);
+	find_sizer->Add(find_edit, wxSizerFlags().Expand());
 
 	if (has_replace) {
-		replace_edit = new wxComboBox(this, -1, "", wxDefaultPosition, FromDIP(wxSize(300, -1)), lagi_MRU_wxAS("Replace"), wxCB_DROPDOWN | wxTE_PROCESS_ENTER, StringBinder(&settings->replace_with));
+		replace_edit = new wxComboBox(this, -1, "", wxDefaultPosition, 
+			wxDefaultSize,
+			lagi_MRU_wxAS("Replace"), 
+			wxCB_DROPDOWN | wxTE_PROCESS_ENTER, 
+			StringBinder(&settings->replace_with));
 		replace_edit->SetMaxLength(0);
 		find_sizer->Add(new wxStaticText(this, -1, _("Replace with:")), wxSizerFlags().Center().Left());
-		find_sizer->Add(replace_edit);
+		find_sizer->Add(replace_edit, wxSizerFlags().Expand());
 	}
 
-	auto options_sizer = new wxBoxSizer(wxVERTICAL);
-	options_sizer->Add(new wxCheckBox(this, -1, _("&Match case"), wxDefaultPosition, wxDefaultSize, 0, wxGenericValidator(&settings->match_case)), wxSizerFlags().Border(wxBOTTOM));
-	options_sizer->Add(new wxCheckBox(this, -1, _("&Use regular expressions"), wxDefaultPosition, wxDefaultSize, 0, wxGenericValidator(&settings->use_regex)), wxSizerFlags().Border(wxBOTTOM));
-	options_sizer->Add(new wxCheckBox(this, -1, _("&Skip Comments"), wxDefaultPosition, wxDefaultSize, 0, wxGenericValidator(&settings->ignore_comments)), wxSizerFlags().Border(wxBOTTOM));
-	options_sizer->Add(new wxCheckBox(this, -1, _("S&kip Override Tags"), wxDefaultPosition, wxDefaultSize, 0, wxGenericValidator(&settings->skip_tags)));
+	// Options in wxStaticBoxSizer
+	auto options_sizer = new wxStaticBoxSizer(wxVERTICAL, this, _("Options"));
+	auto options_grid = new wxFlexGridSizer(2, 2, gap, gap);
+	options_grid->Add(new wxCheckBox(this, -1, _("&Match case"), 
+		wxDefaultPosition, wxDefaultSize, 0, 
+		wxGenericValidator(&settings->match_case)), wxSizerFlags().Border(wxRIGHT));
+	options_grid->Add(new wxCheckBox(this, -1, _("&Use regular expressions"), 
+		wxDefaultPosition, wxDefaultSize, 0, 
+		wxGenericValidator(&settings->use_regex)));
+	options_grid->Add(new wxCheckBox(this, -1, _("&Skip Comments"), 
+		wxDefaultPosition, wxDefaultSize, 0, 
+		wxGenericValidator(&settings->ignore_comments)), wxSizerFlags().Border(wxRIGHT));
+	options_grid->Add(new wxCheckBox(this, -1, _("S&kip Override Tags"), 
+		wxDefaultPosition, wxDefaultSize, 0, 
+		wxGenericValidator(&settings->skip_tags)));
+	options_sizer->Add(options_grid, wxSizerFlags().Expand().Border());
 
-	auto left_sizer = new wxBoxSizer(wxVERTICAL);
-	left_sizer->Add(find_sizer, wxSizerFlags().DoubleBorder(wxBOTTOM));
-	left_sizer->Add(options_sizer);
-
+	// Radio boxes for "In Field" and "Limit to"
 	wxString field[] = { _("&Text"), _("St&yle"), _("A&ctor"), _("&Effect") };
 	wxString affect[] = { _("A&ll rows"), _("Selected &rows") };
-	auto limit_sizer = new wxBoxSizer(wxHORIZONTAL);
-	limit_sizer->Add(new wxRadioBox(this, -1, _("In Field"), wxDefaultPosition, wxDefaultSize, std::size(field), field, 0, wxRA_SPECIFY_COLS, MakeEnumBinder(&settings->field)), wxSizerFlags().Border(wxRIGHT));
-	limit_sizer->Add(new wxRadioBox(this, -1, _("Limit to"), wxDefaultPosition, wxDefaultSize, std::size(affect), affect, 0, wxRA_SPECIFY_COLS, MakeEnumBinder(&settings->limit_to)));
+	auto field_radio = new wxRadioBox(this, -1, _("In Field"), 
+		wxDefaultPosition, wxDefaultSize, std::size(field), 
+		field, 0, wxRA_SPECIFY_COLS, MakeEnumBinder(&settings->field));
+	auto limit_radio = new wxRadioBox(this, -1, _("Limit to"), 
+		wxDefaultPosition, wxDefaultSize, std::size(affect), 
+		affect, 0, wxRA_SPECIFY_COLS, MakeEnumBinder(&settings->limit_to));
 
+	// Horizontal buttons
 	auto find_next = new wxButton(this, -1, _("&Find next"));
 	auto replace_next = new wxButton(this, -1, _("Replace &next"));
 	auto replace_all = new wxButton(this, -1, _("Replace &all"));
 	find_next->SetDefault();
 
-	auto button_sizer = new wxBoxSizer(wxVERTICAL);
-	button_sizer->Add(find_next, wxSizerFlags().Border(wxBOTTOM));
-	button_sizer->Add(replace_next, wxSizerFlags().Border(wxBOTTOM));
-	button_sizer->Add(replace_all, wxSizerFlags().Border(wxBOTTOM));
+	auto button_sizer = new wxBoxSizer(wxHORIZONTAL);
+	button_sizer->Add(find_next);
+	button_sizer->Add(replace_next);
+	button_sizer->Add(replace_all);
 	button_sizer->Add(new wxButton(this, wxID_CANCEL));
 
 	if (!has_replace) {
@@ -107,13 +131,13 @@ DialogSearchReplace<has_replace>::DialogSearchReplace(agi::Context* c)
 		button_sizer->Hide(replace_all);
 	}
 
-	auto top_sizer = new wxBoxSizer(wxHORIZONTAL);
-	top_sizer->Add(left_sizer, wxSizerFlags().Border());
-	top_sizer->Add(button_sizer, wxSizerFlags().Border());
-
+	// Main vertical sizer
 	auto main_sizer = new wxBoxSizer(wxVERTICAL);
-	main_sizer->Add(top_sizer);
-	main_sizer->Add(limit_sizer, wxSizerFlags().Border());
+	main_sizer->Add(find_sizer, wxSizerFlags().Expand().Border());
+	main_sizer->Add(options_sizer, wxSizerFlags().Expand().Border(wxALL & ~wxTOP));
+	main_sizer->Add(field_radio, wxSizerFlags().Expand().Border(wxALL & ~wxTOP));
+	main_sizer->Add(limit_radio, wxSizerFlags().Expand().Border(wxALL & ~wxTOP));
+	main_sizer->Add(button_sizer, wxSizerFlags().Center().Border(wxALL & ~wxTOP));
 	SetSizerAndFit(main_sizer);
 	CenterOnParent();
 

--- a/src/dialog_search_replace.cpp
+++ b/src/dialog_search_replace.cpp
@@ -92,13 +92,13 @@ DialogSearchReplace<has_replace>::DialogSearchReplace(agi::Context* c)
 	auto options_grid = new wxFlexGridSizer(2, 2, gap, gap);
 	options_grid->Add(new wxCheckBox(this, -1, _("&Match case"), 
 		wxDefaultPosition, wxDefaultSize, 0, 
-		wxGenericValidator(&settings->match_case)), wxSizerFlags().Border(wxRIGHT));
+		wxGenericValidator(&settings->match_case)), wxSizerFlags().Border(wxBOTTOM | wxRIGHT));
 	options_grid->Add(new wxCheckBox(this, -1, _("&Use regular expressions"), 
 		wxDefaultPosition, wxDefaultSize, 0, 
 		wxGenericValidator(&settings->use_regex)));
 	options_grid->Add(new wxCheckBox(this, -1, _("&Skip Comments"), 
 		wxDefaultPosition, wxDefaultSize, 0, 
-		wxGenericValidator(&settings->ignore_comments)), wxSizerFlags().Border(wxRIGHT));
+		wxGenericValidator(&settings->ignore_comments)), wxSizerFlags().Border(wxBOTTOM | wxRIGHT));
 	options_grid->Add(new wxCheckBox(this, -1, _("S&kip Override Tags"), 
 		wxDefaultPosition, wxDefaultSize, 0, 
 		wxGenericValidator(&settings->skip_tags)));
@@ -139,6 +139,7 @@ DialogSearchReplace<has_replace>::DialogSearchReplace(agi::Context* c)
 	main_sizer->Add(limit_radio, wxSizerFlags().Expand().Border(wxALL & ~wxTOP));
 	main_sizer->Add(button_sizer, wxSizerFlags().Center().Border(wxALL & ~wxTOP));
 	SetSizerAndFit(main_sizer);
+	SetSize(GetSize().GetHeight() * 4 / 3, -1);
 	CenterOnParent();
 
 	TransferDataToWindow();

--- a/src/dialog_selected_choices.cpp
+++ b/src/dialog_selected_choices.cpp
@@ -38,7 +38,7 @@ int GetSelectedChoices(wxWindow *parent, wxArrayInt& selections, wxString const&
 	buttonSizer->Add(selNone);
 
 	auto sizer = dialog.GetSizer();
-	sizer->Insert(2, buttonSizer, wxSizerFlags(0).Center());
+	sizer->Insert(2, buttonSizer, wxSizerFlags().Center());
 	sizer->Fit(&dialog);
 
 	dialog.SetSelections(selections);

--- a/src/dialog_shift_times.cpp
+++ b/src/dialog_shift_times.cpp
@@ -196,7 +196,8 @@ DialogShiftTimes::DialogShiftTimes(agi::Context *context)
 		shift_frames->Disable();
 
 	// Position controls
-	wxFlexGridSizer* shift_amount_sizer = new wxFlexGridSizer(2, 2, 5, 5);
+	int gap = wxSizerFlags::GetDefaultBorder();
+	auto shift_amount_sizer = new wxFlexGridSizer(2, 2, gap, gap);
 	shift_amount_sizer->AddGrowableCol(1, 1);
 	shift_amount_sizer->Add(shift_by_time, wxSizerFlags().CenterVertical());
 	shift_amount_sizer->Add(shift_time, wxSizerFlags().Expand());

--- a/src/dialog_shift_times.cpp
+++ b/src/dialog_shift_times.cpp
@@ -173,7 +173,7 @@ DialogShiftTimes::DialogShiftTimes(agi::Context *context)
 	wxString time_field_vals[] = { _("Start a&nd End times"), _("&Start times only"), _("&End times only") };
 	time_fields = new wxRadioBox(this, -1, _("Times"), wxDefaultPosition, wxDefaultSize, 3, time_field_vals, 1);
 
-	history_box = new wxListBox(history_static_box, -1, wxDefaultPosition, wxSize(350, 100), 0, nullptr, wxLB_HSCROLL);
+	history_box = new wxListBox(history_static_box, -1, wxDefaultPosition, FromDIP(wxSize(350, 100)), 0, nullptr, wxLB_HSCROLL);
 
 	wxButton *clear_button = new wxButton(history_static_box, -1, _("&Clear"));
 	clear_button->Bind(wxEVT_BUTTON, &DialogShiftTimes::OnClear, this);

--- a/src/dialog_shift_times.cpp
+++ b/src/dialog_shift_times.cpp
@@ -198,9 +198,9 @@ DialogShiftTimes::DialogShiftTimes(agi::Context *context)
 	// Position controls
 	wxFlexGridSizer* shift_amount_sizer = new wxFlexGridSizer(2, 2, 5, 5);
 	shift_amount_sizer->AddGrowableCol(1, 1);
-	shift_amount_sizer->Add(shift_by_time, wxSizerFlags(0).Align(wxALIGN_CENTER_VERTICAL));
+	shift_amount_sizer->Add(shift_by_time, wxSizerFlags().CenterVertical());
 	shift_amount_sizer->Add(shift_time, wxSizerFlags().Expand());
-	shift_amount_sizer->Add(shift_by_frames, wxSizerFlags(0).Align(wxALIGN_CENTER_VERTICAL));
+	shift_amount_sizer->Add(shift_by_frames, wxSizerFlags().CenterVertical());
 	shift_amount_sizer->Add(shift_frames, wxSizerFlags().Expand());
 
 	wxSizer *shift_direction_sizer = new wxBoxSizer(wxHORIZONTAL);

--- a/src/dialog_spellchecker.cpp
+++ b/src/dialog_spellchecker.cpp
@@ -108,7 +108,8 @@ DialogSpellChecker::DialogSpellChecker(agi::Context *context)
 
 	wxSizer *main_sizer = new wxBoxSizer(wxVERTICAL);
 
-	auto current_word_sizer = new wxFlexGridSizer(2, 5, 5);
+	int gap = wxSizerFlags::GetDefaultBorder();
+	auto current_word_sizer = new wxFlexGridSizer(2, gap, gap);
 	main_sizer->Add(current_word_sizer, wxSizerFlags().Expand().Border());
 
 	wxSizer *bottom_sizer = new wxBoxSizer(wxHORIZONTAL);

--- a/src/dialog_spellchecker.cpp
+++ b/src/dialog_spellchecker.cpp
@@ -133,7 +133,7 @@ DialogSpellChecker::DialogSpellChecker(agi::Context *context)
 	});
 
 	// List of suggested corrections
-	suggest_list = new wxListBox(this, -1, wxDefaultPosition, wxSize(300, 150));
+	suggest_list = new wxListBox(this, -1, wxDefaultPosition, FromDIP(wxSize(300, 150)));
 	suggest_list->Bind(wxEVT_LISTBOX, &DialogSpellChecker::OnChangeSuggestion, this);
 	suggest_list->Bind(wxEVT_LISTBOX_DCLICK, &DialogSpellChecker::OnReplace, this);
 	bottom_left_sizer->Add(suggest_list, wxSizerFlags(1).Expand());

--- a/src/dialog_spellchecker.cpp
+++ b/src/dialog_spellchecker.cpp
@@ -109,22 +109,22 @@ DialogSpellChecker::DialogSpellChecker(agi::Context *context)
 	wxSizer *main_sizer = new wxBoxSizer(wxVERTICAL);
 
 	auto current_word_sizer = new wxFlexGridSizer(2, 5, 5);
-	main_sizer->Add(current_word_sizer, wxSizerFlags().Expand().Border(wxALL, 5));
+	main_sizer->Add(current_word_sizer, wxSizerFlags().Expand().Border());
 
 	wxSizer *bottom_sizer = new wxBoxSizer(wxHORIZONTAL);
-	main_sizer->Add(bottom_sizer, wxSizerFlags().Expand().Border(~wxTOP & wxALL, 5));
+	main_sizer->Add(bottom_sizer, wxSizerFlags().Expand().Border(~wxTOP & wxALL));
 
 	wxSizer *bottom_left_sizer = new wxBoxSizer(wxVERTICAL);
-	bottom_sizer->Add(bottom_left_sizer, wxSizerFlags().Expand().Border(wxRIGHT, 5));
+	bottom_sizer->Add(bottom_left_sizer, wxSizerFlags().Expand().Border(wxRIGHT));
 
 	wxSizer *actions_sizer = new wxBoxSizer(wxVERTICAL);
 	bottom_sizer->Add(actions_sizer, wxSizerFlags().Expand());
 
 	// Misspelled word and currently selected correction
 	current_word_sizer->AddGrowableCol(1, 1);
-	current_word_sizer->Add(new wxStaticText(this, -1, _("Misspelled word:")), 0, wxALIGN_CENTER_VERTICAL);
+	current_word_sizer->Add(new wxStaticText(this, -1, _("Misspelled word:")), wxSizerFlags().CenterVertical());
 	current_word_sizer->Add(orig_word = new wxTextCtrl(this, -1, "", wxDefaultPosition, wxDefaultSize, wxTE_READONLY), wxSizerFlags(1).Expand());
-	current_word_sizer->Add(new wxStaticText(this, -1, _("Replace with:")), 0, wxALIGN_CENTER_VERTICAL);
+	current_word_sizer->Add(new wxStaticText(this, -1, _("Replace with:")), wxSizerFlags().CenterVertical());
 	current_word_sizer->Add(replace_word = new wxTextCtrl(this, -1, ""), wxSizerFlags(1).Expand());
 
 	replace_word->Bind(wxEVT_TEXT, [this](wxCommandEvent&) {
@@ -165,11 +165,11 @@ DialogSpellChecker::DialogSpellChecker(agi::Context *context)
 		language->SetSelection(cur_lang_index);
 		language->Bind(wxEVT_COMBOBOX, &DialogSpellChecker::OnChangeLanguage, this);
 
-		bottom_left_sizer->Add(language, wxSizerFlags().Expand().Border(wxTOP, 5));
+		bottom_left_sizer->Add(language, wxSizerFlags().Expand().Border(wxTOP));
 	}
 
 	{
-		wxSizerFlags button_flags = wxSizerFlags().Expand().Border(wxBOTTOM, 5);
+		wxSizerFlags button_flags = wxSizerFlags().Expand().Border(wxBOTTOM);
 
 		auto make_checkbox = [&](wxString const& text, const char *opt) {
 			auto checkbox = new wxCheckBox(this, -1, text);

--- a/src/dialog_style_editor.cpp
+++ b/src/dialog_style_editor.cpp
@@ -195,17 +195,17 @@ DialogStyleEditor::DialogStyleEditor(wxWindow *parent, AssStyle *style, agi::Con
 
 	// Create controls
 	StyleName = new wxTextCtrl(NameSizerBox, -1, to_wx(style->name));
-	FontName = new wxComboBox(FontSizerBox, -1, to_wx(style->font), wxDefaultPosition, wxSize(150, -1), 0, nullptr, wxCB_DROPDOWN);
+	FontName = new wxComboBox(FontSizerBox, -1, to_wx(style->font), wxDefaultPosition, FromDIP(wxSize(150, -1)), 0, nullptr, wxCB_DROPDOWN);
 	auto FontSize = num_text_ctrl(FontSizerBox, &work->fontsize, 0, 10000.0, 1.0, 0);
 	BoxBold = new wxCheckBox(FontSizerBox, -1, _("&Bold"));
 	BoxItalic = new wxCheckBox(FontSizerBox, -1, _("&Italic"));
 	BoxUnderline = new wxCheckBox(FontSizerBox, -1, _("&Underline"));
 	BoxStrikeout = new wxCheckBox(FontSizerBox, -1, _("&Strikeout"));
 	ColourButton *colorButton[] = {
-		new ColourButton(ColorsSizerBox, wxSize(55, 16), true, style->primary, ColorValidator(&work->primary)),
-		new ColourButton(ColorsSizerBox, wxSize(55, 16), true, style->secondary, ColorValidator(&work->secondary)),
-		new ColourButton(ColorsSizerBox, wxSize(55, 16), true, style->outline, ColorValidator(&work->outline)),
-		new ColourButton(ColorsSizerBox, wxSize(55, 16), true, style->shadow, ColorValidator(&work->shadow))
+		new ColourButton(ColorsSizerBox, FromDIP(wxSize(55, 16)), true, style->primary, ColorValidator(&work->primary)),
+		new ColourButton(ColorsSizerBox, FromDIP(wxSize(55, 16)), true, style->secondary, ColorValidator(&work->secondary)),
+		new ColourButton(ColorsSizerBox, FromDIP(wxSize(55, 16)), true, style->outline, ColorValidator(&work->outline)),
+		new ColourButton(ColorsSizerBox, FromDIP(wxSize(55, 16)), true, style->shadow, ColorValidator(&work->shadow))
 	};
 	for (int i = 0; i < 3; i++)
 		margin[i] = new wxSpinCtrl(MarginSizerBox, -1, std::to_wstring(style->Margin[i]),
@@ -340,9 +340,9 @@ DialogStyleEditor::DialogStyleEditor(wxWindow *parent, AssStyle *style, agi::Con
 	MiscSizer->Add(MiscBoxBottom, wxSizerFlags().Expand().Border(wxTOP));
 
 	// Preview
-	auto previewButton = new ColourButton(PreviewSizerBox, wxSize(45, 16), false, OPT_GET("Colour/Style Editor/Background/Preview")->GetColor());
+	auto previewButton = new ColourButton(PreviewSizerBox, FromDIP(wxSize(45, 16)), false, OPT_GET("Colour/Style Editor/Background/Preview")->GetColor());
 	PreviewText = new wxTextCtrl(PreviewSizerBox, -1, to_wx(OPT_GET("Tool/Style Editor/Preview Text")->GetString()));
-	SubsPreview = new SubtitlesPreview(PreviewSizerBox, wxSize(100, 60), wxSUNKEN_BORDER, OPT_GET("Colour/Style Editor/Background/Preview")->GetColor());
+	SubsPreview = new SubtitlesPreview(PreviewSizerBox, FromDIP(wxSize(100, 60)), wxSUNKEN_BORDER, OPT_GET("Colour/Style Editor/Background/Preview")->GetColor());
 
 	SubsPreview->SetToolTip(_("Preview of current style"));
 	SubsPreview->SetStyle(*style);

--- a/src/dialog_style_editor.cpp
+++ b/src/dialog_style_editor.cpp
@@ -326,7 +326,8 @@ DialogStyleEditor::DialogStyleEditor(wxWindow *parent, AssStyle *style, agi::Con
 	add_with_label(OutlineSizerBox, OutlineSizer, _("Border style:"), OutlineType);
 
 	// Misc
-	auto MiscBoxTop = new wxFlexGridSizer(2, 4, 5, 5);
+	int gap = wxSizerFlags::GetDefaultBorder();
+	auto MiscBoxTop = new wxFlexGridSizer(2, 4, gap, gap);
 	add_with_label(MiscSizerBox, MiscBoxTop, _("Scale X%:"), ScaleX);
 	add_with_label(MiscSizerBox, MiscBoxTop, _("Scale Y%:"), ScaleY);
 	add_with_label(MiscSizerBox, MiscBoxTop, _("Rotation:"), Angle);

--- a/src/dialog_style_editor.cpp
+++ b/src/dialog_style_editor.cpp
@@ -275,30 +275,30 @@ DialogStyleEditor::DialogStyleEditor(wxWindow *parent, AssStyle *style, agi::Con
 	}
 
 	// Style name sizer
-	NameSizer->Add(StyleName, 1, 0, 0);
+	NameSizer->Add(StyleName, 1);
 
 	// Font sizer
 	wxSizer *FontSizerTop = new wxBoxSizer(wxHORIZONTAL);
 	wxSizer *FontSizerBottom = new wxBoxSizer(wxHORIZONTAL);
-	FontSizerTop->Add(FontName, 1, 0, 0);
-	FontSizerTop->Add(FontSize, 0, wxLEFT, 5);
+	FontSizerTop->Add(FontName, 1);
+	FontSizerTop->Add(FontSize, wxSizerFlags().Border(wxLEFT));
 	FontSizerBottom->AddStretchSpacer(1);
-	FontSizerBottom->Add(BoxBold, 0, 0, 0);
-	FontSizerBottom->Add(BoxItalic, 0, wxLEFT, 5);
-	FontSizerBottom->Add(BoxUnderline, 0, wxLEFT, 5);
-	FontSizerBottom->Add(BoxStrikeout, 0, wxLEFT, 5);
+	FontSizerBottom->Add(BoxBold);
+	FontSizerBottom->Add(BoxItalic, wxSizerFlags().Border(wxLEFT));
+	FontSizerBottom->Add(BoxUnderline, wxSizerFlags().Border(wxLEFT));
+	FontSizerBottom->Add(BoxStrikeout, wxSizerFlags().Border(wxLEFT));
 	FontSizerBottom->AddStretchSpacer(1);
-	FontSizer->Add(FontSizerTop, 1, wxEXPAND, 0);
-	FontSizer->Add(FontSizerBottom, 1, wxTOP | wxEXPAND, 5);
+	FontSizer->Add(FontSizerTop, wxSizerFlags(1).Expand());
+	FontSizer->Add(FontSizerBottom, wxSizerFlags(1).Expand().Border(wxTOP));
 
 	// Colors sizer
 	wxString colorLabels[] = { _("Primary"), _("Secondary"), _("Outline"), _("Shadow") };
 	ColorsSizer->AddStretchSpacer(1);
 	for (int i = 0; i < 4; ++i) {
 		auto sizer = new wxBoxSizer(wxVERTICAL);
-		sizer->Add(new wxStaticText(ColorsSizerBox, -1, colorLabels[i]), 0, wxBOTTOM | wxALIGN_CENTER, 5);
-		sizer->Add(colorButton[i], 0, wxBOTTOM | wxALIGN_CENTER, 5);
-		ColorsSizer->Add(sizer, 0, wxLEFT, i?5:0);
+		sizer->Add(new wxStaticText(ColorsSizerBox, -1, colorLabels[i]), wxSizerFlags().Center().Border(wxBOTTOM));
+		sizer->Add(colorButton[i], wxSizerFlags().Center().Border(wxBOTTOM));
+		ColorsSizer->Add(sizer, i ? wxSizerFlags().Border(wxLEFT) : wxSizerFlags());
 	}
 	ColorsSizer->AddStretchSpacer(1);
 
@@ -308,17 +308,17 @@ DialogStyleEditor::DialogStyleEditor(wxWindow *parent, AssStyle *style, agi::Con
 	for (int i=0;i<3;i++) {
 		auto sizer = new wxBoxSizer(wxVERTICAL);
 		sizer->AddStretchSpacer(1);
-		sizer->Add(new wxStaticText(MarginSizerBox, -1, marginLabels[i]), 0, wxCENTER, 0);
-		sizer->Add(margin[i], 0, wxTOP | wxCENTER, 5);
+		sizer->Add(new wxStaticText(MarginSizerBox, -1, marginLabels[i]), wxSizerFlags().Center());
+		sizer->Add(margin[i], wxSizerFlags().Center().Border(wxTOP));
 		sizer->AddStretchSpacer(1);
-		MarginSizer->Add(sizer, 0, wxEXPAND | wxLEFT, i?5:0);
+		MarginSizer->Add(sizer, i ? wxSizerFlags().Expand().Border(wxLEFT) : wxSizerFlags().Expand());
 	}
 	MarginSizer->AddStretchSpacer(1);
 
 	// Margins+Alignment
 	wxSizer *MarginAlign = new wxBoxSizer(wxHORIZONTAL);
-	MarginAlign->Add(MarginSizer, 1, wxEXPAND, 0);
-	MarginAlign->Add(Alignment, 0, wxLEFT | wxEXPAND, 5);
+	MarginAlign->Add(MarginSizer, wxSizerFlags(1).Expand());
+	MarginAlign->Add(Alignment, wxSizerFlags().Expand().Border(wxLEFT));
 
 	// Outline
 	add_with_label(OutlineSizerBox, OutlineSizer, _("Outline:"), Outline);
@@ -350,20 +350,20 @@ DialogStyleEditor::DialogStyleEditor(wxWindow *parent, AssStyle *style, agi::Con
 	previewButton->SetToolTip(_("Color of preview background"));
 
 	wxSizer *PreviewBottomSizer = new wxBoxSizer(wxHORIZONTAL);
-	PreviewBottomSizer->Add(PreviewText, 1, wxEXPAND | wxRIGHT, 5);
-	PreviewBottomSizer->Add(previewButton, 0, wxEXPAND, 0);
-	PreviewSizer->Add(SubsPreview, 1, wxEXPAND | wxBOTTOM, 5);
-	PreviewSizer->Add(PreviewBottomSizer, 0, wxEXPAND, 0);
+	PreviewBottomSizer->Add(PreviewText, wxSizerFlags(1).Expand().Border(wxRIGHT));
+	PreviewBottomSizer->Add(previewButton, wxSizerFlags().Expand());
+	PreviewSizer->Add(SubsPreview, wxSizerFlags(1).Expand().Border(wxBOTTOM));
+	PreviewSizer->Add(PreviewBottomSizer, wxSizerFlags().Expand());
 
 	// Buttons
 	auto ButtonSizer = CreateStdDialogButtonSizer(wxOK | wxCANCEL | wxAPPLY | wxHELP);
 
 	// Left side sizer
 	wxSizer *LeftSizer = new wxBoxSizer(wxVERTICAL);
-	LeftSizer->Add(NameSizer, 0, wxBOTTOM | wxEXPAND, 5);
-	LeftSizer->Add(FontSizer, 0, wxBOTTOM | wxEXPAND, 5);
-	LeftSizer->Add(ColorsSizer, 0, wxBOTTOM | wxEXPAND, 5);
-	LeftSizer->Add(MarginAlign, 0, wxEXPAND, 0);
+	LeftSizer->Add(NameSizer, wxSizerFlags().Expand().Border(wxBOTTOM));
+	LeftSizer->Add(FontSizer, wxSizerFlags().Expand().Border(wxBOTTOM));
+	LeftSizer->Add(ColorsSizer, wxSizerFlags().Expand().Border(wxBOTTOM));
+	LeftSizer->Add(MarginAlign, wxSizerFlags().Expand());
 
 	// Right side sizer
 	wxSizer *RightSizer = new wxBoxSizer(wxVERTICAL);
@@ -373,13 +373,13 @@ DialogStyleEditor::DialogStyleEditor(wxWindow *parent, AssStyle *style, agi::Con
 
 	// Controls Sizer
 	wxSizer *ControlSizer = new wxBoxSizer(wxHORIZONTAL);
-	ControlSizer->Add(LeftSizer, 0, wxEXPAND, 0);
-	ControlSizer->Add(RightSizer, 1, wxLEFT | wxEXPAND, 5);
+	ControlSizer->Add(LeftSizer, wxSizerFlags().Expand());
+	ControlSizer->Add(RightSizer, wxSizerFlags(1).Expand().Border(wxLEFT));
 
 	// General Layout
 	wxSizer *MainSizer = new wxBoxSizer(wxVERTICAL);
-	MainSizer->Add(ControlSizer, 1, wxALL | wxEXPAND, 5);
-	MainSizer->Add(ButtonSizer, 0, wxBOTTOM | wxEXPAND, 5);
+	MainSizer->Add(ControlSizer, wxSizerFlags(1).Expand().Border());
+	MainSizer->Add(ButtonSizer, wxSizerFlags().Expand().Border(wxBOTTOM));
 
 	SetSizerAndFit(MainSizer);
 

--- a/src/dialog_style_manager.cpp
+++ b/src/dialog_style_manager.cpp
@@ -279,7 +279,7 @@ DialogStyleManager::DialogStyleManager(agi::Context *context)
 	wxWindow *CurrentSizerBox = CurrentSizer->GetStaticBox();
 
 	// Catalog
-	CatalogList = new wxComboBox(CatalogSizerBox,-1, "", wxDefaultPosition, wxSize(-1,-1), 0, nullptr, wxCB_READONLY);
+	CatalogList = new wxComboBox(CatalogSizerBox,-1, "", wxDefaultPosition, wxDefaultSize, 0, nullptr, wxCB_READONLY);
 	wxButton *CatalogNew = new wxButton(CatalogSizerBox, -1, _("New"));
 	CatalogDelete = new wxButton(CatalogSizerBox, -1, _("Delete"));
 	CatalogSizer->Add(CatalogList, wxSizerFlags(1).Expand().Border(wxRIGHT));

--- a/src/dialog_style_manager.cpp
+++ b/src/dialog_style_manager.cpp
@@ -290,7 +290,7 @@ DialogStyleManager::DialogStyleManager(agi::Context *context)
 	wxSizer *StorageButtons = make_edit_buttons(StorageSizerBox, _("Copy to &current script ->"), &MoveToLocal, &StorageNew, &StorageEdit, &StorageCopy, &StorageDelete);
 
 	wxSizer *StorageListSizer = new wxBoxSizer(wxHORIZONTAL);
-	StorageList = new wxListBox(StorageSizerBox, -1, wxDefaultPosition, wxSize(240,250), 0, nullptr, wxLB_EXTENDED);
+	StorageList = new wxListBox(StorageSizerBox, -1, wxDefaultPosition, FromDIP(wxSize(240,250)), 0, nullptr, wxLB_EXTENDED);
 	StorageListSizer->Add(StorageList, wxSizerFlags(1).Expand());
 	StorageListSizer->Add(make_move_buttons(StorageSizerBox, &StorageMoveUp, &StorageMoveDown, &StorageMoveTop, &StorageMoveBottom, &StorageSort), wxSizerFlags().Expand());
 
@@ -307,7 +307,7 @@ DialogStyleManager::DialogStyleManager(agi::Context *context)
 	MoveImportSizer->Add(CurrentImport, wxSizerFlags(1).Expand());
 
 	wxSizer *CurrentListSizer = new wxBoxSizer(wxHORIZONTAL);
-	CurrentList = new wxListBox(CurrentSizerBox, -1, wxDefaultPosition, wxSize(240,250), 0, nullptr, wxLB_EXTENDED);
+	CurrentList = new wxListBox(CurrentSizerBox, -1, wxDefaultPosition, FromDIP(wxSize(240,250)), 0, nullptr, wxLB_EXTENDED);
 	CurrentListSizer->Add(CurrentList, wxSizerFlags(1).Expand());
 	CurrentListSizer->Add(make_move_buttons(CurrentSizerBox, &CurrentMoveUp, &CurrentMoveDown, &CurrentMoveTop, &CurrentMoveBottom, &CurrentSort), wxSizerFlags().Expand());
 

--- a/src/dialog_style_manager.cpp
+++ b/src/dialog_style_manager.cpp
@@ -282,38 +282,38 @@ DialogStyleManager::DialogStyleManager(agi::Context *context)
 	CatalogList = new wxComboBox(CatalogSizerBox,-1, "", wxDefaultPosition, wxSize(-1,-1), 0, nullptr, wxCB_READONLY);
 	wxButton *CatalogNew = new wxButton(CatalogSizerBox, -1, _("New"));
 	CatalogDelete = new wxButton(CatalogSizerBox, -1, _("Delete"));
-	CatalogSizer->Add(CatalogList,1,wxEXPAND | wxRIGHT,5);
-	CatalogSizer->Add(CatalogNew,0,wxRIGHT,5);
-	CatalogSizer->Add(CatalogDelete,0,0,0);
+	CatalogSizer->Add(CatalogList, wxSizerFlags(1).Expand().Border(wxRIGHT));
+	CatalogSizer->Add(CatalogNew, wxSizerFlags().Border(wxRIGHT));
+	CatalogSizer->Add(CatalogDelete);
 
 	// Storage styles list
 	wxSizer *StorageButtons = make_edit_buttons(StorageSizerBox, _("Copy to &current script ->"), &MoveToLocal, &StorageNew, &StorageEdit, &StorageCopy, &StorageDelete);
 
 	wxSizer *StorageListSizer = new wxBoxSizer(wxHORIZONTAL);
 	StorageList = new wxListBox(StorageSizerBox, -1, wxDefaultPosition, wxSize(240,250), 0, nullptr, wxLB_EXTENDED);
-	StorageListSizer->Add(StorageList,1,wxEXPAND,0);
+	StorageListSizer->Add(StorageList, wxSizerFlags(1).Expand());
 	StorageListSizer->Add(make_move_buttons(StorageSizerBox, &StorageMoveUp, &StorageMoveDown, &StorageMoveTop, &StorageMoveBottom, &StorageSort), wxSizerFlags().Expand());
 
-	StorageSizer->Add(StorageListSizer,1,wxEXPAND | wxBOTTOM,5);
-	StorageSizer->Add(MoveToLocal,0,wxEXPAND | wxBOTTOM,5);
-	StorageSizer->Add(StorageButtons,0,wxEXPAND,0);
+	StorageSizer->Add(StorageListSizer, wxSizerFlags(1).Expand().Border(wxBOTTOM));
+	StorageSizer->Add(MoveToLocal, wxSizerFlags().Expand().Border(wxBOTTOM));
+	StorageSizer->Add(StorageButtons, wxSizerFlags().Expand());
 
 	// Local styles list
 	wxButton *CurrentImport = new wxButton(CurrentSizerBox, -1, _("&Import from script..."));
 	wxSizer *CurrentButtons = make_edit_buttons(CurrentSizerBox, _("<- Copy to &storage"), &MoveToStorage, &CurrentNew, &CurrentEdit, &CurrentCopy, &CurrentDelete);
 
 	wxSizer *MoveImportSizer = new wxBoxSizer(wxHORIZONTAL);
-	MoveImportSizer->Add(MoveToStorage,1,wxEXPAND | wxRIGHT,5);
-	MoveImportSizer->Add(CurrentImport,1,wxEXPAND,0);
+	MoveImportSizer->Add(MoveToStorage, wxSizerFlags(1).Expand().Border(wxRIGHT));
+	MoveImportSizer->Add(CurrentImport, wxSizerFlags(1).Expand());
 
 	wxSizer *CurrentListSizer = new wxBoxSizer(wxHORIZONTAL);
 	CurrentList = new wxListBox(CurrentSizerBox, -1, wxDefaultPosition, wxSize(240,250), 0, nullptr, wxLB_EXTENDED);
-	CurrentListSizer->Add(CurrentList,1,wxEXPAND,0);
+	CurrentListSizer->Add(CurrentList, wxSizerFlags(1).Expand());
 	CurrentListSizer->Add(make_move_buttons(CurrentSizerBox, &CurrentMoveUp, &CurrentMoveDown, &CurrentMoveTop, &CurrentMoveBottom, &CurrentSort), wxSizerFlags().Expand());
 
-	CurrentSizer->Add(CurrentListSizer,1,wxEXPAND | wxBOTTOM,5);
-	CurrentSizer->Add(MoveImportSizer,0,wxEXPAND | wxBOTTOM,5);
-	CurrentSizer->Add(CurrentButtons,0,wxEXPAND,0);
+	CurrentSizer->Add(CurrentListSizer, wxSizerFlags(1).Expand().Border(wxBOTTOM));
+	CurrentSizer->Add(MoveImportSizer, wxSizerFlags().Expand().Border(wxBOTTOM));
+	CurrentSizer->Add(CurrentButtons, wxSizerFlags().Expand());
 
 	// Buttons
 	wxStdDialogButtonSizer *buttonSizer = CreateStdDialogButtonSizer(wxCANCEL | wxHELP);
@@ -322,12 +322,12 @@ DialogStyleManager::DialogStyleManager(agi::Context *context)
 
 	// General layout
 	wxSizer *StylesSizer = new wxBoxSizer(wxHORIZONTAL);
-	StylesSizer->Add(StorageSizer,0,wxRIGHT | wxEXPAND,5);
-	StylesSizer->Add(CurrentSizer,0,wxEXPAND,0);
+	StylesSizer->Add(StorageSizer, wxSizerFlags().Expand().Border(wxRIGHT));
+	StylesSizer->Add(CurrentSizer, wxSizerFlags().Expand());
 	wxSizer *MainSizer = new wxBoxSizer(wxVERTICAL);
-	MainSizer->Add(CatalogSizer,0,wxEXPAND | wxLEFT | wxRIGHT | wxTOP,5);
-	MainSizer->Add(StylesSizer,1,wxEXPAND | wxALL,5);
-	MainSizer->Add(buttonSizer,0,wxBOTTOM | wxEXPAND,5);
+	MainSizer->Add(CatalogSizer, wxSizerFlags().Expand().Border(wxALL & ~wxBOTTOM));
+	MainSizer->Add(StylesSizer, wxSizerFlags(1).Expand().Border());
+	MainSizer->Add(buttonSizer, wxSizerFlags().Expand().Border(wxBOTTOM));
 
 	SetSizerAndFit(MainSizer);
 

--- a/src/dialog_styling_assistant.cpp
+++ b/src/dialog_styling_assistant.cpp
@@ -86,7 +86,8 @@ DialogStyling::DialogStyling(agi::Context *context)
 		wxStaticBoxSizer *hotkey_sizer = new wxStaticBoxSizer(wxVERTICAL, this, _("Keys"));
 		wxWindow *hotkey_sizer_box = hotkey_sizer->GetStaticBox();
 
-		wxSizer *hotkey_grid = new wxGridSizer(2, 0, 5);
+		int gap = wxSizerFlags::GetDefaultBorder();
+		wxSizer *hotkey_grid = new wxGridSizer(2, 0, gap);
 		add_hotkey(hotkey_grid, hotkey_sizer_box, "tool/styling_assistant/commit", _("Accept changes"));
 		add_hotkey(hotkey_grid, hotkey_sizer_box, "tool/styling_assistant/preview", _("Preview changes"));
 		add_hotkey(hotkey_grid, hotkey_sizer_box, "grid/line/prev", _("Previous line"));

--- a/src/dialog_styling_assistant.cpp
+++ b/src/dialog_styling_assistant.cpp
@@ -62,14 +62,14 @@ DialogStyling::DialogStyling(agi::Context *context)
 
 	{
 		wxStaticBoxSizer *cur_line_box = new wxStaticBoxSizer(wxHORIZONTAL, this, _("Current line"));
-		current_line_text = new wxTextCtrl(cur_line_box->GetStaticBox(), -1, _("Current line"), wxDefaultPosition, wxSize(300, 60), wxTE_MULTILINE | wxTE_READONLY);
+		current_line_text = new wxTextCtrl(cur_line_box->GetStaticBox(), -1, _("Current line"), wxDefaultPosition, FromDIP(wxSize(300, 60)), wxTE_MULTILINE | wxTE_READONLY);
 		cur_line_box->Add(current_line_text, wxSizerFlags(1).Expand());
 		main_sizer->Add(cur_line_box, wxSizerFlags().Expand().Border());
 	}
 
 	{
 		wxStaticBoxSizer *styles_box = new wxStaticBoxSizer(wxVERTICAL, this, _("Styles available"));
-		style_list = new wxListBox(styles_box->GetStaticBox(), -1, wxDefaultPosition, wxSize(150, 180), to_wx(context->ass->GetStyles()));
+		style_list = new wxListBox(styles_box->GetStaticBox(), -1, wxDefaultPosition, FromDIP(wxSize(150, 180)), to_wx(context->ass->GetStyles()));
 		styles_box->Add(style_list, wxSizerFlags(1).Expand());
 		bottom_sizer->Add(styles_box, wxSizerFlags(1).Expand().Border(wxRIGHT));
 	}
@@ -77,7 +77,7 @@ DialogStyling::DialogStyling(agi::Context *context)
 	wxSizer *right_sizer = new wxBoxSizer(wxVERTICAL);
 	{
 		wxStaticBoxSizer *style_text_box = new wxStaticBoxSizer(wxHORIZONTAL, this, _("Set style"));
-		style_name = new wxTextCtrl(style_text_box->GetStaticBox(), -1, "", wxDefaultPosition, wxSize(180, -1), wxTE_PROCESS_ENTER);
+		style_name = new wxTextCtrl(style_text_box->GetStaticBox(), -1, "", wxDefaultPosition, FromDIP(wxSize(180, -1)), wxTE_PROCESS_ENTER);
 		style_text_box->Add(style_name, wxSizerFlags(1).Expand());
 		right_sizer->Add(style_text_box, wxSizerFlags().Expand().Border(wxBOTTOM));
 	}

--- a/src/dialog_styling_assistant.cpp
+++ b/src/dialog_styling_assistant.cpp
@@ -63,23 +63,23 @@ DialogStyling::DialogStyling(agi::Context *context)
 	{
 		wxStaticBoxSizer *cur_line_box = new wxStaticBoxSizer(wxHORIZONTAL, this, _("Current line"));
 		current_line_text = new wxTextCtrl(cur_line_box->GetStaticBox(), -1, _("Current line"), wxDefaultPosition, wxSize(300, 60), wxTE_MULTILINE | wxTE_READONLY);
-		cur_line_box->Add(current_line_text, 1, wxEXPAND, 0);
-		main_sizer->Add(cur_line_box, 0, wxEXPAND | wxALL, 5);
+		cur_line_box->Add(current_line_text, wxSizerFlags(1).Expand());
+		main_sizer->Add(cur_line_box, wxSizerFlags().Expand().Border());
 	}
 
 	{
 		wxStaticBoxSizer *styles_box = new wxStaticBoxSizer(wxVERTICAL, this, _("Styles available"));
 		style_list = new wxListBox(styles_box->GetStaticBox(), -1, wxDefaultPosition, wxSize(150, 180), to_wx(context->ass->GetStyles()));
-		styles_box->Add(style_list, 1, wxEXPAND, 0);
-		bottom_sizer->Add(styles_box, 1, wxEXPAND | wxRIGHT, 5);
+		styles_box->Add(style_list, wxSizerFlags(1).Expand());
+		bottom_sizer->Add(styles_box, wxSizerFlags(1).Expand().Border(wxRIGHT));
 	}
 
 	wxSizer *right_sizer = new wxBoxSizer(wxVERTICAL);
 	{
 		wxStaticBoxSizer *style_text_box = new wxStaticBoxSizer(wxHORIZONTAL, this, _("Set style"));
 		style_name = new wxTextCtrl(style_text_box->GetStaticBox(), -1, "", wxDefaultPosition, wxSize(180, -1), wxTE_PROCESS_ENTER);
-		style_text_box->Add(style_name, 1, wxEXPAND);
-		right_sizer->Add(style_text_box, 0, wxEXPAND | wxBOTTOM, 5);
+		style_text_box->Add(style_name, wxSizerFlags(1).Expand());
+		right_sizer->Add(style_text_box, wxSizerFlags().Expand().Border(wxBOTTOM));
 	}
 
 	{
@@ -96,14 +96,14 @@ DialogStyling::DialogStyling(agi::Context *context)
 		hotkey_grid->Add(new wxStaticText(hotkey_sizer_box, -1, _("Click on list")));
 		hotkey_grid->Add(new wxStaticText(hotkey_sizer_box, -1, _("Select style")));
 
-		hotkey_sizer->Add(hotkey_grid, 0, wxEXPAND | wxBOTTOM, 5);
+		hotkey_sizer->Add(hotkey_grid, wxSizerFlags().Expand().Border(wxBOTTOM));
 
 		auto_seek = new wxCheckBox(hotkey_sizer_box, -1, _("&Seek video to line start time"));
 		auto_seek->SetValue(true);
-		hotkey_sizer->Add(auto_seek, 0, 0, 0);
+		hotkey_sizer->Add(auto_seek);
 		hotkey_sizer->AddStretchSpacer(1);
 
-		right_sizer->Add(hotkey_sizer, 0, wxEXPAND | wxBOTTOM, 5);
+		right_sizer->Add(hotkey_sizer, wxSizerFlags().Expand().Border(wxBOTTOM));
 	}
 
 	{
@@ -112,17 +112,17 @@ DialogStyling::DialogStyling(agi::Context *context)
 
 		play_audio = new wxButton(actions_box->GetStaticBox(), -1, _("Play &Audio"));
 		play_audio->Enable(!!c->project->AudioProvider());
-		actions_box->Add(play_audio, 0, wxLEFT | wxRIGHT | wxBOTTOM, 5);
+		actions_box->Add(play_audio, wxSizerFlags().Border(wxALL & ~wxTOP));
 
 		play_video = new wxButton(actions_box->GetStaticBox(), -1, _("Play &Video"));
 		play_video->Enable(!!c->project->VideoProvider());
-		actions_box->Add(play_video, 0, wxBOTTOM | wxRIGHT, 5);
+		actions_box->Add(play_video, wxSizerFlags().Border(wxBOTTOM | wxRIGHT));
 
 		actions_box->AddStretchSpacer(1);
-		right_sizer->Add(actions_box, 0, wxEXPAND, 0);
+		right_sizer->Add(actions_box, wxSizerFlags().Expand());
 	}
 	bottom_sizer->Add(right_sizer);
-	main_sizer->Add(bottom_sizer, 1, wxEXPAND | wxLEFT | wxBOTTOM | wxRIGHT, 5);
+	main_sizer->Add(bottom_sizer, wxSizerFlags(1).Expand().Border(wxALL & ~wxTOP));
 
 	{
 		auto button_sizer = new wxStdDialogButtonSizer;
@@ -130,7 +130,7 @@ DialogStyling::DialogStyling(agi::Context *context)
 		button_sizer->AddButton(new HelpButton(this, "Styling Assistant"));
 		button_sizer->Realize();
 
-		main_sizer->Add(button_sizer, 0, wxEXPAND | wxBOTTOM | wxLEFT | wxRIGHT, 5);
+		main_sizer->Add(button_sizer, wxSizerFlags().Expand().Border(wxALL & ~wxTOP));
 	}
 
 	SetSizerAndFit(main_sizer);

--- a/src/dialog_styling_assistant.cpp
+++ b/src/dialog_styling_assistant.cpp
@@ -87,7 +87,7 @@ DialogStyling::DialogStyling(agi::Context *context)
 		wxWindow *hotkey_sizer_box = hotkey_sizer->GetStaticBox();
 
 		int gap = wxSizerFlags::GetDefaultBorder();
-		wxSizer *hotkey_grid = new wxGridSizer(2, 0, gap);
+		wxSizer *hotkey_grid = new wxGridSizer(2, gap, gap);
 		add_hotkey(hotkey_grid, hotkey_sizer_box, "tool/styling_assistant/commit", _("Accept changes"));
 		add_hotkey(hotkey_grid, hotkey_sizer_box, "tool/styling_assistant/preview", _("Preview changes"));
 		add_hotkey(hotkey_grid, hotkey_sizer_box, "grid/line/prev", _("Previous line"));

--- a/src/dialog_text_import.cpp
+++ b/src/dialog_text_import.cpp
@@ -51,15 +51,15 @@ bool ShowPlainTextImportDialog() {
 	};
 
 	auto fg = new wxFlexGridSizer(2, 5, 5);
-	fg->Add(new wxStaticText(&d, -1, _("Actor separator:")), 0, wxALIGN_CENTRE_VERTICAL);
-	fg->Add(make_text_ctrl(&seperator), 0, wxEXPAND);
-	fg->Add(new wxStaticText(&d, -1, _("Comment starter:")), 0, wxALIGN_CENTRE_VERTICAL);
-	fg->Add(make_text_ctrl(&comment), 0, wxEXPAND);
+	fg->Add(new wxStaticText(&d, -1, _("Actor separator:")), wxSizerFlags().CenterVertical());
+	fg->Add(make_text_ctrl(&seperator), wxSizerFlags().Expand());
+	fg->Add(new wxStaticText(&d, -1, _("Comment starter:")), wxSizerFlags().CenterVertical());
+	fg->Add(make_text_ctrl(&comment), wxSizerFlags().Expand());
 
 	auto main_sizer = new wxBoxSizer(wxVERTICAL);
-	main_sizer->Add(fg, 1, wxALL|wxEXPAND, 5);
-	main_sizer->Add(new wxCheckBox(&d, -1, _("Include blank lines"), wxDefaultPosition, wxDefaultSize, 0, wxGenericValidator(&include_blank)), 0, wxLEFT|wxRIGHT|wxALIGN_RIGHT, 5);
-	main_sizer->Add(d.CreateSeparatedButtonSizer(wxOK|wxCANCEL), 0, wxALL|wxEXPAND, 5);
+	main_sizer->Add(fg, wxSizerFlags(1).Expand().Border());
+	main_sizer->Add(new wxCheckBox(&d, -1, _("Include blank lines"), wxDefaultPosition, wxDefaultSize, 0, wxGenericValidator(&include_blank)), wxSizerFlags().HorzBorder().Right());
+	main_sizer->Add(d.CreateSeparatedButtonSizer(wxOK|wxCANCEL), wxSizerFlags().Expand().Border());
 	d.SetSizerAndFit(main_sizer);
 
 	d.Bind(wxEVT_BUTTON, [&](wxCommandEvent&) {

--- a/src/dialog_text_import.cpp
+++ b/src/dialog_text_import.cpp
@@ -50,7 +50,8 @@ bool ShowPlainTextImportDialog() {
 		return new wxTextCtrl(&d, -1, "", wxDefaultPosition, wxDefaultSize, 0, StringBinder(var));
 	};
 
-	auto fg = new wxFlexGridSizer(2, 5, 5);
+	int gap = wxSizerFlags::GetDefaultBorder();
+	auto fg = new wxFlexGridSizer(2, gap, gap);
 	fg->Add(new wxStaticText(&d, -1, _("Actor separator:")), wxSizerFlags().CenterVertical());
 	fg->Add(make_text_ctrl(&seperator), wxSizerFlags().Expand());
 	fg->Add(new wxStaticText(&d, -1, _("Comment starter:")), wxSizerFlags().CenterVertical());

--- a/src/dialog_timing_processor.cpp
+++ b/src/dialog_timing_processor.cpp
@@ -108,7 +108,7 @@ struct DialogTimingProcessor {
 wxTextCtrl *make_ctrl(wxWindow *parent, wxSizer *sizer, wxString const& desc, int *value, wxCheckBox *cb, wxString const& tooltip) {
 	wxIntegerValidator<int> validator(value);
 	validator.SetMin(0);
-	wxTextCtrl *ctrl = new wxTextCtrl(parent, -1, "", wxDefaultPosition, wxSize(60,-1), 0, validator);
+	wxTextCtrl *ctrl = new wxTextCtrl(parent, -1, "", wxDefaultPosition, parent->FromDIP(wxSize(60,-1)), 0, validator);
 	ctrl->SetToolTip(tooltip);
 	if (!desc.empty())
 		sizer->Add(new wxStaticText(parent, -1, desc), wxSizerFlags().Center().Border(wxRIGHT));
@@ -156,7 +156,7 @@ DialogTimingProcessor::DialogTimingProcessor(agi::Context *c)
 	// Styles box
 	auto LeftSizer = new wxStaticBoxSizer(wxVERTICAL,&d,_("Apply to styles"));
 	wxWindow *LeftSizerBox = LeftSizer->GetStaticBox();
-	StyleList = new wxCheckListBox(LeftSizerBox, -1, wxDefaultPosition, wxSize(150,150), to_wx(c->ass->GetStyles()));
+	StyleList = new wxCheckListBox(LeftSizerBox, -1, wxDefaultPosition, d.FromDIP(wxSize(150, 150)), to_wx(c->ass->GetStyles()));
 	StyleList->SetToolTip(_("Select styles to process. Unchecked ones will be ignored."));
 
 	auto all = new wxButton(LeftSizerBox,-1,_("&All"));
@@ -215,7 +215,8 @@ DialogTimingProcessor::DialogTimingProcessor(agi::Context *c)
 	// Keyframes sizer
 	auto KeyframesSizer = new wxStaticBoxSizer(wxHORIZONTAL, &d, _("Keyframe snapping"));
 	wxWindow *KeyframesSizerBox = KeyframesSizer->GetStaticBox();
-	auto KeyframesFlexSizer = new wxFlexGridSizer(2,5,5,0);
+	int gap = wxSizerFlags::GetDefaultBorder();
+	auto KeyframesFlexSizer = new wxFlexGridSizer(2, 5, gap, 0);
 
 	keysEnable = new wxCheckBox(KeyframesSizerBox, -1, _("E&nable"));
 	keysEnable->SetToolTip(_("Enable snapping of subtitles to nearest keyframe, if distance is within threshold"));

--- a/src/dialog_timing_processor.cpp
+++ b/src/dialog_timing_processor.cpp
@@ -169,7 +169,7 @@ DialogTimingProcessor::DialogTimingProcessor(agi::Context *c)
 	auto optionsSizer = new wxStaticBoxSizer(wxHORIZONTAL,&d,_("Options"));
 	onlySelection = new wxCheckBox(optionsSizer->GetStaticBox(),-1,_("Affect &selection only"));
 	onlySelection->SetValue(OPT_GET("Tool/Timing Post Processor/Only Selection")->GetBool());
-	optionsSizer->Add(onlySelection,1,0,0);
+	optionsSizer->Add(onlySelection, 1);
 
 	// Lead-in/out box
 	auto LeadSizer = new wxStaticBoxSizer(wxHORIZONTAL, &d, _("Lead-in/Lead-out"));
@@ -220,7 +220,7 @@ DialogTimingProcessor::DialogTimingProcessor(agi::Context *c)
 	keysEnable = new wxCheckBox(KeyframesSizerBox, -1, _("E&nable"));
 	keysEnable->SetToolTip(_("Enable snapping of subtitles to nearest keyframe, if distance is within threshold"));
 	keysEnable->SetValue(OPT_GET("Tool/Timing Post Processor/Enable/Keyframe")->GetBool());
-	KeyframesFlexSizer->Add(keysEnable,0,wxRIGHT|wxEXPAND,10);
+	KeyframesFlexSizer->Add(keysEnable, wxSizerFlags().Expand().DoubleBorder(wxRIGHT));
 
 	// Keyframes are only available if timecodes are loaded
 	bool keysAvailable = !c->project->Keyframes().empty() && c->project->Timecodes().IsLoaded();
@@ -243,7 +243,7 @@ DialogTimingProcessor::DialogTimingProcessor(agi::Context *c)
 	make_ctrl(KeyframesSizerBox, KeyframesFlexSizer, _("Ends after thres.:"), &afterEnd, keysEnable,
 		_("Threshold for 'after end' distance, that is, how many milliseconds a subtitle must end after a keyframe to snap to it"));
 
-	KeyframesSizer->Add(KeyframesFlexSizer,0,wxEXPAND);
+	KeyframesSizer->Add(KeyframesFlexSizer, wxSizerFlags().Expand());
 	KeyframesSizer->AddStretchSpacer(1);
 
 	// Button sizer
@@ -253,17 +253,17 @@ DialogTimingProcessor::DialogTimingProcessor(agi::Context *c)
 
 	// Right Sizer
 	auto RightSizer = new wxBoxSizer(wxVERTICAL);
-	RightSizer->Add(optionsSizer,0,wxBOTTOM|wxEXPAND,5);
-	RightSizer->Add(LeadSizer,0,wxBOTTOM|wxEXPAND,5);
-	RightSizer->Add(AdjacentSizer,0,wxBOTTOM|wxEXPAND,5);
-	RightSizer->Add(KeyframesSizer,0,wxBOTTOM|wxEXPAND,5);
+	RightSizer->Add(optionsSizer, wxSizerFlags().Expand().Border(wxBOTTOM));
+	RightSizer->Add(LeadSizer, wxSizerFlags().Expand().Border(wxBOTTOM));
+	RightSizer->Add(AdjacentSizer, wxSizerFlags().Expand().Border(wxBOTTOM));
+	RightSizer->Add(KeyframesSizer, wxSizerFlags().Expand().Border(wxBOTTOM));
 	RightSizer->AddStretchSpacer(1);
-	RightSizer->Add(ButtonSizer,0,wxEXPAND,0);
+	RightSizer->Add(ButtonSizer, wxSizerFlags().Expand());
 
 	// Style buttons sizer
 	auto StyleButtonsSizer = new wxBoxSizer(wxHORIZONTAL);
-	StyleButtonsSizer->Add(all,1,0,0);
-	StyleButtonsSizer->Add(none,1,0,0);
+	StyleButtonsSizer->Add(all, 1);
+	StyleButtonsSizer->Add(none, 1);
 
 	// Left sizer
 	LeftSizer->Add(StyleList, wxSizerFlags(1).Border(wxBOTTOM));
@@ -271,12 +271,12 @@ DialogTimingProcessor::DialogTimingProcessor(agi::Context *c)
 
 	// Top Sizer
 	auto TopSizer = new wxBoxSizer(wxHORIZONTAL);
-	TopSizer->Add(LeftSizer,0,wxRIGHT|wxEXPAND,5);
-	TopSizer->Add(RightSizer,1,wxEXPAND,0);
+	TopSizer->Add(LeftSizer, wxSizerFlags().Expand().Border(wxRIGHT));
+	TopSizer->Add(RightSizer, wxSizerFlags(1).Expand());
 
 	// Main Sizer
 	auto MainSizer = new wxBoxSizer(wxVERTICAL);
-	MainSizer->Add(TopSizer,1,wxALL|wxEXPAND,5);
+	MainSizer->Add(TopSizer, wxSizerFlags(1).Expand().Border());
 	d.SetSizerAndFit(MainSizer);
 	d.CenterOnParent();
 

--- a/src/dialog_translation.cpp
+++ b/src/dialog_translation.cpp
@@ -80,7 +80,7 @@ DialogTranslation::DialogTranslation(agi::Context *c)
 		line_number_display = new wxStaticText(original_box->GetStaticBox(), -1, "");
 		original_box->Add(line_number_display, wxSizerFlags().Border(wxBOTTOM));
 
-		original_text = new wxStyledTextCtrl(original_box->GetStaticBox(), -1, wxDefaultPosition, wxSize(320, 80));
+		original_text = new wxStyledTextCtrl(original_box->GetStaticBox(), -1, wxDefaultPosition, FromDIP(wxSize(320, 80)));
 		original_text->SetWrapMode(wxSTC_WRAP_WORD);
 		original_text->SetMarginWidth(1, 0);
 		original_text->StyleSetForeground(1, wxColour(10, 60, 200));
@@ -93,7 +93,7 @@ DialogTranslation::DialogTranslation(agi::Context *c)
 	{
 		wxStaticBoxSizer *translated_box = new wxStaticBoxSizer(wxVERTICAL, this, _("Translation"));
 
-		translated_text = new SubsTextEditCtrl(translated_box->GetStaticBox(), wxSize(320, 80), 0, nullptr);
+		translated_text = new SubsTextEditCtrl(translated_box->GetStaticBox(), FromDIP(wxSize(320, 80)), 0, nullptr);
 		translated_text->SetWrapMode(wxSTC_WRAP_WORD);
 		translated_text->SetMarginWidth(1, 0);
 		translated_text->SetFocus();

--- a/src/dialog_translation.cpp
+++ b/src/dialog_translation.cpp
@@ -78,16 +78,16 @@ DialogTranslation::DialogTranslation(agi::Context *c)
 		wxStaticBoxSizer *original_box = new wxStaticBoxSizer(wxVERTICAL, this, _("Original"));
 
 		line_number_display = new wxStaticText(original_box->GetStaticBox(), -1, "");
-		original_box->Add(line_number_display, 0, wxBOTTOM, 5);
+		original_box->Add(line_number_display, wxSizerFlags().Border(wxBOTTOM));
 
 		original_text = new wxStyledTextCtrl(original_box->GetStaticBox(), -1, wxDefaultPosition, wxSize(320, 80));
 		original_text->SetWrapMode(wxSTC_WRAP_WORD);
 		original_text->SetMarginWidth(1, 0);
 		original_text->StyleSetForeground(1, wxColour(10, 60, 200));
 		original_text->SetReadOnly(true);
-		original_box->Add(original_text, 1, wxEXPAND, 0);
+		original_box->Add(original_text, wxSizerFlags(1).Expand());
 
-		translation_sizer->Add(original_box, 1, wxEXPAND, 0);
+		translation_sizer->Add(original_box, wxSizerFlags(1).Expand());
 	}
 
 	{
@@ -100,10 +100,10 @@ DialogTranslation::DialogTranslation(agi::Context *c)
 		translated_text->Bind(wxEVT_CHAR_HOOK, &DialogTranslation::OnKeyDown, this);
 		translated_text->CmdKeyAssign(wxSTC_KEY_RETURN, wxSTC_KEYMOD_SHIFT, wxSTC_CMD_NEWLINE);
 
-		translated_box->Add(translated_text, 1, wxEXPAND, 0);
-		translation_sizer->Add(translated_box, 1, wxTOP|wxEXPAND, 5);
+		translated_box->Add(translated_text, wxSizerFlags(1).Expand());
+		translation_sizer->Add(translated_box, wxSizerFlags(1).Expand().Border(wxTOP));
 	}
-	main_sizer->Add(translation_sizer, 1, wxALL | wxEXPAND, 5);
+	main_sizer->Add(translation_sizer, wxSizerFlags(1).Expand().Border());
 
 	wxSizer *right_box = new wxBoxSizer(wxHORIZONTAL);
 	{
@@ -119,13 +119,13 @@ DialogTranslation::DialogTranslation(agi::Context *c)
 		add_hotkey(hotkey_grid, hotkey_sizer_box, "video/play/line", _("Play video"));
 		add_hotkey(hotkey_grid, hotkey_sizer_box, "audio/play/selection", _("Play audio"));
 		add_hotkey(hotkey_grid, hotkey_sizer_box, "edit/line/delete", _("Delete line"));
-		hotkey_sizer->Add(hotkey_grid, 0, wxEXPAND, 0);
+		hotkey_sizer->Add(hotkey_grid, wxSizerFlags().Expand());
 
 		seek_video = new wxCheckBox(hotkey_sizer_box, -1, _("Enable &preview"));
 		seek_video->SetValue(true);
-		hotkey_sizer->Add(seek_video, 0, wxTOP, 5);
+		hotkey_sizer->Add(seek_video, wxSizerFlags().Border(wxTOP));
 
-		right_box->Add(hotkey_sizer, 1, wxRIGHT | wxEXPAND, 5);
+		right_box->Add(hotkey_sizer, wxSizerFlags(1).Expand().Border(wxRIGHT));
 	}
 
 	{
@@ -134,23 +134,23 @@ DialogTranslation::DialogTranslation(agi::Context *c)
 		wxButton *play_audio = new wxButton(actions_box->GetStaticBox(), -1, _("Play &Audio"));
 		play_audio->Enable(!!c->project->AudioProvider());
 		play_audio->Bind(wxEVT_BUTTON, &DialogTranslation::OnPlayAudioButton, this);
-		actions_box->Add(play_audio, 0, wxALL, 5);
+		actions_box->Add(play_audio, wxSizerFlags().Border());
 
 		wxButton *play_video = new wxButton(actions_box->GetStaticBox(), -1, _("Play &Video"));
 		play_video->Enable(!!c->project->VideoProvider());
 		play_video->Bind(wxEVT_BUTTON, &DialogTranslation::OnPlayVideoButton, this);
-		actions_box->Add(play_video, 0, wxLEFT | wxRIGHT | wxBOTTOM, 5);
+		actions_box->Add(play_video, wxSizerFlags().Border(wxALL & ~wxTOP));
 
-		right_box->Add(actions_box, 0);
+		right_box->Add(actions_box);
 	}
-	main_sizer->Add(right_box, 0, wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND, 5);
+	main_sizer->Add(right_box, wxSizerFlags().Expand().Border(wxALL & ~wxTOP));
 
 	{
 		auto standard_buttons = new wxStdDialogButtonSizer();
 		standard_buttons->AddButton(new wxButton(this, wxID_CANCEL));
 		standard_buttons->AddButton(new HelpButton(this, "Translation Assistant"));
 		standard_buttons->Realize();
-		main_sizer->Add(standard_buttons, 0, wxALIGN_RIGHT | wxLEFT | wxBOTTOM | wxRIGHT, 5);
+		main_sizer->Add(standard_buttons, wxSizerFlags().Right().Border(wxALL & ~wxTOP));
 	}
 
 	SetSizerAndFit(main_sizer);

--- a/src/dialog_translation.cpp
+++ b/src/dialog_translation.cpp
@@ -110,7 +110,8 @@ DialogTranslation::DialogTranslation(agi::Context *c)
 		wxStaticBoxSizer *hotkey_sizer = new wxStaticBoxSizer(wxVERTICAL, this, _("Keys"));
 		wxWindow *hotkey_sizer_box = hotkey_sizer->GetStaticBox();
 
-		wxSizer *hotkey_grid = new wxGridSizer(2, 0, 5);
+		int gap = wxSizerFlags::GetDefaultBorder();
+		wxSizer *hotkey_grid = new wxGridSizer(2, 0, gap);
 		add_hotkey(hotkey_grid, hotkey_sizer_box, "tool/translation_assistant/commit", _("Accept changes"));
 		add_hotkey(hotkey_grid, hotkey_sizer_box, "tool/translation_assistant/preview", _("Preview changes"));
 		add_hotkey(hotkey_grid, hotkey_sizer_box, "tool/translation_assistant/prev", _("Previous line"));

--- a/src/dialog_translation.cpp
+++ b/src/dialog_translation.cpp
@@ -111,7 +111,7 @@ DialogTranslation::DialogTranslation(agi::Context *c)
 		wxWindow *hotkey_sizer_box = hotkey_sizer->GetStaticBox();
 
 		int gap = wxSizerFlags::GetDefaultBorder();
-		wxSizer *hotkey_grid = new wxGridSizer(2, 0, gap);
+		wxSizer *hotkey_grid = new wxGridSizer(2, gap, gap);
 		add_hotkey(hotkey_grid, hotkey_sizer_box, "tool/translation_assistant/commit", _("Accept changes"));
 		add_hotkey(hotkey_grid, hotkey_sizer_box, "tool/translation_assistant/preview", _("Preview changes"));
 		add_hotkey(hotkey_grid, hotkey_sizer_box, "tool/translation_assistant/prev", _("Previous line"));

--- a/src/dialog_version_check.cpp
+++ b/src/dialog_version_check.cpp
@@ -94,7 +94,7 @@ VersionCheckerResultDialog::VersionCheckerResultDialog(wxString const& main_text
 	wxSizer *main_sizer = new wxBoxSizer(wxVERTICAL);
 
 	wxStaticText *text = new wxStaticText(this, -1, main_text);
-	text->Wrap(controls_width);
+	text->Wrap(FromDIP(controls_width));
 	main_sizer->Add(text, wxSizerFlags().Expand().Border(wxBOTTOM));
 
 	for (auto const& update : updates) {
@@ -106,7 +106,7 @@ VersionCheckerResultDialog::VersionCheckerResultDialog(wxString const& main_text
 		text->SetFont(boldfont);
 		main_sizer->Add(text, wxSizerFlags().Expand().Border(wxBOTTOM));
 
-		wxTextCtrl *descbox = new wxTextCtrl(this, -1, to_wx(update.description), wxDefaultPosition, wxSize(controls_width,60), wxTE_MULTILINE|wxTE_READONLY);
+		wxTextCtrl *descbox = new wxTextCtrl(this, -1, to_wx(update.description), wxDefaultPosition, FromDIP(wxSize(controls_width,60)), wxTE_MULTILINE|wxTE_READONLY);
 		main_sizer->Add(descbox, wxSizerFlags().Expand().Border(wxBOTTOM));
 
 		main_sizer->Add(new wxHyperlinkCtrl(this, -1, to_wx(update.url), to_wx(update.url)), wxSizerFlags().Left().Border(wxBOTTOM));

--- a/src/dialog_version_check.cpp
+++ b/src/dialog_version_check.cpp
@@ -95,21 +95,21 @@ VersionCheckerResultDialog::VersionCheckerResultDialog(wxString const& main_text
 
 	wxStaticText *text = new wxStaticText(this, -1, main_text);
 	text->Wrap(controls_width);
-	main_sizer->Add(text, wxSizerFlags().Expand().Border(wxBOTTOM, 6));
+	main_sizer->Add(text, wxSizerFlags().Expand().Border(wxBOTTOM));
 
 	for (auto const& update : updates) {
-		main_sizer->Add(new wxStaticLine(this), wxSizerFlags().Expand().Border(wxALL, 6));
+		main_sizer->Add(new wxStaticLine(this), wxSizerFlags().Expand().Border());
 
 		text = new wxStaticText(this, -1, to_wx(update.friendly_name));
 		wxFont boldfont = text->GetFont();
 		boldfont.SetWeight(wxFONTWEIGHT_BOLD);
 		text->SetFont(boldfont);
-		main_sizer->Add(text, wxSizerFlags().Expand().Border(wxBOTTOM, 6));
+		main_sizer->Add(text, wxSizerFlags().Expand().Border(wxBOTTOM));
 
 		wxTextCtrl *descbox = new wxTextCtrl(this, -1, to_wx(update.description), wxDefaultPosition, wxSize(controls_width,60), wxTE_MULTILINE|wxTE_READONLY);
-		main_sizer->Add(descbox, wxSizerFlags().Expand().Border(wxBOTTOM, 6));
+		main_sizer->Add(descbox, wxSizerFlags().Expand().Border(wxBOTTOM));
 
-		main_sizer->Add(new wxHyperlinkCtrl(this, -1, to_wx(update.url), to_wx(update.url)), wxSizerFlags().Left().Border(wxBOTTOM, 6));
+		main_sizer->Add(new wxHyperlinkCtrl(this, -1, to_wx(update.url), to_wx(update.url)), wxSizerFlags().Left().Border(wxBOTTOM));
 	}
 
 	automatic_check_checkbox = new wxCheckBox(this, -1, _("&Auto Check for Updates"));
@@ -124,8 +124,8 @@ VersionCheckerResultDialog::VersionCheckerResultDialog(wxString const& main_text
 	SetEscapeId(wxID_OK);
 
 	if (updates.size())
-		main_sizer->Add(new wxStaticLine(this), wxSizerFlags().Expand().Border(wxALL, 6));
-	main_sizer->Add(automatic_check_checkbox, wxSizerFlags().Expand().Border(wxBOTTOM, 6));
+		main_sizer->Add(new wxStaticLine(this), wxSizerFlags().Expand().Border());
+	main_sizer->Add(automatic_check_checkbox, wxSizerFlags().Expand().Border(wxBOTTOM));
 
 	auto button_sizer = new wxStdDialogButtonSizer();
 	button_sizer->AddButton(close_button);
@@ -135,7 +135,7 @@ VersionCheckerResultDialog::VersionCheckerResultDialog(wxString const& main_text
 	main_sizer->Add(button_sizer, wxSizerFlags().Expand());
 
 	wxSizer *outer_sizer = new wxBoxSizer(wxVERTICAL);
-	outer_sizer->Add(main_sizer, wxSizerFlags().Expand().Border(wxALL, 12));
+	outer_sizer->Add(main_sizer, wxSizerFlags().Expand().DoubleBorder());
 
 	SetSizerAndFit(outer_sizer);
 	Centre();

--- a/src/dialog_version_check.cpp
+++ b/src/dialog_version_check.cpp
@@ -95,21 +95,21 @@ VersionCheckerResultDialog::VersionCheckerResultDialog(wxString const& main_text
 
 	wxStaticText *text = new wxStaticText(this, -1, main_text);
 	text->Wrap(controls_width);
-	main_sizer->Add(text, 0, wxBOTTOM|wxEXPAND, 6);
+	main_sizer->Add(text, wxSizerFlags().Expand().Border(wxBOTTOM, 6));
 
 	for (auto const& update : updates) {
-		main_sizer->Add(new wxStaticLine(this), 0, wxEXPAND|wxALL, 6);
+		main_sizer->Add(new wxStaticLine(this), wxSizerFlags().Expand().Border(wxALL, 6));
 
 		text = new wxStaticText(this, -1, to_wx(update.friendly_name));
 		wxFont boldfont = text->GetFont();
 		boldfont.SetWeight(wxFONTWEIGHT_BOLD);
 		text->SetFont(boldfont);
-		main_sizer->Add(text, 0, wxEXPAND|wxBOTTOM, 6);
+		main_sizer->Add(text, wxSizerFlags().Expand().Border(wxBOTTOM, 6));
 
 		wxTextCtrl *descbox = new wxTextCtrl(this, -1, to_wx(update.description), wxDefaultPosition, wxSize(controls_width,60), wxTE_MULTILINE|wxTE_READONLY);
-		main_sizer->Add(descbox, 0, wxEXPAND|wxBOTTOM, 6);
+		main_sizer->Add(descbox, wxSizerFlags().Expand().Border(wxBOTTOM, 6));
 
-		main_sizer->Add(new wxHyperlinkCtrl(this, -1, to_wx(update.url), to_wx(update.url)), 0, wxALIGN_LEFT|wxBOTTOM, 6);
+		main_sizer->Add(new wxHyperlinkCtrl(this, -1, to_wx(update.url), to_wx(update.url)), wxSizerFlags().Left().Border(wxBOTTOM, 6));
 	}
 
 	automatic_check_checkbox = new wxCheckBox(this, -1, _("&Auto Check for Updates"));
@@ -124,18 +124,18 @@ VersionCheckerResultDialog::VersionCheckerResultDialog(wxString const& main_text
 	SetEscapeId(wxID_OK);
 
 	if (updates.size())
-		main_sizer->Add(new wxStaticLine(this), 0, wxEXPAND|wxALL, 6);
-	main_sizer->Add(automatic_check_checkbox, 0, wxEXPAND|wxBOTTOM, 6);
+		main_sizer->Add(new wxStaticLine(this), wxSizerFlags().Expand().Border(wxALL, 6));
+	main_sizer->Add(automatic_check_checkbox, wxSizerFlags().Expand().Border(wxBOTTOM, 6));
 
 	auto button_sizer = new wxStdDialogButtonSizer();
 	button_sizer->AddButton(close_button);
 	if (remind_later_button)
 		button_sizer->AddButton(remind_later_button);
 	button_sizer->Realize();
-	main_sizer->Add(button_sizer, 0, wxEXPAND, 0);
+	main_sizer->Add(button_sizer, wxSizerFlags().Expand());
 
 	wxSizer *outer_sizer = new wxBoxSizer(wxVERTICAL);
-	outer_sizer->Add(main_sizer, 0, wxALL|wxEXPAND, 12);
+	outer_sizer->Add(main_sizer, wxSizerFlags().Expand().Border(wxALL, 12));
 
 	SetSizerAndFit(outer_sizer);
 	Centre();

--- a/src/dialog_video_details.cpp
+++ b/src/dialog_video_details.cpp
@@ -55,7 +55,8 @@ void ShowVideoDetailsDialog(agi::Context *c) {
 	auto video_sizer = new wxStaticBoxSizer(wxVERTICAL, &d, _("Video"));
 	wxWindow *video_sizer_box = video_sizer->GetStaticBox();
 
-	auto fg = new wxFlexGridSizer(2, 5, 10);
+	int gap = wxSizerFlags::GetDefaultBorder();
+	auto fg = new wxFlexGridSizer(2, gap, wxRound(2 * wxSizerFlags::GetDefaultBorderFractional()));
 	auto make_field = [&, video_sizer_box](wxString const& name, wxString const& value) {
 		fg->Add(new wxStaticText(video_sizer_box, -1, name), wxSizerFlags().CenterVertical());
 		fg->Add(new wxTextCtrl(video_sizer_box, -1, value, wxDefaultPosition, wxSize(300,-1), wxTE_READONLY), wxSizerFlags().CenterVertical().Expand());

--- a/src/dialog_video_details.cpp
+++ b/src/dialog_video_details.cpp
@@ -59,7 +59,7 @@ void ShowVideoDetailsDialog(agi::Context *c) {
 	auto fg = new wxFlexGridSizer(2, gap, wxRound(2 * wxSizerFlags::GetDefaultBorderFractional()));
 	auto make_field = [&, video_sizer_box](wxString const& name, wxString const& value) {
 		fg->Add(new wxStaticText(video_sizer_box, -1, name), wxSizerFlags().CenterVertical());
-		fg->Add(new wxTextCtrl(video_sizer_box, -1, value, wxDefaultPosition, wxSize(300,-1), wxTE_READONLY), wxSizerFlags().CenterVertical().Expand());
+		fg->Add(new wxTextCtrl(video_sizer_box, -1, value, wxDefaultPosition, d.FromDIP(wxSize(300,-1)), wxTE_READONLY), wxSizerFlags().CenterVertical().Expand());
 	};
 	make_field(_("File name:"), c->project->VideoName().wstring());
 	make_field(_("FPS:"), fmt_wx("%.3f", fps.FPS()));

--- a/src/dialog_video_details.cpp
+++ b/src/dialog_video_details.cpp
@@ -57,8 +57,8 @@ void ShowVideoDetailsDialog(agi::Context *c) {
 
 	auto fg = new wxFlexGridSizer(2, 5, 10);
 	auto make_field = [&, video_sizer_box](wxString const& name, wxString const& value) {
-		fg->Add(new wxStaticText(video_sizer_box, -1, name), 0, wxALIGN_CENTRE_VERTICAL);
-		fg->Add(new wxTextCtrl(video_sizer_box, -1, value, wxDefaultPosition, wxSize(300,-1), wxTE_READONLY), 0, wxALIGN_CENTRE_VERTICAL | wxEXPAND);
+		fg->Add(new wxStaticText(video_sizer_box, -1, name), wxSizerFlags().CenterVertical());
+		fg->Add(new wxTextCtrl(video_sizer_box, -1, value, wxDefaultPosition, wxSize(300,-1), wxTE_READONLY), wxSizerFlags().CenterVertical().Expand());
 	};
 	make_field(_("File name:"), c->project->VideoName().wstring());
 	make_field(_("FPS:"), fmt_wx("%.3f", fps.FPS()));
@@ -74,8 +74,8 @@ void ShowVideoDetailsDialog(agi::Context *c) {
 	video_sizer->Add(fg);
 
 	auto main_sizer = new wxBoxSizer(wxVERTICAL);
-	main_sizer->Add(video_sizer, 1, wxALL|wxEXPAND, 5);
-	main_sizer->Add(d.CreateSeparatedButtonSizer(wxOK), 0, wxALL|wxEXPAND, 5);
+	main_sizer->Add(video_sizer, wxSizerFlags(1).Expand().Border());
+	main_sizer->Add(d.CreateSeparatedButtonSizer(wxOK), wxSizerFlags().Expand().Border());
 	d.SetSizerAndFit(main_sizer);
 
 	d.CenterOnParent();

--- a/src/export_framerate.cpp
+++ b/src/export_framerate.cpp
@@ -79,8 +79,8 @@ wxWindow *AssTransformFramerateFilter::GetConfigDialogWindow(wxWindow *parent, a
 		FromVideo->Enable(false);
 	}
 	InputFramerate = new wxTextCtrl(base,-1,initialInput);
-	InputSizer->Add(InputFramerate,0,wxEXPAND | wxLEFT,5);
-	InputSizer->Add(FromVideo,0,wxEXPAND | wxLEFT,5);
+	InputSizer->Add(InputFramerate, wxSizerFlags().Expand().Border(wxLEFT));
+	InputSizer->Add(FromVideo, wxSizerFlags().Expand().Border(wxLEFT));
 	InputSizer->AddStretchSpacer(1);
 
 	// Output sizers
@@ -90,7 +90,7 @@ wxWindow *AssTransformFramerateFilter::GetConfigDialogWindow(wxWindow *parent, a
 
 	// Output top line
 	RadioOutputVFR = new wxRadioButton(base,-1,_("V&ariable"),wxDefaultPosition,wxDefaultSize,wxRB_GROUP);
-	OutputSizerTop->Add(RadioOutputVFR,0,wxEXPAND,0);
+	OutputSizerTop->Add(RadioOutputVFR, wxSizerFlags().Expand());
 
 	// Output bottom line
 	RadioOutputCFR = new wxRadioButton(base,-1,_("&Constant: "));
@@ -100,24 +100,24 @@ wxWindow *AssTransformFramerateFilter::GetConfigDialogWindow(wxWindow *parent, a
 		RadioOutputCFR->SetValue(true);
 	}
 	OutputFramerate = new wxTextCtrl(base,-1,initialOutput);
-	OutputSizerBottom->Add(RadioOutputCFR,0,wxEXPAND,0);
-	OutputSizerBottom->Add(OutputFramerate,0,wxEXPAND | wxLEFT,5);
+	OutputSizerBottom->Add(RadioOutputCFR, wxSizerFlags().Expand());
+	OutputSizerBottom->Add(OutputFramerate, wxSizerFlags().Expand().Border(wxLEFT));
 	OutputSizerBottom->AddStretchSpacer(1);
 
 	// Reverse checkbox
 	Reverse = new wxCheckBox(base,-1,_("&Reverse transformation"));
 
 	// Output final
-	OutputSizer->Add(OutputSizerTop,0,wxLEFT,5);
-	OutputSizer->Add(OutputSizerBottom,0,wxLEFT,5);
+	OutputSizer->Add(OutputSizerTop, wxSizerFlags().Border(wxLEFT));
+	OutputSizer->Add(OutputSizerBottom, wxSizerFlags().Border(wxLEFT));
 
 	// Main window
 	auto MainSizer = new wxFlexGridSizer(3,2,5,10);
-	MainSizer->Add(new wxStaticText(base,-1,_("Input framerate: ")),0,wxEXPAND | wxALIGN_CENTER_VERTICAL,0);
-	MainSizer->Add(InputSizer,0,wxEXPAND,0);
-	MainSizer->Add(new wxStaticText(base,-1,_("Output: ")),0,wxALIGN_CENTER_VERTICAL,0);
-	MainSizer->Add(OutputSizer,0,wxEXPAND,0);
-	MainSizer->Add(Reverse,0,wxTOP|wxEXPAND,5);
+	MainSizer->Add(new wxStaticText(base,-1,_("Input framerate: ")), wxSizerFlags().Expand().CenterVertical());
+	MainSizer->Add(InputSizer, wxSizerFlags().Expand());
+	MainSizer->Add(new wxStaticText(base,-1,_("Output: ")), wxSizerFlags().CenterVertical());
+	MainSizer->Add(OutputSizer, wxSizerFlags().Expand());
+	MainSizer->Add(Reverse, wxSizerFlags().Expand().Border(wxTOP));
 
 	// Window
 	base->SetSizerAndFit(MainSizer);

--- a/src/export_framerate.cpp
+++ b/src/export_framerate.cpp
@@ -112,7 +112,8 @@ wxWindow *AssTransformFramerateFilter::GetConfigDialogWindow(wxWindow *parent, a
 	OutputSizer->Add(OutputSizerBottom, wxSizerFlags().Border(wxLEFT));
 
 	// Main window
-	auto MainSizer = new wxFlexGridSizer(3,2,5,10);
+	int gap = wxSizerFlags::GetDefaultBorder();
+	auto MainSizer = new wxFlexGridSizer(3, 2, gap, wxRound(2 * wxSizerFlags::GetDefaultBorderFractional()));
 	MainSizer->Add(new wxStaticText(base,-1,_("Input framerate: ")), wxSizerFlags().Expand().CenterVertical());
 	MainSizer->Add(InputSizer, wxSizerFlags().Expand());
 	MainSizer->Add(new wxStaticText(base,-1,_("Output: ")), wxSizerFlags().CenterVertical());

--- a/src/frame_main.cpp
+++ b/src/frame_main.cpp
@@ -201,15 +201,15 @@ void FrameMain::InitContents() {
 
 	StartupLog("Arrange main sizers");
 	ToolsSizer = new wxBoxSizer(wxVERTICAL);
-	ToolsSizer->Add(audioBox, 0, wxEXPAND);
-	ToolsSizer->Add(EditBox, 1, wxEXPAND);
+	ToolsSizer->Add(audioBox, wxSizerFlags().Expand());
+	ToolsSizer->Add(EditBox, wxSizerFlags(1).Expand());
 	TopSizer = new wxBoxSizer(wxHORIZONTAL);
-	TopSizer->Add(videoBox, 0, wxEXPAND, 0);
-	TopSizer->Add(ToolsSizer, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
+	TopSizer->Add(videoBox, wxSizerFlags().Expand());
+	TopSizer->Add(ToolsSizer, wxSizerFlags(1).Expand().Border(wxALL & ~wxTOP));
 	MainSizer = new wxBoxSizer(wxVERTICAL);
-	MainSizer->Add(new wxStaticLine(Panel),0,wxEXPAND,0);
-	MainSizer->Add(TopSizer,0,wxEXPAND,0);
-	MainSizer->Add(context->subsGrid,1,wxEXPAND,0);
+	MainSizer->Add(new wxStaticLine(Panel), wxSizerFlags().Expand());
+	MainSizer->Add(TopSizer, wxSizerFlags().Expand());
+	MainSizer->Add(context->subsGrid, wxSizerFlags(1).Expand());
 	Panel->SetSizer(MainSizer);
 
 	StartupLog("Perform layout");

--- a/src/grid_column.cpp
+++ b/src/grid_column.cpp
@@ -26,6 +26,7 @@
 #include <libaegisub/character_count.h>
 
 #include <wx/dc.h>
+#include <wx/window.h>
 
 void WidthHelper::Age() {
 	for (auto it = begin(widths), e = end(widths); it != e; ) {
@@ -83,7 +84,7 @@ void GridColumn::UpdateWidth(const agi::Context *c, WidthHelper &helper) {
 
 	width = Width(c, helper);
 	if (width) // 10 is an arbitrary amount of padding
-		width = 10 + std::max(width, helper(Header()));
+		width = c->parent->FromDIP(10) + std::max(width, helper(Header()));
 }
 
 void GridColumn::Paint(wxDC &dc, int x, int y, const AssDialogue *d, const agi::Context *c) const {

--- a/src/grid_column.cpp
+++ b/src/grid_column.cpp
@@ -90,8 +90,8 @@ void GridColumn::UpdateWidth(const agi::Context *c, WidthHelper &helper) {
 void GridColumn::Paint(wxDC &dc, int x, int y, const AssDialogue *d, const agi::Context *c) const {
 	wxString str = Value(d, c);
 	if (Centered())
-		x += (width - 6 - dc.GetTextExtent(str).GetWidth()) / 2;
-	dc.DrawText(str, x + 4, y + 2);
+		x += (width - dc.FromDIP(6) - dc.GetTextExtent(str).GetWidth()) / 2;
+	dc.DrawText(str, x + dc.FromDIP(4), y + dc.FromDIP(2));
 }
 
 namespace {
@@ -337,12 +337,12 @@ public:
 			double alpha = std::min((double)(cps - cps_min + 1) / (cps_max - cps_min + 1), 1.0);
 			dc.SetBrush(wxBrush(blend(to_wx(bg_color->GetColor()), dc.GetBrush().GetColour(), alpha)));
 			dc.SetPen(*wxTRANSPARENT_PEN);
-			dc.DrawRectangle(x, y + 1, width, ext.GetHeight() + 3);
+			dc.DrawRectangle(x, y + 1, width, ext.GetHeight() + dc.FromDIP(4) - 1);
 			dc.SetTextForeground(blend(*wxBLACK, tc, alpha));
 		}
 
-		x += (width + 2 - ext.GetWidth()) / 2;
-		dc.DrawText(str, x, y + 2);
+		x += (width + dc.FromDIP(2) - ext.GetWidth()) / 2;
+		dc.DrawText(str, x, y + dc.FromDIP(2));
 		dc.SetTextForeground(tc);
 	}
 };

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -129,7 +129,8 @@ void General_DefaultStyles(wxTreebook *book, Preferences *parent) {
 	staticbox->Add(instructions, wxSizerFlags().Border());
 	staticbox->AddSpacer(16);
 
-	auto general = new wxFlexGridSizer(2, 5, 5);
+	int gap = wxSizerFlags::GetDefaultBorder();
+	auto general = new wxFlexGridSizer(2, gap, gap);
 	general->AddGrowableCol(0, 1);
 	staticbox->Add(general, wxSizerFlags(1).Expand());
 
@@ -337,7 +338,8 @@ void Interface_Colours(wxTreebook *book, Preferences *parent) {
 	p->OptionAdd(syntax, _("Karaoke variables"), "Colour/Subtitle/Syntax/Karaoke Variable");
 
 	p->sizer = new wxBoxSizer(wxVERTICAL);
-	main_sizer->AddSpacer(5);
+	int gap = wxSizerFlags::GetDefaultBorder();
+	main_sizer->AddSpacer(gap);
 	main_sizer->Add(p->sizer, 1);
 
 	auto color_schemes = p->PageSizer(_("Audio Color Schemes"));

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -801,7 +801,7 @@ void Preferences::OnResetDefault(wxCommandEvent&) {
 	EndModal(-1);
 }
 
-Preferences::Preferences(wxWindow *parent): wxDialog(parent, -1, _("Preferences"), wxDefaultPosition, wxSize(-1, -1), wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER) {
+Preferences::Preferences(wxWindow *parent): wxDialog(parent, -1, _("Preferences"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER) {
 	SetIcons(GETICONS(options_button));
 
 	book = new wxTreebook(this, -1, wxDefaultPosition, wxDefaultSize);

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -125,7 +125,7 @@ void General_DefaultStyles(wxTreebook *book, Preferences *parent) {
 
 	auto instructions = new wxStaticText(staticbox->GetStaticBox(), wxID_ANY, _("The chosen style catalogs will be loaded when you start a new file or import files in the various formats.\n\nYou can set up style catalogs in the Style Manager."));
 	p->sizer->Fit(p);
-	instructions->Wrap(400);
+	instructions->Wrap(p->FromDIP(400));
 	staticbox->Add(instructions, wxSizerFlags().Border());
 	staticbox->AddSpacer(16);
 
@@ -429,7 +429,7 @@ void Advanced(wxTreebook *book, Preferences *parent) {
 	font.SetPointSize(12);
 	warning->SetFont(font);
 	p->sizer->Fit(p);
-	warning->Wrap(400);
+	warning->Wrap(p->FromDIP(400));
 	general.sizer->Add(warning, wxSizerFlags().Border());
 
 	p->SetSizerAndFit(p->sizer);
@@ -612,7 +612,7 @@ public:
 			size.x += GetView()->FromDIP(icon_width);
 			return size;
 		}
-		return wxSize(80,20);
+		return GetView()->FromDIP(wxSize(80, 20));
 	}
 
 	bool GetValueFromEditorCtrl(wxWindow* editor, wxVariant &var) override {
@@ -662,7 +662,7 @@ public:
 	}
 
 	bool GetValue(wxVariant &) const override { return false; }
-	wxSize GetSize() const override { return !value ? wxSize(80, 20) : GetTextExtent(value); }
+	wxSize GetSize() const override { return !value ? GetView()->FromDIP(wxSize(80, 20)) : GetTextExtent(value); }
 	bool HasEditorCtrl() const override { return true; }
 };
 
@@ -703,8 +703,8 @@ Interface_Hotkeys::Interface_Hotkeys(wxTreebook *book, Preferences *parent)
 	dvc = new wxDataViewCtrl(this, -1);
 	dvc->AssociateModel(model.get());
 #ifndef __APPLE__
-	dvc->AppendColumn(new wxDataViewColumn(_("Hotkey"), new HotkeyRenderer, 0, 125, wxALIGN_LEFT, wxCOL_SORTABLE | wxCOL_RESIZABLE));
-	dvc->AppendColumn(new wxDataViewColumn(_("Command"), new CommandRenderer, 1, 250, wxALIGN_LEFT, wxCOL_SORTABLE | wxCOL_RESIZABLE));
+	dvc->AppendColumn(new wxDataViewColumn(_("Hotkey"), new HotkeyRenderer, 0, FromDIP(125), wxALIGN_LEFT, wxCOL_SORTABLE | wxCOL_RESIZABLE));
+	dvc->AppendColumn(new wxDataViewColumn(_("Command"), new CommandRenderer, 1, FromDIP(250), wxALIGN_LEFT, wxCOL_SORTABLE | wxCOL_RESIZABLE));
 #else
 	auto col = new wxDataViewColumn(_("Hotkey"), new wxDataViewTextRenderer("string", wxDATAVIEW_CELL_EDITABLE), 0, 150, wxALIGN_LEFT, wxCOL_SORTABLE | wxCOL_RESIZABLE);
 	col->SetMinWidth(150);

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -120,18 +120,18 @@ void General_DefaultStyles(wxTreebook *book, Preferences *parent) {
 	auto p = new OptionPage(book, parent, _("Default styles"), OptionPage::PAGE_SUB);
 
 	auto staticbox = new wxStaticBoxSizer(wxVERTICAL, p, _("Default style catalogs"));
-	p->sizer->Add(staticbox, 0, wxEXPAND, 5);
+	p->sizer->Add(staticbox, wxSizerFlags().Expand());
 	p->sizer->AddSpacer(8);
 
 	auto instructions = new wxStaticText(staticbox->GetStaticBox(), wxID_ANY, _("The chosen style catalogs will be loaded when you start a new file or import files in the various formats.\n\nYou can set up style catalogs in the Style Manager."));
 	p->sizer->Fit(p);
 	instructions->Wrap(400);
-	staticbox->Add(instructions, 0, wxALL, 5);
+	staticbox->Add(instructions, wxSizerFlags().Border());
 	staticbox->AddSpacer(16);
 
 	auto general = new wxFlexGridSizer(2, 5, 5);
 	general->AddGrowableCol(0, 1);
-	staticbox->Add(general, 1, wxEXPAND, 5);
+	staticbox->Add(general, wxSizerFlags(1).Expand());
 
 	// Build a list of available style catalogs, and wished-available ones
 	auto const& avail_catalogs = AssStyleStorage::GetCatalogs();
@@ -428,7 +428,7 @@ void Advanced(wxTreebook *book, Preferences *parent) {
 	warning->SetFont(font);
 	p->sizer->Fit(p);
 	warning->Wrap(400);
-	general.sizer->Add(warning, 0, wxALL, 5);
+	general.sizer->Add(warning, wxSizerFlags().Border());
 
 	p->SetSizerAndFit(p->sizer);
 }
@@ -828,14 +828,14 @@ Preferences::Preferences(wxWindow *parent): wxDialog(parent, -1, _("Preferences"
 	applyButton = stdButtonSizer->GetApplyButton();
 	wxSizer *buttonSizer = new wxBoxSizer(wxHORIZONTAL);
 	auto defaultButton = new wxButton(this, -1, _("&Restore Defaults"));
-	buttonSizer->Add(defaultButton, wxSizerFlags(0).Expand());
+	buttonSizer->Add(defaultButton, wxSizerFlags().Expand());
 	buttonSizer->AddStretchSpacer(1);
-	buttonSizer->Add(stdButtonSizer, wxSizerFlags(0).Expand());
+	buttonSizer->Add(stdButtonSizer, wxSizerFlags().Expand());
 
 	// Main Sizer
 	wxSizer *mainSizer = new wxBoxSizer(wxVERTICAL);
 	mainSizer->Add(book, wxSizerFlags(1).Expand().Border());
-	mainSizer->Add(buttonSizer, wxSizerFlags(0).Expand().Border(wxALL & ~wxTOP));
+	mainSizer->Add(buttonSizer, wxSizerFlags().Expand().Border(wxALL & ~wxTOP));
 
 	SetSizerAndFit(mainSizer);
 	CenterOnParent();

--- a/src/preferences_base.cpp
+++ b/src/preferences_base.cpp
@@ -133,7 +133,7 @@ wxControl *OptionPage::OptionAdd(PageSection section, const wxString &name, cons
 	switch (opt->GetType()) {
 		case agi::OptionType::Bool: {
 			auto cb = new wxCheckBox(section.box, -1, name);
-			section.sizer->Add(cb, 1, wxEXPAND, 0);
+			section.sizer->Add(cb, wxSizerFlags(1).Expand());
 			cb->SetValue(opt->GetBool());
 			cb->Bind(wxEVT_CHECKBOX, BoolUpdater(opt_name, parent));
 			return cb;
@@ -212,10 +212,10 @@ void OptionPage::OptionChoice(PageSection section, const wxString &name, const w
 
 PageSection OptionPage::PageSizer(wxString name) {
 	auto tmp_sizer = new wxStaticBoxSizer(wxHORIZONTAL, this, name);
-	sizer->Add(tmp_sizer, 0,wxEXPAND, 5);
+	sizer->Add(tmp_sizer, wxSizerFlags().Expand());
 	auto flex = new wxFlexGridSizer(2,5,5);
 	flex->AddGrowableCol(0,1);
-	tmp_sizer->Add(flex, 1, wxEXPAND, 5);
+	tmp_sizer->Add(flex, wxSizerFlags(1).Expand());
 	sizer->AddSpacer(8);
 	return {flex, tmp_sizer->GetStaticBox()};
 }

--- a/src/preferences_base.cpp
+++ b/src/preferences_base.cpp
@@ -213,7 +213,8 @@ void OptionPage::OptionChoice(PageSection section, const wxString &name, const w
 PageSection OptionPage::PageSizer(wxString name) {
 	auto tmp_sizer = new wxStaticBoxSizer(wxHORIZONTAL, this, name);
 	sizer->Add(tmp_sizer, wxSizerFlags().Expand());
-	auto flex = new wxFlexGridSizer(2,5,5);
+	int gap = wxSizerFlags::GetDefaultBorder();
+	auto flex = new wxFlexGridSizer(2, gap, gap);
 	flex->AddGrowableCol(0,1);
 	tmp_sizer->Add(flex, wxSizerFlags(1).Expand());
 	sizer->AddSpacer(8);

--- a/src/preferences_base.cpp
+++ b/src/preferences_base.cpp
@@ -161,7 +161,7 @@ wxControl *OptionPage::OptionAdd(PageSection section, const wxString &name, cons
 		}
 
 		case agi::OptionType::Color: {
-			auto cb = new ColourButton(section.box, wxSize(40,10), kwargs.alpha, opt->GetColor());
+			auto cb = new ColourButton(section.box, FromDIP(wxSize(40,10)), kwargs.alpha, opt->GetColor());
 			cb->Bind(EVT_COLOR, ColourUpdater(opt_name, parent));
 			Add(section, name, cb);
 			return cb;
@@ -229,7 +229,7 @@ void OptionPage::OptionBrowse(PageSection section, const wxString &name, const c
 		throw agi::InternalError("Option must be agi::OptionType::String for BrowseButton.");
 
 	auto text = new wxTextCtrl(section.box, -1 , to_wx(opt->GetString()));
-	text->SetMinSize(wxSize(160, -1));
+	text->SetMinSize(FromDIP(wxSize(160, -1)));
 	text->Bind(wxEVT_TEXT, StringUpdater(opt_name, parent));
 
 	auto browse = new wxButton(section.box, -1, _("Browse..."));
@@ -261,7 +261,7 @@ void OptionPage::OptionFont(PageSection section, std::string opt_prefix) {
 	parent->AddChangeableOption(size_opt->GetName());
 
 	auto font_name = new wxTextCtrl(section.box, -1, to_wx(face_opt->GetString()));
-	font_name->SetMinSize(wxSize(160, -1));
+	font_name->SetMinSize(FromDIP(wxSize(160, -1)));
 	font_name->Bind(wxEVT_TEXT, StringUpdater(face_opt->GetName().c_str(), parent));
 	font_name->SetHint(wxNORMAL_FONT->GetFaceName());
 

--- a/src/subs_edit_box.cpp
+++ b/src/subs_edit_box.cpp
@@ -123,7 +123,7 @@ SubsEditBox::SubsEditBox(wxWindow *parent, agi::Context *context)
 	style_box = MakeComboBox("Default", wxCB_READONLY, &SubsEditBox::OnStyleChange, _("Style for this line"));
 
 	style_edit_button = new wxButton(this, -1, _("Edit"), wxDefaultPosition,
-		wxSize(GetTextExtent(_("Edit")).GetWidth() + 20, -1));
+		wxSize(GetTextExtent(_("Edit")).GetWidth() + FromDIP(20), -1));
 	style_edit_button->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
 		if (active_style) {
 			wxArrayString font_list = wxFontEnumerator::GetFacenames();
@@ -133,12 +133,12 @@ SubsEditBox::SubsEditBox(wxWindow *parent, agi::Context *context)
 	});
 	top_sizer->Add(style_edit_button, wxSizerFlags().Center().Border(wxRIGHT));
 
-	actor_box = new Placeholder<wxComboBox>(this, _("Actor"), wxSize(110, -1), wxCB_DROPDOWN | wxTE_PROCESS_ENTER, _("Actor name for this speech. This is only for reference, and is mainly useless."));
+	actor_box = new Placeholder<wxComboBox>(this, _("Actor"), FromDIP(wxSize(110, -1)), wxCB_DROPDOWN | wxTE_PROCESS_ENTER, _("Actor name for this speech. This is only for reference, and is mainly useless."));
 	Bind(wxEVT_TEXT, &SubsEditBox::OnActorChange, this, actor_box->GetId());
 	Bind(wxEVT_COMBOBOX, &SubsEditBox::OnActorChange, this, actor_box->GetId());
 	top_sizer->Add(actor_box, wxSizerFlags(2).Center().Border(wxRIGHT));
 
-	effect_box = new Placeholder<wxComboBox>(this, _("Effect"), wxSize(80,-1), wxCB_DROPDOWN | wxTE_PROCESS_ENTER, _("Effect for this line. This can be used to store extra information for karaoke scripts, or for the effects supported by the renderer."));
+	effect_box = new Placeholder<wxComboBox>(this, _("Effect"), FromDIP(wxSize(80,-1)), wxCB_DROPDOWN | wxTE_PROCESS_ENTER, _("Effect for this line. This can be used to store extra information for karaoke scripts, or for the effects supported by the renderer."));
 	Bind(wxEVT_TEXT, &SubsEditBox::OnEffectChange, this, effect_box->GetId());
 	Bind(wxEVT_COMBOBOX, &SubsEditBox::OnEffectChange, this, effect_box->GetId());
 	top_sizer->Add(effect_box, wxSizerFlags(3).Center());
@@ -300,7 +300,7 @@ wxButton *SubsEditBox::MakeBottomButton(const char *cmd_name) {
 
 wxComboBox *SubsEditBox::MakeComboBox(wxString const& initial_text, int style, void (SubsEditBox::*handler)(wxCommandEvent&), wxString const& tooltip) {
 	wxString styles[] = { "Default" };
-	wxComboBox *ctrl = new wxComboBox(this, -1, initial_text, wxDefaultPosition, wxSize(110,-1), 1, styles, style | wxTE_PROCESS_ENTER);
+	wxComboBox *ctrl = new wxComboBox(this, -1, initial_text, wxDefaultPosition, FromDIP(wxSize(110, -1)), 1, styles, style | wxTE_PROCESS_ENTER);
 	ctrl->SetToolTip(tooltip);
 	top_sizer->Add(ctrl, wxSizerFlags(2).Center().Border(wxRIGHT));
 	Bind(wxEVT_COMBOBOX, handler, this, ctrl->GetId());

--- a/src/subs_edit_box.cpp
+++ b/src/subs_edit_box.cpp
@@ -109,6 +109,7 @@ SubsEditBox::SubsEditBox(wxWindow *parent, agi::Context *context)
 	using std::bind;
 
 	// Top controls
+	int gap = wxSizerFlags::GetDefaultBorder();
 	top_sizer = new wxBoxSizer(wxHORIZONTAL);
 
 	comment_box = new wxCheckBox(this,-1,_("&Comment"));
@@ -153,18 +154,18 @@ SubsEditBox::SubsEditBox(wxWindow *parent, agi::Context *context)
 	layer = new wxSpinCtrl(this,-1,"",wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS | wxTE_PROCESS_ENTER,0,999,0);
 	layer->SetToolTip(_("Layer number"));
 	middle_left_sizer->Add(layer, wxSizerFlags().Center());
-	middle_left_sizer->AddSpacer(5);
+	middle_left_sizer->AddSpacer(gap);
 
 	start_time = MakeTimeCtrl(_("Start time"), TIME_START);
 	end_time   = MakeTimeCtrl(_("End time"), TIME_END);
-	middle_left_sizer->AddSpacer(5);
+	middle_left_sizer->AddSpacer(gap);
 	duration   = MakeTimeCtrl(_("Line duration"), TIME_DURATION);
-	middle_left_sizer->AddSpacer(5);
+	middle_left_sizer->AddSpacer(gap);
 
 	margin[0] = MakeMarginCtrl(_("Left Margin (0 = default from style)"), 0, _("left margin change"));
 	margin[1] = MakeMarginCtrl(_("Right Margin (0 = default from style)"), 1, _("right margin change"));
 	margin[2] = MakeMarginCtrl(_("Vertical Margin (0 = default from style)"), 2, _("vertical margin change"));
-	middle_left_sizer->AddSpacer(5);
+	middle_left_sizer->AddSpacer(gap);
 
 	// Middle-bottom controls
 	middle_right_sizer = new wxBoxSizer(wxHORIZONTAL);
@@ -173,14 +174,14 @@ SubsEditBox::SubsEditBox(wxWindow *parent, agi::Context *context)
 	MakeButton("edit/style/underline");
 	MakeButton("edit/style/strikeout");
 	MakeButton("edit/font");
-	middle_right_sizer->AddSpacer(5);
+	middle_right_sizer->AddSpacer(gap);
 	MakeButton("edit/color/primary");
 	MakeButton("edit/color/secondary");
 	MakeButton("edit/color/outline");
 	MakeButton("edit/color/shadow");
-	middle_right_sizer->AddSpacer(5);
+	middle_right_sizer->AddSpacer(gap);
 	MakeButton("grid/line/next/create");
-	middle_right_sizer->AddSpacer(10);
+	middle_right_sizer->AddSpacer(2 * gap);
 
 	by_time = MakeRadio(_("T&ime"), true, _("Time by h:mm:ss.cs"));
 	by_frame = MakeRadio(_("F&rame"), false, _("Time by frame number"));

--- a/src/subs_edit_box.cpp
+++ b/src/subs_edit_box.cpp
@@ -117,7 +117,7 @@ SubsEditBox::SubsEditBox(wxWindow *parent, agi::Context *context)
 	// Only supported in wxgtk
 	comment_box->SetCanFocus(false);
 #endif
-	top_sizer->Add(comment_box, 0, wxRIGHT | wxALIGN_CENTER, 5);
+	top_sizer->Add(comment_box, wxSizerFlags().Center().Border(wxRIGHT));
 
 	style_box = MakeComboBox("Default", wxCB_READONLY, &SubsEditBox::OnStyleChange, _("Style for this line"));
 
@@ -140,12 +140,12 @@ SubsEditBox::SubsEditBox(wxWindow *parent, agi::Context *context)
 	effect_box = new Placeholder<wxComboBox>(this, _("Effect"), wxSize(80,-1), wxCB_DROPDOWN | wxTE_PROCESS_ENTER, _("Effect for this line. This can be used to store extra information for karaoke scripts, or for the effects supported by the renderer."));
 	Bind(wxEVT_TEXT, &SubsEditBox::OnEffectChange, this, effect_box->GetId());
 	Bind(wxEVT_COMBOBOX, &SubsEditBox::OnEffectChange, this, effect_box->GetId());
-	top_sizer->Add(effect_box, 3, wxALIGN_CENTER, 0);
+	top_sizer->Add(effect_box, wxSizerFlags(3).Center());
 
 	char_count = new wxTextCtrl(this, -1, "0", wxDefaultPosition, wxDefaultSize, wxTE_READONLY | wxTE_CENTER);
 	char_count->SetInitialSize(char_count->GetSizeFromText(wxS("000")));
 	char_count->SetToolTip(_("Number of characters in the longest line of this subtitle."));
-	top_sizer->Add(char_count, 0, wxALIGN_CENTER, 0);
+	top_sizer->Add(char_count, wxSizerFlags().Center());
 
 	// Middle controls
 	middle_left_sizer = new wxBoxSizer(wxHORIZONTAL);
@@ -193,9 +193,9 @@ SubsEditBox::SubsEditBox(wxWindow *parent, agi::Context *context)
 
 	// Main sizer
 	wxSizer *main_sizer = new wxBoxSizer(wxVERTICAL);
-	main_sizer->Add(top_sizer,0,wxEXPAND | wxALL,3);
-	main_sizer->Add(middle_left_sizer,0,wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM,3);
-	main_sizer->Add(middle_right_sizer,0,wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM,3);
+	main_sizer->Add(top_sizer, wxSizerFlags().Expand().Border(wxALL, 3));
+	main_sizer->Add(middle_left_sizer, wxSizerFlags().Expand().Border(wxALL & ~wxTOP, 3));
+	main_sizer->Add(middle_right_sizer, wxSizerFlags().Expand().Border(wxALL & ~wxTOP, 3));
 
 	// Text editor
 	edit_ctrl = new SubsTextEditCtrl(this, FromDIP(wxSize(300,50)), wxBORDER_SUNKEN, c);
@@ -203,8 +203,8 @@ SubsEditBox::SubsEditBox(wxWindow *parent, agi::Context *context)
 
 	secondary_editor = new wxTextCtrl(this, -1, "", wxDefaultPosition, FromDIP(wxSize(300,50)), wxBORDER_SUNKEN | wxTE_MULTILINE | wxTE_READONLY);
 
-	main_sizer->Add(secondary_editor,1,wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM,3);
-	main_sizer->Add(edit_ctrl,1,wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM,3);
+	main_sizer->Add(secondary_editor, wxSizerFlags(1).Expand().Border(wxALL & ~wxTOP, 3));
+	main_sizer->Add(edit_ctrl, wxSizerFlags(1).Expand().Border(wxALL & ~wxTOP, 3));
 	main_sizer->Hide(secondary_editor);
 
 	bottom_sizer = new wxBoxSizer(wxHORIZONTAL);
@@ -543,14 +543,14 @@ void SubsEditBox::OnSize(wxSizeEvent &evt) {
 	if (button_bar_split) {
 		if (availableWidth > midMin + botMin) {
 			GetSizer()->Detach(middle_right_sizer);
-			middle_left_sizer->Add(middle_right_sizer,0,wxALIGN_CENTER_VERTICAL);
+			middle_left_sizer->Add(middle_right_sizer, wxSizerFlags().CenterVertical());
 			button_bar_split = false;
 		}
 	}
 	else {
 		if (availableWidth < midMin) {
 			middle_left_sizer->Detach(middle_right_sizer);
-			GetSizer()->Insert(2,middle_right_sizer,0,wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM,3);
+			GetSizer()->Insert(2, middle_right_sizer, wxSizerFlags().Expand().Border(wxALL & ~wxTOP, 3));
 			button_bar_split = true;
 		}
 	}

--- a/src/video_box.cpp
+++ b/src/video_box.cpp
@@ -76,24 +76,24 @@ VideoBox::VideoBox(wxWindow *parent, bool isDetached, agi::Context *context)
 	videoDisplay->MoveBeforeInTabOrder(videoSlider);
 
 	auto toolbarSizer = new wxBoxSizer(wxVERTICAL);
-	toolbarSizer->Add(visualToolBar, wxSizerFlags(1));
-	toolbarSizer->Add(visualSubToolBar, wxSizerFlags());
+	toolbarSizer->Add(visualToolBar, 1);
+	toolbarSizer->Add(visualSubToolBar);
 
 	auto topSizer = new wxBoxSizer(wxHORIZONTAL);
-	topSizer->Add(toolbarSizer, 0, wxEXPAND);
-	topSizer->Add(videoDisplay, isDetached, isDetached ? wxEXPAND : 0);
+	topSizer->Add(toolbarSizer, wxSizerFlags().Expand());
+	topSizer->Add(videoDisplay, isDetached ? wxSizerFlags(1).Expand() : wxSizerFlags());
 
 	auto videoBottomSizer = new wxBoxSizer(wxHORIZONTAL);
-	videoBottomSizer->Add(mainToolbar, wxSizerFlags(0).Center());
+	videoBottomSizer->Add(mainToolbar, wxSizerFlags().Center());
 	videoBottomSizer->Add(VideoPosition, wxSizerFlags(1).Center().Border(wxLEFT));
 	videoBottomSizer->Add(VideoSubsPos, wxSizerFlags(1).Center().Border(wxLEFT));
-	videoBottomSizer->Add(zoomBox, wxSizerFlags(0).Center().Border(wxLEFT | wxRIGHT));
+	videoBottomSizer->Add(zoomBox, wxSizerFlags().Center().HorzBorder());
 
 	auto VideoSizer = new wxBoxSizer(wxVERTICAL);
-	VideoSizer->Add(topSizer, 1, wxEXPAND, 0);
-	VideoSizer->Add(new wxStaticLine(this), 0, wxEXPAND, 0);
-	VideoSizer->Add(videoSlider, 0, wxEXPAND, 0);
-	VideoSizer->Add(videoBottomSizer, 0, wxEXPAND | wxBOTTOM, 5);
+	VideoSizer->Add(topSizer, wxSizerFlags(1).Expand());
+	VideoSizer->Add(new wxStaticLine(this), wxSizerFlags().Expand());
+	VideoSizer->Add(videoSlider, wxSizerFlags().Expand());
+	VideoSizer->Add(videoBottomSizer, wxSizerFlags().Expand().Border(wxBOTTOM));
 	SetSizer(VideoSizer);
 
 	UpdateTimeBoxes();

--- a/src/video_box.cpp
+++ b/src/video_box.cpp
@@ -58,10 +58,10 @@ VideoBox::VideoBox(wxWindow *parent, bool isDetached, agi::Context *context)
 
 	auto mainToolbar = toolbar::GetToolbar(this, "video", context, "Video", false);
 
-	VideoPosition = new wxTextCtrl(this, -1, "", wxDefaultPosition, wxSize(110, -1), wxTE_READONLY);
+	VideoPosition = new wxTextCtrl(this, -1, "", wxDefaultPosition, FromDIP(wxSize(110, -1)), wxTE_READONLY);
 	VideoPosition->SetToolTip(_("Current frame time and number"));
 
-	VideoSubsPos = new wxTextCtrl(this, -1, "", wxDefaultPosition, wxSize(110, -1), wxTE_READONLY);
+	VideoSubsPos = new wxTextCtrl(this, -1, "", wxDefaultPosition, FromDIP(wxSize(110, -1)), wxTE_READONLY);
 	VideoSubsPos->SetToolTip(_("Time of this frame relative to start and end of current subs"));
 
 	wxArrayString choices;


### PR DESCRIPTION
I expect this PR will eventually be composed with these commits:

- [x] Corrections
  - [x] Corrections to some of `sizer->Add(...)` where a positive border width was specified, but the border direction was not specified;
  - [x] Corrections to some of `sizer->Add(...)` where the border direction was specified, but the border width is set to 0;
  - [x] Corrections to a `sizer->Add(...)` where both Center and Expand were used;
  - [x] Corrections to a misuse of `sizer->Add(...)`;
- [ ] `wxSizerFlags().Border()` for implicit Hi-DPI management
  - [x] Rewrite all usages of 5px/10px/15px borders in `sizer->Add()` with `wxSizerFlags().Border()` family
  - [x] Rewrite all usages of 6px/12px borders
  - [ ] (Undecided) Rewrite all usages of 3px borders
- [ ] (Cosmetic, optional) Rewrite all cases where the border width is 0 with `wxSizerFlags()`
- [ ] `FromDIP` for Hi-DPI support
  - [x] Replace all `wxSize(-1, -1)` with wxDefaultSize
  - [x] Wrap all constant `wxSize(a, b)` and `SetSize(a, b)` with `FromDIP`
  - [x] Wrap all the column width with `FromDIP`, in all `Create`/`Append`/`Insert` columns
  - [x] Simple custom-drawn controls (not involving triangles), such as the subtitle grid
  - [ ] Hard custom-drawn controls such as the video slider and audio display
  - [ ] A overhaul to the color picker. The current code relies on a one-to-one correspondence between 256 pixels and color values