### PR TITLE
Fix Undefined Behavior in GridColumnLineNumber

### DIFF
--- a/src/grid_column.cpp
+++ b/src/grid_column.cpp
@@ -111,6 +111,8 @@ struct GridColumnLineNumber final : GridColumn {
 	}
 
 	int Width(const agi::Context *c, WidthHelper &helper) const override {
+		if (c->ass->Events.empty())
+			return helper("1");
 		return helper(Value(&c->ass->Events.back()));
 	}
 };


### PR DESCRIPTION
At one point during initialization, `GridColumnLineNumber::Width()` gets called when the event list is empty, and the function calls `back()` on the list, which is UB. The bug was found with UBSan:
```
/usr/include/boost/intrusive/pointer_traits.hpp:306:14: runtime error: downcast of address 0x7d4fddb58490 which does not point to an object of type 'AssDialogue'
0x7d4fddb58490: note: object has a possibly invalid vptr: abs(offset to top) too big
 6f 7c 00 00  b0 fa c8 dd 6f 7c 00 00  b0 fa c8 dd 6f 7c 00 00  d8 e4 71 60 55 55 00 00  10 51 d5 dd
              ^~~~~~~~~~~~~~~~~~~~~~~
              possibly invalid vptr
```

Fix this by instead returning the width of the string "1" when the list is empty.