### PR TITLE
Ignore gesture events when zoom gesture isn't active

### DIFF
--- a/src/video_display.h
+++ b/src/video_display.h
@@ -101,6 +101,7 @@ class VideoDisplay final : public wxGLCanvas {
 	/// The zoom level of the video inside the viewport.
 	double contentZoomValue = 1;
 
+	bool isZoomGestureActive = false;
 	double contentZoomAtGestureStart = 1;
 	Vector2D zoomGestureAnchorPoint = {0, 0};
 


### PR DESCRIPTION
On wxGTK+Wayland, right-clicking sends the last GestureEnd event again, which was not caught by the existing workaround.

Instead of trying to pattern-match the false events, let's ignore all events unless we received a GestureStart event first.

(This has a merge conflict with #542. If you merge #542 first, you can use 5548e107f09b9ff57c5cfe11ab979ad235bcd5ef. If you merge this first, I will rebase #542.)