### PR TITLE
Remove stray `#undef`

### DIFF
--- a/libaegisub/include/libaegisub/type_name.h
+++ b/libaegisub/include/libaegisub/type_name.h
@@ -36,8 +36,6 @@ AGI_DEFINE_TYPE_NAME(unsigned long);
 AGI_DEFINE_TYPE_NAME(unsigned long long);
 AGI_DEFINE_TYPE_NAME(void);
 
-#undef AGI_TYPE_NAME_PRIMITIVE
-
 #define AGI_TYPE_NAME_MODIFIER(pre, type) \
 	template<typename T> \
 	struct type_name<T type> { \


### PR DESCRIPTION
Originally, `AGI_DEFINE_TYPE_NAME` was named `AGI_TYPE_NAME_PRIMITIVE`, was only used internally in `type_name.h` and was `#undef`ed after use. Commit 0cf35894e11c7ceadd74da2c9bef8b36994de69f renamed it and made it a part of the header's API, but forgot to remove the `#undef` (which now has no effect).