### PR TITLE
Panning/zooming improvements and fixes, round 2

### DIFF
--- a/src/video_display.cpp
+++ b/src/video_display.cpp
@@ -315,8 +315,8 @@ void VideoDisplay::PositionVideo() {
 	content_width = viewportSize.GetWidth();
 	content_height = viewportSize.GetHeight();
 
-	// Adjust aspect ratio if necessary
 	if (freeSize) {
+		// Adjust aspect ratio if necessary
 		int vidW = provider->GetWidth();
 		int vidH = provider->GetHeight();
 
@@ -332,6 +332,12 @@ void VideoDisplay::PositionVideo() {
 		else if (videoAr - displayAr > 0.01) {
 			content_height = content_width / videoAr;
 		}
+
+		// Update windowZoomValue
+		// We must use content_height before content zoom has been applied to it
+		windowZoomValue = double(content_height) / vidH;
+		zoomBox->ChangeValue(fmt_wx("%g%%", windowZoomValue * 100.));
+		con->ass->Properties.video_zoom = windowZoomValue;
 	}
 
 	// Apply content zoom
@@ -398,16 +404,8 @@ void VideoDisplay::FitClientSizeToVideo() {
 }
 
 void VideoDisplay::OnSizeEvent(wxSizeEvent &) {
-	if (freeSize) {
-		UpdateViewportSize();
-		PositionVideo();
-		windowZoomValue = double(content_height) / con->project->VideoProvider()->GetHeight();
-		zoomBox->ChangeValue(fmt_wx("%g%%", windowZoomValue * 100.));
-		con->ass->Properties.video_zoom = windowZoomValue;
-	}
-	else {
-		PositionVideo();
-	}
+	if (freeSize) UpdateViewportSize();
+	PositionVideo();
 }
 
 void VideoDisplay::OnMouseEvent(wxMouseEvent& event) {

--- a/src/video_display.cpp
+++ b/src/video_display.cpp
@@ -152,6 +152,8 @@ VideoDisplay::VideoDisplay(wxToolBar *toolbar, bool freeSize, wxComboBox *zoomBo
 	con->videoController->JumpToFrame(con->videoController->GetFrameN());
 
 	SetLayoutDirection(wxLayout_LeftToRight);
+
+	UpdateViewportSize(wxSize(1, 1));
 }
 
 VideoDisplay::~VideoDisplay () {
@@ -209,9 +211,6 @@ void VideoDisplay::Render() try {
 			err.GetMessage()));
 		return;
 	}
-
-	if (viewportSize.GetWidth() == 0) viewportSize.SetWidth(1);
-	if (viewportSize.GetHeight() == 0) viewportSize.SetHeight(1);
 
 	if (!content_height || !content_width)
 		PositionVideo();
@@ -293,6 +292,17 @@ void VideoDisplay::DrawOverscanMask(float horizontal_percent, float vertical_per
 	gl.DrawMultiPolygon(points, vstart, vcount, pos, v, true);
 }
 
+void VideoDisplay::UpdateViewportSize(wxSize newSize) {
+	// In free size mode, we ignore the argument and use the client size
+	// to avoid the viewport and client sizes getting out of sync
+	if (freeSize)
+		newSize = GetClientSize() * scale_factor;
+	assert(newSize != wxDefaultSize);
+	if (newSize.GetWidth() < 1) newSize.SetWidth(1);
+	if (newSize.GetHeight() < 1) newSize.SetHeight(1);
+	viewportSize = newSize;
+}
+
 void VideoDisplay::PositionVideo() {
 	auto provider = con->project->VideoProvider();
 	if (!provider || !IsShownOnScreen()) return;
@@ -356,10 +366,10 @@ void VideoDisplay::FitClientSizeToVideo() {
 
 	if (!provider || !IsShownOnScreen()) return;
 
-	viewportSize.Set(provider->GetWidth(), provider->GetHeight());
-	viewportSize *= windowZoomValue;
+	wxSize newViewportSize(provider->GetWidth(), provider->GetHeight());
+	newViewportSize *= windowZoomValue;
 	if (con->videoController->GetAspectRatioType() != AspectRatio::Default)
-		viewportSize.SetWidth(viewportSize.GetHeight() * con->videoController->GetAspectRatioValue());
+		newViewportSize.SetWidth(newViewportSize.GetHeight() * con->videoController->GetAspectRatioValue());
 
 	wxEventBlocker blocker(this);
 	if (freeSize) {
@@ -368,22 +378,23 @@ void VideoDisplay::FitClientSizeToVideo() {
 
 		wxSize cs = GetClientSize();
 		wxSize oldSize = top->GetSize();
-		top->SetSize(top->GetSize() + viewportSize / scale_factor - cs);
+		top->SetSize(top->GetSize() + newViewportSize / scale_factor - cs);
 		SetClientSize(cs + top->GetSize() - oldSize);
 	}
 	else {
-		SetMinClientSize(viewportSize / scale_factor);
-		SetMaxClientSize(viewportSize / scale_factor);
+		SetMinClientSize(newViewportSize / scale_factor);
+		SetMaxClientSize(newViewportSize / scale_factor);
 
 		GetGrandParent()->Layout();
 	}
 
+	UpdateViewportSize(newViewportSize); // must be called after setting the client size
 	PositionVideo();
 }
 
 void VideoDisplay::OnSizeEvent(wxSizeEvent &) {
 	if (freeSize) {
-		viewportSize = GetClientSize() * scale_factor;
+		UpdateViewportSize();
 		PositionVideo();
 		windowZoomValue = double(content_height) / con->project->VideoProvider()->GetHeight();
 		zoomBox->ChangeValue(fmt_wx("%g%%", windowZoomValue * 100.));

--- a/src/video_display.cpp
+++ b/src/video_display.cpp
@@ -153,7 +153,7 @@ VideoDisplay::VideoDisplay(wxToolBar *toolbar, bool freeSize, wxComboBox *zoomBo
 
 	SetLayoutDirection(wxLayout_LeftToRight);
 
-	UpdateViewportSize(wxSize(1, 1));
+	UpdateViewportSize(false, wxSize(1, 1));
 }
 
 VideoDisplay::~VideoDisplay () {
@@ -292,7 +292,7 @@ void VideoDisplay::DrawOverscanMask(float horizontal_percent, float vertical_per
 	gl.DrawMultiPolygon(points, vstart, vcount, pos, v, true);
 }
 
-void VideoDisplay::UpdateViewportSize(wxSize newSize) {
+void VideoDisplay::UpdateViewportSize(bool rescalePan, wxSize newSize) {
 	// In free size mode, we ignore the argument and use the client size
 	// to avoid the viewport and client sizes getting out of sync
 	if (freeSize)
@@ -300,7 +300,7 @@ void VideoDisplay::UpdateViewportSize(wxSize newSize) {
 	assert(newSize != wxDefaultSize);
 	if (newSize.GetWidth() < 1) newSize.SetWidth(1);
 	if (newSize.GetHeight() < 1) newSize.SetHeight(1);
-	if (viewportSize.GetHeight() >= 1) {
+	if (rescalePan && viewportSize.GetHeight() >= 1) {
 		double ratio = double(newSize.GetHeight()) / viewportSize.GetHeight();
 		pan_x *= ratio;
 		pan_y *= ratio;
@@ -308,9 +308,11 @@ void VideoDisplay::UpdateViewportSize(wxSize newSize) {
 	viewportSize = newSize;
 }
 
-void VideoDisplay::PositionVideo() {
+void VideoDisplay::PositionVideo(bool preserveContentSize) {
 	auto provider = con->project->VideoProvider();
 	if (!provider || !IsShownOnScreen()) return;
+
+	int old_content_height = content_height;
 
 	content_width = viewportSize.GetWidth();
 	content_height = viewportSize.GetHeight();
@@ -339,6 +341,9 @@ void VideoDisplay::PositionVideo() {
 		zoomBox->ChangeValue(fmt_wx("%g%%", windowZoomValue * 100.));
 		con->ass->Properties.video_zoom = windowZoomValue;
 	}
+
+	if (preserveContentSize)
+		contentZoomValue = double(old_content_height) / content_height;
 
 	// Apply content zoom
 	content_width *= contentZoomValue;
@@ -399,13 +404,14 @@ void VideoDisplay::FitClientSizeToVideo() {
 		GetGrandParent()->Layout();
 	}
 
-	UpdateViewportSize(newViewportSize); // must be called after setting the client size
+	UpdateViewportSize(true, newViewportSize); // must be called after setting the client size
 	PositionVideo();
 }
 
 void VideoDisplay::OnSizeEvent(wxSizeEvent &) {
-	if (freeSize) UpdateViewportSize();
-	PositionVideo();
+	bool preserveContentSize = freeSize && IsContentZoomActive();
+	if (freeSize) UpdateViewportSize(false);
+	PositionVideo(preserveContentSize);
 }
 
 void VideoDisplay::OnMouseEvent(wxMouseEvent& event) {

--- a/src/video_display.h
+++ b/src/video_display.h
@@ -147,6 +147,14 @@ class VideoDisplay final : public wxGLCanvas {
 	/// @brief Recompute the size of the viewport based on the current window zoom and video resolution,
 	///        then resize the client area to match the viewport
 	void FitClientSizeToVideo();
+	/// @brief Set the viewport size to @p newSize
+	///
+	/// You should call @ref PositionVideo() after this.
+	///
+	/// In free size mode, the @p newSize argument is ignored and client size is used instead.
+	///
+	/// @param newSize The new size, ignored in free size mode
+	void UpdateViewportSize(wxSize newSize = wxDefaultSize);
 	/// @brief Update content size and position based on the current viewport size, content zoom and pan
 	///
 	/// Updates @ref content_left, @ref content_width, @ref content_bottom, @ref content_top and @ref content_height

--- a/src/video_display.h
+++ b/src/video_display.h
@@ -153,12 +153,15 @@ class VideoDisplay final : public wxGLCanvas {
 	///
 	/// In free size mode, the @p newSize argument is ignored and client size is used instead.
 	///
+	/// @param rescalePan Should the current pan be rescaled for the new viewport?
 	/// @param newSize The new size, ignored in free size mode
-	void UpdateViewportSize(wxSize newSize = wxDefaultSize);
+	void UpdateViewportSize(bool rescalePan, wxSize newSize = wxDefaultSize);
 	/// @brief Update content size and position based on the current viewport size, content zoom and pan
 	///
 	/// Updates @ref content_left, @ref content_width, @ref content_bottom, @ref content_top and @ref content_height
-	void PositionVideo();
+	///
+	/// @param preserveContentSize Should content zoom be adjusted to maintain current content size?
+	void PositionVideo(bool preserveContentSize = false);
 	/// Set the window zoom level to that indicated by the dropdown
 	void SetWindowZoomFromBox(wxCommandEvent&);
 	/// Set the window zoom level to that indicated by the text
@@ -225,6 +228,7 @@ public:
 
 	/// @brief Reset content zoom and pan
 	void ResetContentZoom();
+	bool IsContentZoomActive() { return contentZoomValue != 1 || pan_x != 0 || pan_y != 0; }
 
 	/// Get the last seen position of the mouse in script coordinates
 	Vector2D GetMousePosition() const;

--- a/src/video_display.h
+++ b/src/video_display.h
@@ -105,7 +105,7 @@ class VideoDisplay final : public wxGLCanvas {
 	double contentZoomAtGestureStart = 1;
 	Vector2D zoomGestureAnchorPoint = {0, 0};
 
-	/// The video pan, in units relative to the viewport height.
+	/// The video pan, in physical pixels
 	/// @see viewportSize
 	double pan_x = 0;
 	double pan_y = 0;
@@ -147,7 +147,7 @@ class VideoDisplay final : public wxGLCanvas {
 	/// @brief Recompute the size of the viewport based on the current window zoom and video resolution,
 	///        then resize the client area to match the viewport
 	void FitClientSizeToVideo();
-	/// @brief Set the viewport size to @p newSize
+	/// @brief Set the viewport size to @p newSize and rescale the pan values
 	///
 	/// You should call @ref PositionVideo() after this.
 	///


### PR DESCRIPTION
A few additional fixes that didn't make it into the first round:
- Fix the value in the zoom box being incorrect when using content zoom in detached mode
- Don't resize/move the video when resizing the window in detached mode and panning/zooming is active

<details><summary>Video comparison</summary>

[before.webm](https://github.com/user-attachments/assets/805bbffe-17a0-4be7-91e5-45def4f38d51)

[after.webm](https://github.com/user-attachments/assets/b71fdf53-6fd8-461d-ade6-5836a8329b88)

</details>