### PR TITLE
Add commands `audio/go_to/start`, `audio/go_to/end`

### DIFF
--- a/src/audio_box.cpp
+++ b/src/audio_box.cpp
@@ -230,7 +230,18 @@ void AudioBox::ScrollAudioBy(int pixel_amount) {
 	audioDisplay->ScrollBy(pixel_amount);
 }
 
-void AudioBox::ScrollToActiveLine() {
-	if (controller->GetTimingController())
-		audioDisplay->ScrollTimeRangeInView(controller->GetTimingController()->GetIdealVisibleTimeRange());
+void AudioBox::ScrollToActiveLine(ScrollMode mode) {
+	if (controller->GetTimingController()) {
+		switch (mode) {
+			case ScrollMode::Range:
+				audioDisplay->ScrollTimeRangeInView(controller->GetTimingController()->GetIdealVisibleTimeRange());
+				break;
+			case ScrollMode::Start:
+				audioDisplay->ScrollTimeToCenter(controller->GetTimingController()->GetActiveLineRange().begin());
+				break;
+			case ScrollMode::End:
+				audioDisplay->ScrollTimeToCenter(controller->GetTimingController()->GetActiveLineRange().end());
+				break;
+		}
+	}
 }

--- a/src/audio_box.h
+++ b/src/audio_box.h
@@ -92,8 +92,18 @@ public:
 	/// A positive amount moves the display to the right, making later parts of the audio visible.
 	void ScrollAudioBy(int pixel_amount);
 
-	/// Make the currently active line visible in the audio display
-	void ScrollToActiveLine();
+	enum class ScrollMode {
+		/// Try to make the whole line visible
+		Range,
+		/// Center the start point in the audio display
+		Start,
+		/// Center the end point in the audio display
+		End,
+	 };
+
+	/// @brief Make the currently active line visible in the audio display
+	/// @param mode What part of the line shoud be made visible
+	void ScrollToActiveLine(ScrollMode mode = ScrollMode::Range);
 
 	DECLARE_EVENT_TABLE()
 };

--- a/src/audio_display.cpp
+++ b/src/audio_display.cpp
@@ -632,6 +632,14 @@ void AudioDisplay::ScrollPixelToLeft(int pixel_position)
 	Refresh();
 }
 
+void AudioDisplay::ScrollTimeToCenter(int time)
+{
+	const int client_width = GetClientRect().GetWidth();
+	const int pixel_position = AbsoluteXFromTime(time);
+
+	ScrollPixelToLeft(pixel_position - client_width / 2);
+}
+
 void AudioDisplay::ScrollTimeRangeInView(const TimeRange &range)
 {
 	int client_width = GetClientRect().GetWidth();

--- a/src/audio_display.h
+++ b/src/audio_display.h
@@ -219,6 +219,10 @@ public:
 	void ScrollPixelToLeft(int pixel_position);
 
 	/// @brief Scroll the audio display
+	/// @param time Time in milliseconds to put at the center of the audio display
+	void ScrollTimeToCenter(int time);
+
+	/// @brief Scroll the audio display
 	/// @param range Time range to ensure is in view
 	///
 	/// If the entire range is already visible inside the display, nothing is

--- a/src/command/audio.cpp
+++ b/src/command/audio.cpp
@@ -403,6 +403,28 @@ struct audio_go_to final : public validate_audio_open {
 	}
 };
 
+struct audio_go_to_start final : public validate_audio_open {
+	CMD_NAME("audio/go_to/start")
+	STR_MENU("Go to selection start")
+	STR_DISP("Go to selection start")
+	STR_HELP("Scroll the audio display to center on the start of current audio selection")
+
+	void operator()(agi::Context *c) override {
+		c->audioBox->ScrollToActiveLine(AudioBox::ScrollMode::Start);
+	}
+};
+
+struct audio_go_to_end final : public validate_audio_open {
+	CMD_NAME("audio/go_to/end")
+	STR_MENU("Go to selection end")
+	STR_DISP("Go to selection end")
+	STR_HELP("Scroll the audio display to center on the end of current audio selection")
+
+	void operator()(agi::Context *c) override {
+		c->audioBox->ScrollToActiveLine(AudioBox::ScrollMode::End);
+	}
+};
+
 struct audio_scroll_left final : public validate_audio_open {
 	CMD_NAME("audio/scroll/left")
 		STR_MENU("Scroll left")
@@ -543,6 +565,8 @@ namespace cmd {
 		reg(std::make_unique<audio_commit_next>());
 		reg(std::make_unique<audio_commit_stay>());
 		reg(std::make_unique<audio_go_to>());
+		reg(std::make_unique<audio_go_to_start>());
+		reg(std::make_unique<audio_go_to_end>());
 		reg(std::make_unique<audio_karaoke>());
 		reg(std::make_unique<audio_open>());
 		reg(std::make_unique<audio_open_blank>());


### PR DESCRIPTION
These are similar to the existing `audio/go_to` command, but always exactly center the audio display on the start or end of the active line. This is useful for doing fine timing adjustments, especially when zoomed-in so that only a small part of the current line is visible.

Without these, I have to press <kbd>A</kbd>/<kbd>F</kbd> repeatedly to scroll the audio display, but that is slow and annoying.

No default keybinds are added by this PR (but I personally bound them to <kbd>Shift</kbd>+<kbd>A</kbd> and <kbd>Shift</kbd>+<kbd>F</kbd>).