### PR TITLE
Fix wxWidgets subproject build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -157,6 +157,7 @@ wx_dep = dependency('wxWidgets', version: '>=' + get_option('wx_version'),
 
 if wx_dep.found()
     deps += wx_dep
+    wx_defines_dep = wx_dep
 else
     build_shared = true
     if get_option('default_library') == 'static'
@@ -190,6 +191,10 @@ else
             deps += wx.dependency(cmake_target)
         endif
     endforeach
+
+    # meson doesn't let you get defines from a library that has sources which need to be built,
+    # but allows it if you use partial_dependency() to get only includes and compile args.
+    wx_defines_dep = wx.dependency('wxmono').partial_dependency(compile_args: true, includes: true)
 
     if host_machine.system() == 'windows' or host_machine.system() == 'darwin'
         deps += [
@@ -234,7 +239,7 @@ check_deps = [
 ]
 
 if host_machine.system() == 'linux'
-    if cc.get_define('__WXGTK3__', dependencies: wx_dep, prefix: '#include <wx/defs.h>') != ''
+    if cc.get_define('__WXGTK3__', dependencies: wx_defines_dep, prefix: '#include <wx/defs.h>') != ''
         check_deps += [['libportal-gtk3', [], 'libportal', [], []]]
     else
         check_deps += [['libportal', [], 'libportal', [], []]]


### PR DESCRIPTION
Fixes #555.

The toolkit detection is fixed by removing sources from the dependency with `partial_dependency`. This happens to work because of obscure meson implementation details.

The nonexistent target is fixed by adding logic to detect if the target exists. With the detection logic in place, I've also added `wxlexilla` to the list of dependencies, since it's needed for wxWidgets 3.3 and with the detection logic, it won't break wxWidgets 3.2.

The conditionally added `wxpng`, `wxzlib` and `wxexpat` could maybe be converted to also use this detection logic instead of hardcoding which platforms they are needed on, but I'm not sure and didn't want to break anything that works, so I kept it as is.