### PR TITLE
Bugfixes regarding adding controls in the sizer

### DIFF
--- a/src/audio_box.cpp
+++ b/src/audio_box.cpp
@@ -89,7 +89,7 @@ AudioBox::AudioBox(wxWindow *parent, agi::Context *context)
 
 	auto link_btn = new ToggleBitmap(panel, context, "audio/opt/vertical_link", 16, "Audio", FromDIP(wxSize(20, -1)));
 	link_btn->SetMaxSize(wxDefaultSize);
-	VertVolArea->Add(link_btn, 0, wxRIGHT | wxEXPAND, 0);
+	VertVolArea->Add(link_btn, 0, wxEXPAND, 0);
 	BindConnection(OPT_SUB("Audio/Link", &AudioBox::OnVerticalLink, this));
 
 	// Top sizer

--- a/src/dialog_about.cpp
+++ b/src/dialog_about.cpp
@@ -142,9 +142,9 @@ void ShowAboutDialog(wxWindow *parent) {
 
 	wxSizer *MainSizer = new wxBoxSizer(wxVERTICAL);
 	MainSizer->Add(new wxStaticBitmap(&d, -1, GETIMAGE(splash)), 0, wxCENTER, 0);
-	MainSizer->Add(new wxStaticLine(&d, wxID_ANY), 0, wxEXPAND | wxALL, 0);
-	MainSizer->Add(textctrl, 0, wxEXPAND | wxALL, 0);
-	MainSizer->Add(new wxStaticLine(&d, wxID_ANY), 0, wxEXPAND | wxALL, 0);
+	MainSizer->Add(new wxStaticLine(&d, wxID_ANY), 0, wxEXPAND, 0);
+	MainSizer->Add(textctrl, 0, wxEXPAND, 0);
+	MainSizer->Add(new wxStaticLine(&d, wxID_ANY), 0, wxEXPAND, 0);
 	MainSizer->Add(d.CreateButtonSizer(wxOK), 0, wxEXPAND | wxALL, 6);
 
 	d.SetSizerAndFit(MainSizer);

--- a/src/dialog_colorpicker.cpp
+++ b/src/dialog_colorpicker.cpp
@@ -611,7 +611,7 @@ DialogColorPicker::DialogColorPicker(wxWindow *parent, agi::Color initial_color,
 	auto ass_colors_sizer = MakeColorInputSizer(rgb_box, ass_labels, ass_ctrls);
 	if (!alpha)
 		ass_colors_sizer->Hide(alpha_input);
-	rgb_box_sizer->Add(ass_colors_sizer, 0, wxALL|wxCENTER|wxEXPAND, 3);
+	rgb_box_sizer->Add(ass_colors_sizer, 0, wxALL|wxEXPAND, 3);
 
 	wxString hsl_labels[] = { _("Hue:"), _("Sat.:"), _("Lum.:") };
 	hsl_box_sizer->Add(MakeColorInputSizer(hsl_box, hsl_labels, hsl_input), 0, wxALL|wxEXPAND, 3);

--- a/src/dialog_jumpto.cpp
+++ b/src/dialog_jumpto.cpp
@@ -77,13 +77,13 @@ DialogJumpTo::DialogJumpTo(agi::Context *c)
 	JumpFrame->SetMaxLength(std::to_string(c->project->VideoProvider()->GetFrameCount() - 1).size());
 	JumpTime = new TimeEdit(&d, -1, c, agi::Time(c->videoController->TimeAtFrame(jumpframe)).GetAssFormatted(), wxSize(-1,-1));
 
-	auto TimesSizer = new wxGridSizer(2, 5, 5);
+	auto TimesSizer = new wxFlexGridSizer(2, 5, 5);
 
-	TimesSizer->Add(LabelFrame, 1, wxALIGN_CENTER_VERTICAL);
-	TimesSizer->Add(JumpFrame, wxEXPAND);
+	TimesSizer->Add(LabelFrame, wxSizerFlags().CenterVertical());
+	TimesSizer->Add(JumpFrame);
 
-	TimesSizer->Add(LabelTime, 1, wxALIGN_CENTER_VERTICAL);
-	TimesSizer->Add(JumpTime, wxEXPAND);
+	TimesSizer->Add(LabelTime, wxSizerFlags().CenterVertical());
+	TimesSizer->Add(JumpTime);
 
 	auto ButtonSizer = d.CreateStdDialogButtonSizer(wxOK | wxCANCEL);
 

--- a/src/dialog_jumpto.cpp
+++ b/src/dialog_jumpto.cpp
@@ -73,8 +73,10 @@ DialogJumpTo::DialogJumpTo(agi::Context *c)
 	auto LabelFrame = new wxStaticText(&d, -1, _("Frame: "));
 	auto LabelTime = new wxStaticText(&d, -1, _("Time: "));
 
+	int JumpFrameSize = std::to_string(c->project->VideoProvider()->GetFrameCount() - 1).size();
 	JumpFrame = new wxTextCtrl(&d,-1,"",wxDefaultPosition,wxSize(-1,-1),wxTE_PROCESS_ENTER, IntValidator((int)jumpframe));
-	JumpFrame->SetMaxLength(std::to_string(c->project->VideoProvider()->GetFrameCount() - 1).size());
+	JumpFrame->SetInitialSize(JumpFrame->GetSizeFromText(wxString(JumpFrameSize, '0')));
+	JumpFrame->SetMaxLength(JumpFrameSize);
 	JumpTime = new TimeEdit(&d, -1, c, agi::Time(c->videoController->TimeAtFrame(jumpframe)).GetAssFormatted(), wxSize(-1,-1));
 
 	auto TimesSizer = new wxFlexGridSizer(2, 5, 5);

--- a/src/dialog_kara_timing_copy.cpp
+++ b/src/dialog_kara_timing_copy.cpp
@@ -454,9 +454,9 @@ DialogKanjiTimer::DialogKanjiTimer(agi::Context *c)
 
 	// Layout it all
 	BottomLeftStackSizer->Add(StylesBoxSizer, 0, wxEXPAND|wxBOTTOM, 6);
-	BottomLeftStackSizer->Add(HelpBoxSizer, 1, wxEXPAND, 6);
+	BottomLeftStackSizer->Add(HelpBoxSizer, 1, wxEXPAND, 0);
 	BottomShelfSizer->Add(BottomLeftStackSizer, 1, wxEXPAND|wxRIGHT, 6);
-	BottomShelfSizer->Add(ButtonsBoxSizer, 0, wxEXPAND, 6);
+	BottomShelfSizer->Add(ButtonsBoxSizer, 0, wxEXPAND, 0);
 	MainStackSizer->Add(DisplayBoxSizer, 0, wxEXPAND|wxALL, 6);
 	MainStackSizer->Add(BottomShelfSizer, 1, wxEXPAND|wxLEFT|wxRIGHT, 6);
 	MainStackSizer->Add(buttonSizer, 0, wxEXPAND|wxALL, 6);

--- a/src/dialog_properties.cpp
+++ b/src/dialog_properties.cpp
@@ -116,7 +116,7 @@ DialogProperties::DialogProperties(agi::Context *c)
 	AddProperty(TopSizerBox, TopSizerGrid, _("Update details:"), "Update Details");
 
 	TopSizerGrid->AddGrowableCol(1,1);
-	TopSizer->Add(TopSizerGrid,1,wxALL | wxEXPAND,0);
+	TopSizer->Add(TopSizerGrid,1,wxEXPAND,0);
 
 	// Resolution box
 	wxStaticBoxSizer *res_box_sizer = new wxStaticBoxSizer(wxVERTICAL, &d, _("Resolution"));

--- a/src/dialog_style_editor.cpp
+++ b/src/dialog_style_editor.cpp
@@ -275,12 +275,12 @@ DialogStyleEditor::DialogStyleEditor(wxWindow *parent, AssStyle *style, agi::Con
 	}
 
 	// Style name sizer
-	NameSizer->Add(StyleName, 1, wxALL, 0);
+	NameSizer->Add(StyleName, 1, 0, 0);
 
 	// Font sizer
 	wxSizer *FontSizerTop = new wxBoxSizer(wxHORIZONTAL);
 	wxSizer *FontSizerBottom = new wxBoxSizer(wxHORIZONTAL);
-	FontSizerTop->Add(FontName, 1, wxALL, 0);
+	FontSizerTop->Add(FontName, 1, 0, 0);
 	FontSizerTop->Add(FontSize, 0, wxLEFT, 5);
 	FontSizerBottom->AddStretchSpacer(1);
 	FontSizerBottom->Add(BoxBold, 0, 0, 0);
@@ -288,7 +288,7 @@ DialogStyleEditor::DialogStyleEditor(wxWindow *parent, AssStyle *style, agi::Con
 	FontSizerBottom->Add(BoxUnderline, 0, wxLEFT, 5);
 	FontSizerBottom->Add(BoxStrikeout, 0, wxLEFT, 5);
 	FontSizerBottom->AddStretchSpacer(1);
-	FontSizer->Add(FontSizerTop, 1, wxALL | wxEXPAND, 0);
+	FontSizer->Add(FontSizerTop, 1, wxEXPAND, 0);
 	FontSizer->Add(FontSizerBottom, 1, wxTOP | wxEXPAND, 5);
 
 	// Colors sizer
@@ -317,7 +317,7 @@ DialogStyleEditor::DialogStyleEditor(wxWindow *parent, AssStyle *style, agi::Con
 
 	// Margins+Alignment
 	wxSizer *MarginAlign = new wxBoxSizer(wxHORIZONTAL);
-	MarginAlign->Add(MarginSizer, 1, wxLEFT | wxEXPAND, 0);
+	MarginAlign->Add(MarginSizer, 1, wxEXPAND, 0);
 	MarginAlign->Add(Alignment, 0, wxLEFT | wxEXPAND, 5);
 
 	// Outline
@@ -353,7 +353,7 @@ DialogStyleEditor::DialogStyleEditor(wxWindow *parent, AssStyle *style, agi::Con
 	PreviewBottomSizer->Add(PreviewText, 1, wxEXPAND | wxRIGHT, 5);
 	PreviewBottomSizer->Add(previewButton, 0, wxEXPAND, 0);
 	PreviewSizer->Add(SubsPreview, 1, wxEXPAND | wxBOTTOM, 5);
-	PreviewSizer->Add(PreviewBottomSizer, 0, wxEXPAND | wxBOTTOM, 0);
+	PreviewSizer->Add(PreviewBottomSizer, 0, wxEXPAND, 0);
 
 	// Buttons
 	auto ButtonSizer = CreateStdDialogButtonSizer(wxOK | wxCANCEL | wxAPPLY | wxHELP);
@@ -363,7 +363,7 @@ DialogStyleEditor::DialogStyleEditor(wxWindow *parent, AssStyle *style, agi::Con
 	LeftSizer->Add(NameSizer, 0, wxBOTTOM | wxEXPAND, 5);
 	LeftSizer->Add(FontSizer, 0, wxBOTTOM | wxEXPAND, 5);
 	LeftSizer->Add(ColorsSizer, 0, wxBOTTOM | wxEXPAND, 5);
-	LeftSizer->Add(MarginAlign, 0, wxBOTTOM | wxEXPAND, 0);
+	LeftSizer->Add(MarginAlign, 0, wxEXPAND, 0);
 
 	// Right side sizer
 	wxSizer *RightSizer = new wxBoxSizer(wxVERTICAL);

--- a/src/dialog_style_manager.cpp
+++ b/src/dialog_style_manager.cpp
@@ -291,12 +291,12 @@ DialogStyleManager::DialogStyleManager(agi::Context *context)
 
 	wxSizer *StorageListSizer = new wxBoxSizer(wxHORIZONTAL);
 	StorageList = new wxListBox(StorageSizerBox, -1, wxDefaultPosition, wxSize(240,250), 0, nullptr, wxLB_EXTENDED);
-	StorageListSizer->Add(StorageList,1,wxEXPAND | wxRIGHT,0);
+	StorageListSizer->Add(StorageList,1,wxEXPAND,0);
 	StorageListSizer->Add(make_move_buttons(StorageSizerBox, &StorageMoveUp, &StorageMoveDown, &StorageMoveTop, &StorageMoveBottom, &StorageSort), wxSizerFlags().Expand());
 
 	StorageSizer->Add(StorageListSizer,1,wxEXPAND | wxBOTTOM,5);
 	StorageSizer->Add(MoveToLocal,0,wxEXPAND | wxBOTTOM,5);
-	StorageSizer->Add(StorageButtons,0,wxEXPAND | wxBOTTOM,0);
+	StorageSizer->Add(StorageButtons,0,wxEXPAND,0);
 
 	// Local styles list
 	wxButton *CurrentImport = new wxButton(CurrentSizerBox, -1, _("&Import from script..."));
@@ -308,12 +308,12 @@ DialogStyleManager::DialogStyleManager(agi::Context *context)
 
 	wxSizer *CurrentListSizer = new wxBoxSizer(wxHORIZONTAL);
 	CurrentList = new wxListBox(CurrentSizerBox, -1, wxDefaultPosition, wxSize(240,250), 0, nullptr, wxLB_EXTENDED);
-	CurrentListSizer->Add(CurrentList,1,wxEXPAND | wxRIGHT,0);
+	CurrentListSizer->Add(CurrentList,1,wxEXPAND,0);
 	CurrentListSizer->Add(make_move_buttons(CurrentSizerBox, &CurrentMoveUp, &CurrentMoveDown, &CurrentMoveTop, &CurrentMoveBottom, &CurrentSort), wxSizerFlags().Expand());
 
 	CurrentSizer->Add(CurrentListSizer,1,wxEXPAND | wxBOTTOM,5);
 	CurrentSizer->Add(MoveImportSizer,0,wxEXPAND | wxBOTTOM,5);
-	CurrentSizer->Add(CurrentButtons,0,wxEXPAND | wxBOTTOM,0);
+	CurrentSizer->Add(CurrentButtons,0,wxEXPAND,0);
 
 	// Buttons
 	wxStdDialogButtonSizer *buttonSizer = CreateStdDialogButtonSizer(wxCANCEL | wxHELP);
@@ -323,7 +323,7 @@ DialogStyleManager::DialogStyleManager(agi::Context *context)
 	// General layout
 	wxSizer *StylesSizer = new wxBoxSizer(wxHORIZONTAL);
 	StylesSizer->Add(StorageSizer,0,wxRIGHT | wxEXPAND,5);
-	StylesSizer->Add(CurrentSizer,0,wxLEFT | wxEXPAND,0);
+	StylesSizer->Add(CurrentSizer,0,wxEXPAND,0);
 	wxSizer *MainSizer = new wxBoxSizer(wxVERTICAL);
 	MainSizer->Add(CatalogSizer,0,wxEXPAND | wxLEFT | wxRIGHT | wxTOP,5);
 	MainSizer->Add(StylesSizer,1,wxEXPAND | wxALL,5);

--- a/src/dialog_styling_assistant.cpp
+++ b/src/dialog_styling_assistant.cpp
@@ -119,7 +119,7 @@ DialogStyling::DialogStyling(agi::Context *context)
 		actions_box->Add(play_video, 0, wxBOTTOM | wxRIGHT, 5);
 
 		actions_box->AddStretchSpacer(1);
-		right_sizer->Add(actions_box, 0, wxEXPAND, 5);
+		right_sizer->Add(actions_box, 0, wxEXPAND, 0);
 	}
 	bottom_sizer->Add(right_sizer);
 	main_sizer->Add(bottom_sizer, 1, wxEXPAND | wxLEFT | wxBOTTOM | wxRIGHT, 5);

--- a/src/dialog_timing_processor.cpp
+++ b/src/dialog_timing_processor.cpp
@@ -169,7 +169,7 @@ DialogTimingProcessor::DialogTimingProcessor(agi::Context *c)
 	auto optionsSizer = new wxStaticBoxSizer(wxHORIZONTAL,&d,_("Options"));
 	onlySelection = new wxCheckBox(optionsSizer->GetStaticBox(),-1,_("Affect &selection only"));
 	onlySelection->SetValue(OPT_GET("Tool/Timing Post Processor/Only Selection")->GetBool());
-	optionsSizer->Add(onlySelection,1,wxALL,0);
+	optionsSizer->Add(onlySelection,1,0,0);
 
 	// Lead-in/out box
 	auto LeadSizer = new wxStaticBoxSizer(wxHORIZONTAL, &d, _("Lead-in/Lead-out"));
@@ -258,7 +258,7 @@ DialogTimingProcessor::DialogTimingProcessor(agi::Context *c)
 	RightSizer->Add(AdjacentSizer,0,wxBOTTOM|wxEXPAND,5);
 	RightSizer->Add(KeyframesSizer,0,wxBOTTOM|wxEXPAND,5);
 	RightSizer->AddStretchSpacer(1);
-	RightSizer->Add(ButtonSizer,0,wxLEFT|wxRIGHT|wxBOTTOM|wxEXPAND,0);
+	RightSizer->Add(ButtonSizer,0,wxEXPAND,0);
 
 	// Style buttons sizer
 	auto StyleButtonsSizer = new wxBoxSizer(wxHORIZONTAL);
@@ -272,7 +272,7 @@ DialogTimingProcessor::DialogTimingProcessor(agi::Context *c)
 	// Top Sizer
 	auto TopSizer = new wxBoxSizer(wxHORIZONTAL);
 	TopSizer->Add(LeftSizer,0,wxRIGHT|wxEXPAND,5);
-	TopSizer->Add(RightSizer,1,wxALL|wxEXPAND,0);
+	TopSizer->Add(RightSizer,1,wxEXPAND,0);
 
 	// Main Sizer
 	auto MainSizer = new wxBoxSizer(wxVERTICAL);

--- a/src/frame_main.cpp
+++ b/src/frame_main.cpp
@@ -207,9 +207,9 @@ void FrameMain::InitContents() {
 	TopSizer->Add(videoBox, 0, wxEXPAND, 0);
 	TopSizer->Add(ToolsSizer, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
 	MainSizer = new wxBoxSizer(wxVERTICAL);
-	MainSizer->Add(new wxStaticLine(Panel),0,wxEXPAND | wxALL,0);
-	MainSizer->Add(TopSizer,0,wxEXPAND | wxALL,0);
-	MainSizer->Add(context->subsGrid,1,wxEXPAND | wxALL,0);
+	MainSizer->Add(new wxStaticLine(Panel),0,wxEXPAND,0);
+	MainSizer->Add(TopSizer,0,wxEXPAND,0);
+	MainSizer->Add(context->subsGrid,1,wxEXPAND,0);
 	Panel->SetSizer(MainSizer);
 
 	StartupLog("Perform layout");

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -249,7 +249,7 @@ void Interface_Colours(wxTreebook *book, Preferences *parent) {
 	wxSizer *main_sizer = new wxBoxSizer(wxHORIZONTAL);
 
 	p->sizer = new wxBoxSizer(wxVERTICAL);
-	main_sizer->Add(p->sizer, wxEXPAND);
+	main_sizer->Add(p->sizer, 1);
 
 	auto audio = p->PageSizer(_("Audio Display"));
 	p->OptionAdd(audio, _("Play cursor"), "Colour/Audio Display/Play Cursor");
@@ -280,7 +280,7 @@ void Interface_Colours(wxTreebook *book, Preferences *parent) {
 
 	p->sizer = new wxBoxSizer(wxVERTICAL);
 	main_sizer->AddSpacer(5);
-	main_sizer->Add(p->sizer, wxEXPAND);
+	main_sizer->Add(p->sizer, 1);
 
 	auto color_schemes = p->PageSizer(_("Audio Color Schemes"));
 	wxArrayString schemes = to_wx(OPT_GET("Audio/Colour Schemes")->GetListString());
@@ -635,7 +635,7 @@ Interface_Hotkeys::Interface_Hotkeys(wxTreebook *book, Preferences *parent)
 	dvc->AppendTextColumn(_("Description"), 2, wxDATAVIEW_CELL_INERT, 300, wxALIGN_LEFT, wxCOL_SORTABLE | wxCOL_RESIZABLE);
 
 	wxSizer *buttons = new wxBoxSizer(wxHORIZONTAL);
-	buttons->Add(quick_search, wxSizerFlags(1).Expand().Border());
+	buttons->Add(quick_search, wxSizerFlags(1).CenterVertical().Border());
 	buttons->Add(new_button, wxSizerFlags().Border());
 	buttons->Add(edit_button, wxSizerFlags().Border());
 	buttons->Add(delete_button, wxSizerFlags().Border());

--- a/src/preferences_base.cpp
+++ b/src/preferences_base.cpp
@@ -235,8 +235,8 @@ void OptionPage::OptionBrowse(PageSection section, const wxString &name, const c
 	browse->Bind(wxEVT_BUTTON, std::bind(browse_button, text));
 
 	auto button_sizer = new wxBoxSizer(wxHORIZONTAL);
-	button_sizer->Add(text, wxSizerFlags(1).Expand());
-	button_sizer->Add(browse, wxSizerFlags().Expand());
+	button_sizer->Add(text, wxSizerFlags(1).CenterVertical());
+	button_sizer->Add(browse, wxSizerFlags().CenterVertical());
 
 	Add(section, name, button_sizer);
 
@@ -271,8 +271,8 @@ void OptionPage::OptionFont(PageSection section, std::string opt_prefix) {
 	pick_btn->Bind(wxEVT_BUTTON, std::bind(font_button, parent, font_name, font_size));
 
 	auto button_sizer = new wxBoxSizer(wxHORIZONTAL);
-	button_sizer->Add(font_name, wxSizerFlags(1).Expand());
-	button_sizer->Add(pick_btn, wxSizerFlags().Expand());
+	button_sizer->Add(font_name, wxSizerFlags(1).CenterVertical());
+	button_sizer->Add(pick_btn, wxSizerFlags().CenterVertical());
 
 	Add(section, _("Font Face"), button_sizer);
 	Add(section, _("Font Size"), font_size);

--- a/src/subs_edit_box.cpp
+++ b/src/subs_edit_box.cpp
@@ -140,12 +140,12 @@ SubsEditBox::SubsEditBox(wxWindow *parent, agi::Context *context)
 	effect_box = new Placeholder<wxComboBox>(this, _("Effect"), wxSize(80,-1), wxCB_DROPDOWN | wxTE_PROCESS_ENTER, _("Effect for this line. This can be used to store extra information for karaoke scripts, or for the effects supported by the renderer."));
 	Bind(wxEVT_TEXT, &SubsEditBox::OnEffectChange, this, effect_box->GetId());
 	Bind(wxEVT_COMBOBOX, &SubsEditBox::OnEffectChange, this, effect_box->GetId());
-	top_sizer->Add(effect_box, 3, wxALIGN_CENTER, 5);
+	top_sizer->Add(effect_box, 3, wxALIGN_CENTER, 0);
 
 	char_count = new wxTextCtrl(this, -1, "0", wxDefaultPosition, wxDefaultSize, wxTE_READONLY | wxTE_CENTER);
 	char_count->SetInitialSize(char_count->GetSizeFromText(wxS("000")));
 	char_count->SetToolTip(_("Number of characters in the longest line of this subtitle."));
-	top_sizer->Add(char_count, 0, wxALIGN_CENTER, 5);
+	top_sizer->Add(char_count, 0, wxALIGN_CENTER, 0);
 
 	// Middle controls
 	middle_left_sizer = new wxBoxSizer(wxHORIZONTAL);


### PR DESCRIPTION
My local repo is currently too messy, so I've decided to split that massive PR #512 and first incorporate some bugfixes into the upstream.

Of these commits, https://github.com/TypesettingTools/Aegisub/commit/1e747f6398716e1799cae40e477fa680180f2549 aims to fix the following problem:

<img width="456" height="202" alt="image" src="https://github.com/user-attachments/assets/c5af2759-d662-44be-9828-12e1025324b6" />
