### PR TITLE
Make the menubar entries for hide, hide others and show all work on mac os

### DIFF
--- a/src/command/app.cpp
+++ b/src/command/app.cpp
@@ -297,6 +297,39 @@ struct app_bring_to_front final : public Command {
 		osx::bring_to_front();
 	}
 };
+
+struct app_hide final : public Command {
+	CMD_NAME("app/hide")
+	STR_MENU("Hide")
+	STR_DISP("Hide")
+	STR_HELP("Hide the application")
+
+	void operator()(agi::Context *) override {
+		osx::hide_aegisub();
+	}
+};
+
+struct app_hide_others final : public Command {
+	CMD_NAME("app/hide_others")
+	STR_MENU("Hide others")
+	STR_DISP("Hide others")
+	STR_HELP("Hide all other applications")
+
+	void operator()(agi::Context *) override {
+		osx::hide_others();
+	}
+};
+
+struct app_show_all final : public Command {
+	CMD_NAME("app/show_all")
+	STR_MENU("Show all")
+	STR_DISP("Show all")
+	STR_HELP("Show all applications")
+
+	void operator()(agi::Context *) override {
+		osx::show_all();
+	}
+};
 #endif
 
 }
@@ -319,6 +352,9 @@ namespace cmd {
 		reg(std::make_unique<app_minimize>());
 		reg(std::make_unique<app_maximize>());
 		reg(std::make_unique<app_bring_to_front>());
+		reg(std::make_unique<app_hide>());
+		reg(std::make_unique<app_hide_others>());
+		reg(std::make_unique<app_show_all>());
 #endif
 #ifdef WITH_UPDATE_CHECKER
 		reg(std::make_unique<app_updates>());

--- a/src/command/app.cpp
+++ b/src/command/app.cpp
@@ -305,7 +305,7 @@ struct app_hide final : public Command {
 	STR_HELP("Hide the application")
 
 	void operator()(agi::Context *) override {
-		osx::hide_aegisub();
+		osx::hide_application();
 	}
 };
 
@@ -316,7 +316,7 @@ struct app_hide_others final : public Command {
 	STR_HELP("Hide all other applications")
 
 	void operator()(agi::Context *) override {
-		osx::hide_others();
+		osx::hide_other_applications();
 	}
 };
 
@@ -327,7 +327,7 @@ struct app_show_all final : public Command {
 	STR_HELP("Show all applications")
 
 	void operator()(agi::Context *) override {
-		osx::show_all();
+		osx::show_all_applications();
 	}
 };
 #endif

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -258,6 +258,15 @@ public:
 				case wxID_PREFERENCES:
 					cmd::call("app/options", context);
 					break;
+				case wxID_OSX_HIDE:
+					cmd::call("app/hide", context);
+					break;
+				case wxID_OSX_HIDEOTHERS:
+					cmd::call("app/hide_others", context);
+					break;
+				case wxID_OSX_SHOWALL:
+					cmd::call("app/show_all", context);
+					break;
 				case wxID_EXIT:
 					cmd::call("app/exit", context);
 					break;

--- a/src/osx/osx_utils.mm
+++ b/src/osx/osx_utils.mm
@@ -83,4 +83,16 @@ bool activate_top_window_other_than(wxFrame *wx) {
 void bring_to_front() {
 	[NSApp arrangeInFront:nil];
 }
+
+void hide_aegisub() {
+    [NSApp hide:nil];
+}
+
+void hide_others() {
+    [NSApp hideOtherApplications:nil];
+}
+
+void show_all() {
+    [NSApp unhideAllApplications:nil];
+}
 }

--- a/src/osx/osx_utils.mm
+++ b/src/osx/osx_utils.mm
@@ -84,15 +84,15 @@ void bring_to_front() {
 	[NSApp arrangeInFront:nil];
 }
 
-void hide_aegisub() {
+void hide_application() {
     [NSApp hide:nil];
 }
 
-void hide_others() {
+void hide_other_applications() {
     [NSApp hideOtherApplications:nil];
 }
 
-void show_all() {
+void show_all_applications() {
     [NSApp unhideAllApplications:nil];
 }
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -106,6 +106,12 @@ namespace osx {
 	bool activate_top_window_other_than(wxFrame *wx);
 	// Bring all windows to the front, maintaining relative z-order
 	void bring_to_front();
+	// Hide the application
+	void hide_aegisub();
+	// Hide all other applications
+	void hide_others();
+	// Unhide all applications
+	void show_all();
 
 namespace ime {
 	/// Inject the IME helper into the given wxSTC

--- a/src/utils.h
+++ b/src/utils.h
@@ -107,11 +107,11 @@ namespace osx {
 	// Bring all windows to the front, maintaining relative z-order
 	void bring_to_front();
 	// Hide the application
-	void hide_aegisub();
+	void hide_application();
 	// Hide all other applications
-	void hide_others();
+	void hide_other_applications();
 	// Unhide all applications
-	void show_all();
+	void show_all_applications();
 
 namespace ime {
 	/// Inject the IME helper into the given wxSTC


### PR DESCRIPTION
Currently on macos the menubar entries Hide Aegisub, Hide Others and Show All are in the menu bar, but these entries are not functional. This PR makes these entries work, also the corresponding keyboard shortcuts work now.