### PR TITLE
Implement Wayland-compatible eyedropper using XDG Desktop Portals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
         if: startsWith(matrix.config.os, 'ubuntu-')
         run: |
           sudo apt-get update
-          sudo apt-get install ninja-build build-essential libx11-dev libfreetype6-dev pkg-config libfontconfig1-dev libass-dev libasound2-dev libffms2-dev intltool libboost-all-dev libhunspell-dev libcurl4-openssl-dev libuchardet-dev libgtest-dev libgmock-dev libwxgtk3.2-dev
+          sudo apt-get install ninja-build build-essential libx11-dev libfreetype6-dev pkg-config libfontconfig1-dev libass-dev libasound2-dev libffms2-dev intltool libboost-all-dev libhunspell-dev libcurl4-openssl-dev libuchardet-dev libgtest-dev libgmock-dev libwxgtk3.2-dev libportal-gtk3-dev
 
       - name: Configure
         run: meson setup build ${{ matrix.config.args }} -Dbuildtype=${{ matrix.config.buildtype }} ${{ github.ref_type == 'tag' && '-Dofficial_release=true' || '' }}

--- a/README.md
+++ b/README.md
@@ -93,11 +93,12 @@ libcurl:     libcurl4-openssl-dev  or  libcurl4-gnutls-dev
 opengl:      libgl1-mesa-dev
 gtest:       libgtest-dev
 gmock:       libgmock-dev
+libportal:   libportal-gtk3-dev
 ```
 
 I.e. to install on Ubuntu 24.04 run this command:
 ``` bash
-sudo apt install build-essential pkg-config meson ninja-build gettext intltool libfontconfig1-dev libass-dev libboost-chrono-dev libboost-locale-dev libboost-regex-dev libboost-system-dev libboost-thread-dev zlib1g-dev wx3.2-headers libwxgtk3.2-dev icu-devtools libicu-dev libpulse-dev libasound2-dev libopenal-dev libffms2-dev libfftw3-dev libhunspell-dev libuchardet-dev libcurl4-gnutls-dev libgl1-mesa-dev libgtest-dev libgmock-dev
+sudo apt install build-essential pkg-config meson ninja-build gettext intltool libfontconfig1-dev libass-dev libboost-chrono-dev libboost-locale-dev libboost-regex-dev libboost-system-dev libboost-thread-dev zlib1g-dev wx3.2-headers libwxgtk3.2-dev icu-devtools libicu-dev libpulse-dev libasound2-dev libopenal-dev libffms2-dev libfftw3-dev libhunspell-dev libuchardet-dev libcurl4-gnutls-dev libgl1-mesa-dev libgtest-dev libgmock-dev libportal-gtk3-dev
 ```
 
 #### Build Aegisub

--- a/meson.build
+++ b/meson.build
@@ -218,8 +218,7 @@ endif
 deps += dependency('icu-uc', version: '>=4.8.1.1')
 deps += dependency('icu-i18n', version: '>=4.8.1.1')
 
-dep_avail = []
-foreach dep: [
+check_deps = [
     # audio, in order of precedence
     ['libpulse', [], 'PulseAudio', [], []],
     ['alsa', [], 'ALSA', [], []],
@@ -232,6 +231,17 @@ foreach dep: [
     ['hunspell', [], 'Hunspell', ['hunspell', 'hunspell_dep'], []],
     ['uchardet', [], 'uchardet', ['uchardet', 'uchardet_dep'], []],
 ]
+
+if host_machine.system() == 'linux'
+    if cc.get_define('__WXGTK3__', dependencies: wx_dep, prefix: '#include <wx/defs.h>') != ''
+        check_deps += [['libportal-gtk3', [], 'libportal', [], []]]
+    else
+        check_deps += [['libportal', [], 'libportal', [], []]]
+    endif
+endif
+
+dep_avail = []
+foreach dep: check_deps
     optname = dep[0].split('-')[0]
     if not get_option(optname).disabled()
         # [provide] section is ignored if required is false;

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -11,6 +11,7 @@ option('avisynth', type: 'feature', description: 'AviSynth video source')
 option('fftw3', type: 'feature', description: 'FFTW3 support')
 option('hunspell', type: 'feature', description: 'Hunspell spell checker')
 option('uchardet', type: 'feature', description: 'uchardet character encoding detection')
+option('libportal', type: 'feature', description: 'XDG Desktop Portal support through libportal')
 option('csri', type: 'feature', description: 'CSRI support')
 
 option('system_luajit', type: 'boolean', value: false, description: 'Force using system luajit')

--- a/src/dialog_about.cpp
+++ b/src/dialog_about.cpp
@@ -125,6 +125,9 @@ void ShowAboutDialog(wxWindow *parent) {
 #ifdef WITH_UPDATE_CHECKER
 		"    libcurl - Copyright (c) Daniel Stenberg et al;\n"
 #endif
+#ifdef WITH_LIBPORTAL
+		"    libportal - Copyright (c) libportal authors;\n"
+#endif
 		+ _("\nSee the help file for full credits.\n")
 #ifdef BUILD_CREDIT
 		+ fmt_tl("Built by %s on %s.", GetAegisubBuildCredit(), GetAegisubBuildTime())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,6 +55,7 @@
 #include "utils.h"
 #include "value_event.h"
 #include "version.h"
+#include "xdg_desktop_portal_utils.h"
 
 #include <libaegisub/dispatch.h>
 #include <libaegisub/format_path.h>
@@ -257,6 +258,8 @@ bool AegisubApp::OnInit() {
 
 		exception_message = _("Oops, Aegisub has crashed!\n\nAn attempt has been made to save a copy of your file to:\n\n%s\n\nAegisub will now close.");
 
+		agi::xdp_utils::Initialize();
+
 		// Load plugins
 		Automation4::ScriptFactory::Register(std::make_unique<Automation4::LuaScriptFactory>());
 		libass::CacheFonts();
@@ -343,6 +346,8 @@ int AegisubApp::OnExit() {
 	delete config::global_scripts;
 
 	AssExportFilterChain::Clear();
+
+	agi::xdp_utils::Cleanup();
 
 	// Keep this last!
 	delete agi::log::log;

--- a/src/meson.build
+++ b/src/meson.build
@@ -242,6 +242,8 @@ opt_src = [
                'ffmpegsource_common.cpp']],
 
     ['Hunspell', 'spellchecker_hunspell.cpp'],
+
+    ['libportal', 'xdg_desktop_portal_utils.cpp'],
 ]
 
 foreach opt: opt_src

--- a/src/xdg_desktop_portal_utils.cpp
+++ b/src/xdg_desktop_portal_utils.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2026, Aegisub contributors
+//
+// Permission to use, copy, modify, and distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+//
+// Aegisub Project https://aegisub.org/
+
+/// @file xdg_desktop_portal_utils.cpp
+/// @brief Utilities related to XDG Desktop Portals
+/// @ingroup utility linux
+///
+
+
+#ifdef WITH_LIBPORTAL
+#include "xdg_desktop_portal_utils.h"
+
+#ifdef __WXGTK3__
+#include <libportal-gtk3/portal-gtk3.h>
+#endif
+
+namespace agi::xdp_utils {
+	XdpPortal *portal = nullptr;
+
+	std::unique_ptr<XdpParent, decltype(&xdp_parent_free)> GetXdpParent(wxWindow *window) {
+#ifdef __WXGTK3__
+		GtkWidget *gtk_widget = GTK_WIDGET(window->GetHandle());
+		GtkWindow *gtk_window = GTK_WINDOW(gtk_widget_get_toplevel(gtk_widget));
+		return {xdp_parent_new_gtk(gtk_window), xdp_parent_free};
+#else
+		return {nullptr, xdp_parent_free};
+#endif
+	}
+
+	void Initialize() {
+		portal = xdp_portal_new();
+	}
+
+	void Cleanup() {
+		g_object_unref(portal);
+		portal = nullptr;
+	}
+}
+
+#endif // WITH_LIBPORTAL

--- a/src/xdg_desktop_portal_utils.h
+++ b/src/xdg_desktop_portal_utils.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2026, Aegisub contributors
+//
+// Permission to use, copy, modify, and distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+//
+// Aegisub Project https://aegisub.org/
+
+/// @file xdg_desktop_portal_utils.h
+/// @see xdg_desktop_portal_utils.cpp
+/// @ingroup utility linux
+///
+
+#pragma once
+
+#ifdef WITH_LIBPORTAL
+
+#include <libportal/portal.h>
+
+#include <wx/window.h>
+
+#include <memory>
+
+namespace agi::xdp_utils {
+	extern XdpPortal *portal;
+	std::unique_ptr<XdpParent, decltype(&xdp_parent_free)> GetXdpParent(wxWindow *window);
+	void Initialize();
+	void Cleanup();
+}
+
+#else // WITH_LIBPORTAL
+
+namespace agi::xdp_utils {
+	inline void Initialize() {}
+	inline void Cleanup() {}
+}
+
+#endif // WITH_LIBPORTAL


### PR DESCRIPTION
This PR adds a new XDG Desktop Portal-based eyedropper implementation for Linux.

The Portal-based dropper has the following limitations:
 - It doesn't work if Desktop Portals are not properly installed or configured on the system (this may affect users on old or less maintained distros, those using more obscure desktop environments, or users with custom setups).
 - The functionality is not equivalent to the current dropper: The current dropper captures a 7x7 area around cursor, but the Portal API only gives us the color directly under cursor.

For the vast majority of users on Linux, this is an improvement over the current dropper, which:
 - is broken on wxGTK3 with X11 (the color picker works exactly once, i.e. if you pick the color a second time, the screenshot it takes is just the same as the first one until you restart Aegisub).
 - doesn't work on Wayland at all, not even XWayland (this is unfixable because of Wayland security model).

Implementation notes:
 - I added some new files so I had to put some copyright notice there. I copied the notice from other files, but changed the copyright statement to `Copyright (c) 2026, Aegisub contributors` and updated the project URL to `https://aegisub.org/`. I noticed the copyright notices in most files are incorrect (they were not updated when the file was modified).
 - I put some things I added into a new `agi::xdp_utils` namespace. Not sure if this matches current conventions, although existing use of namespaces seemed inconsistent to me anyway.
 - I added an `#ifdef` around `xdg_desktop_portal_utils.cpp`, even though it's unnecessary because the file is compiled conditionally. This matches how it's done in the `audio_player_*` files.
 - I remember encountering off-by-one errors (where using the eyedropper on the current color preview would give a slightly different color), but I was unable to reproduce it.
 - If invoking the color picker fails, no feedback is provided (nothing happens when the button is clicked). Displaying an error message would be better.
 - There is a (very unlikely) possibility that the dialog could be closed before the OS returns the color from the Portal API. This case is not handled correctly in the code, it just sends an event to a dangling pointer.