### PR TITLE
feat: Add theme (and general config.json) import functionality

### DIFF
--- a/src/colour_button.h
+++ b/src/colour_button.h
@@ -43,6 +43,12 @@ public:
 
 	/// Get the currently selected color
 	agi::Color GetColor() { return colour; }
+
+	/// Set the currently selected color
+	void SetColor(agi::Color color) { 
+        colour = color;
+        UpdateBitmap();
+    };
 };
 
 struct ColorValidator final : public wxValidator {

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -25,6 +25,7 @@
 #include <wx/dialog.h>
 
 class wxButton;
+class wxControl;
 class wxTreebook;
 namespace agi { class OptionValue; }
 
@@ -36,6 +37,7 @@ private:
 	wxButton *applyButton;
 
 	std::map<std::string, std::unique_ptr<agi::OptionValue>> pending_changes;
+	std::map<std::string, wxControl*> option_controls;
 	std::vector<Thunk> pending_callbacks;
 	std::vector<std::string> option_names;
 
@@ -62,4 +64,16 @@ public:
 	/// simply revert to the default config file as a bunch of things other than
 	/// user options are stored in it. Perhaps that should change in the future.
 	void AddChangeableOption(std::string const& name);
+
+	/// Refresh the UI control for an option
+	/// @param name Name of the option to refresh
+	void RefreshControl(std::string const& name);
+
+	/// Add a control to the list of controls for an option
+	/// @param name Name of the option
+	/// @param control Control to add
+	void RegisterControl(std::string const& name, wxControl *control);
+
+    /// Reset all color options to their default values
+    void ResetColors();
 };

--- a/src/preferences_base.cpp
+++ b/src/preferences_base.cpp
@@ -163,6 +163,7 @@ wxControl *OptionPage::OptionAdd(PageSection section, const wxString &name, cons
 			auto cb = new ColourButton(section.box, wxSize(40,10), false, opt->GetColor());
 			cb->Bind(EVT_COLOR, ColourUpdater(opt_name, parent));
 			Add(section, name, cb);
+            parent->RegisterControl(opt_name, cb);
 			return cb;
 		}
 


### PR DESCRIPTION
! Generated with significant LLM assistance !

Adds the ability to import color themes from JSON files within the preferences dialog.

This commit introduces:
- A `SetColor` method to `ColourButton` to allow programmatic color updates.
- A `ThemeImportVisitor` to recursively parse JSON objects and update corresponding color options.
- An "Import Theme..." button in the Interface Colors preference page that opens a file dialog to select a JSON theme file.
- Integration of the theme import logic to update color preferences and refresh the UI.

<img width="626" height="703" alt="image" src="https://github.com/user-attachments/assets/eced8b63-7728-458c-ba94-0347c36c18e1" />

Currently it works with the themes from this collection https://sgt0.github.io/aegisub-themes . However, you need to manually create a valid JSON file with a structure mirroring the value of the "Colors" key in the config.json.

Note that this is a commit to gauge whether this might be an interesting feature. To polish it more, I suggest creating a general themes folder where people could drop their theme and select it from a dropdown menu in the interface. 