### PR TITLE
Fix snapping audio times to current video position

### DIFF
--- a/libaegisub/common/color.cpp
+++ b/libaegisub/common/color.cpp
@@ -47,7 +47,10 @@ std::string Color::GetHexFormatted(bool rgba) const {
 }
 
 std::string Color::GetRgbFormatted() const {
-	return agi::format("rgb(%d, %d, %d)", r, g, b);
+	if (a)
+		return agi::format("rgba(%d, %d, %d, %d)", r, g, b, a);
+	else
+		return agi::format("rgb(%d, %d, %d)", r, g, b);
 }
 
 }

--- a/libaegisub/common/option.cpp
+++ b/libaegisub/common/option.cpp
@@ -113,6 +113,7 @@ class ConfigVisitor final : public json::ConstVisitor {
 		if ((size == 4 && string[0] == '#') ||
 			(size == 7 && string[0] == '#') ||
 			(size >= 10 && string.starts_with("rgb(")) ||
+			(size >= 13 && string.starts_with("rgba(")) ||
 			((size == 9 || size == 10) && string.starts_with("&H")))
 		{
 			values.push_back(std::make_unique<OptionValueColor>(name, agi::Color(string)));

--- a/libaegisub/common/parser.cpp
+++ b/libaegisub/common/parser.cpp
@@ -88,6 +88,7 @@ struct color_grammar : qi::grammar<Iterator, agi::Color()> {
 
 		css_color
 			= "rgb(" >> blank >> rgb_component >> comma >> rgb_component >> comma >> rgb_component >> blank >> ')'
+			| "rgba(" >> blank >> rgb_component >> comma >> rgb_component >> comma >> rgb_component >> comma >> rgb_component >> blank >> ')'
 			| '#' >> hex_byte >> hex_byte >> hex_byte
 			| '#' >> hex_char >> hex_char >> hex_char
 			;

--- a/libaegisub/common/vfr.cpp
+++ b/libaegisub/common/vfr.cpp
@@ -244,6 +244,9 @@ int Framerate::TimeAtFrame(int frame, Time type) const {
 		return cur + (next - cur + 1) / 2;
 	}
 
+	if (numerator == 0)
+		return 0;
+
 	if (frame < 0)
 		return (int)(frame * denominator * 1000 / numerator);
 

--- a/src/audio_display.cpp
+++ b/src/audio_display.cpp
@@ -50,6 +50,7 @@
 #include <algorithm>
 
 #include <wx/dcbuffer.h>
+#include <wx/dcgraph.h>
 #include <wx/mousestate.h>
 
 /// @class AudioDisplayInteractionObject
@@ -848,12 +849,13 @@ void AudioDisplay::OnPaint(wxPaintEvent&)
 
 		if (audio_bounds.Intersects(updrect))
 		{
+			wxGCDC gcdc(dc);	// Markers may use alpha, which needs a GCDC
 			TimeRange updtime(
 				std::max(0, TimeFromRelativeX(updrect.x - foot_size)),
 				std::max(0, TimeFromRelativeX(updrect.x + updrect.width + foot_size)));
 
 			PaintAudio(dc, updtime, updrect);
-			PaintMarkers(dc, updtime);
+			PaintMarkers(gcdc, updtime);
 			PaintLabels(dc, updtime);
 		}
 	}
@@ -898,8 +900,17 @@ void AudioDisplay::PaintMarkers(wxDC &dc, TimeRange updtime)
 	{
 		int marker_x = RelativeXFromTime(marker->GetPosition());
 
-		dc.SetPen(marker->GetStyle());
-		dc.DrawLine(marker_x, audio_top, marker_x, audio_top+audio_height);
+		if (marker->GetWidth() == 0) {
+			dc.SetPen(marker->GetStyle());
+			dc.DrawLine(marker_x, audio_top, marker_x, audio_top+audio_height);
+		} else {
+			int w = RelativeXFromTime(marker->GetPosition() + marker->GetWidth() - 1) - marker_x + 1;
+
+			dc.SetBrush(wxBrush(marker->GetStyle().GetColour()));
+			dc.SetPen(*wxTRANSPARENT_PEN);
+
+			dc.DrawRectangle(marker_x, audio_top, w, audio_height);
+		}
 
 		if (marker->GetFeet() == AudioMarker::Feet_None) continue;
 

--- a/src/audio_marker.cpp
+++ b/src/audio_marker.cpp
@@ -96,8 +96,8 @@ public:
 };
 
 VideoPositionMarkerProvider::VideoPositionMarkerProvider(agi::Context *c)
-: vc(c->videoController.get())
-, video_seek_slot(vc->AddSeekListener(&VideoPositionMarkerProvider::Update, this))
+: c(c)
+, video_seek_slot(c->videoController->AddSeekListener(&VideoPositionMarkerProvider::Update, this))
 , enable_opt_changed_slot(OPT_SUB("Audio/Display/Draw/Video Position", &VideoPositionMarkerProvider::OptChanged, this))
 {
 	OptChanged(*OPT_GET("Audio/Display/Draw/Video Position"));
@@ -106,7 +106,7 @@ VideoPositionMarkerProvider::VideoPositionMarkerProvider(agi::Context *c)
 VideoPositionMarkerProvider::~VideoPositionMarkerProvider() { }
 
 void VideoPositionMarkerProvider::SetPosition(int frame_number) {
-	marker->SetPosition(vc->TimeAtFrame(frame_number));
+	marker->SetPosition(c->videoController->TimeAtFrame(frame_number));
 }
 
 void VideoPositionMarkerProvider::Update(int frame_number) {
@@ -118,7 +118,7 @@ void VideoPositionMarkerProvider::OptChanged(agi::OptionValue const& opt) {
 	if (opt.GetBool()) {
 		video_seek_slot.Unblock();
 		marker = std::make_unique<VideoPositionMarker>();
-		SetPosition(vc->GetFrameN());
+		SetPosition(c->videoController->GetFrameN());
 	}
 	else {
 		video_seek_slot.Block();
@@ -127,6 +127,9 @@ void VideoPositionMarkerProvider::OptChanged(agi::OptionValue const& opt) {
 }
 
 void VideoPositionMarkerProvider::GetMarkers(const TimeRange &range, AudioMarkerVector &out) const {
+	if (!c->project->VideoProvider())
+		return;
+
 	if (marker && range.contains(*marker))
 		out.push_back(marker.get());
 }

--- a/src/audio_marker.cpp
+++ b/src/audio_marker.cpp
@@ -82,6 +82,36 @@ void AudioMarkerProviderKeyframes::GetMarkers(TimeRange const& range, AudioMarke
 		out.push_back(&*a);
 }
 
+class VideoPositionSnapPoint final : public AudioMarker {
+	int position = -1;
+
+public:
+	void SetPosition(int new_pos) { position = new_pos; }
+
+	int GetPosition() const override { return position; }
+	FeetStyle GetFeet() const override { return Feet_None; }
+	wxPen GetStyle() const override { return wxPen{}; }
+};
+
+class VideoPositionRange final : public AudioMarker {
+	Pen style;
+	int position = -1;
+	int width = 0;
+
+public:
+	VideoPositionRange(bool previous) : style{previous ? "Colour/Audio Display/Previous Frame Range" : "Colour/Audio Display/Current Frame Range"} { }
+
+	void SetPosition(int frame, int nextframe) {
+		position = frame + 1;
+		width = std::max(1, nextframe - frame);
+	}
+
+	int GetPosition() const override { return position; }
+	int GetWidth() const override { return width; }
+	FeetStyle GetFeet() const override { return Feet_None; }
+	wxPen GetStyle() const override { return style; }
+};
+
 class VideoPositionMarker final : public AudioMarker {
 	Pen style{"Colour/Audio Display/Play Cursor"};
 	int position = -1;
@@ -92,7 +122,6 @@ public:
 	int GetPosition() const override { return position; }
 	FeetStyle GetFeet() const override { return Feet_None; }
 	wxPen GetStyle() const override { return style; }
-	operator int() const { return position; }
 };
 
 VideoPositionMarkerProvider::VideoPositionMarkerProvider(agi::Context *c)
@@ -105,33 +134,61 @@ VideoPositionMarkerProvider::VideoPositionMarkerProvider(agi::Context *c)
 
 VideoPositionMarkerProvider::~VideoPositionMarkerProvider() { }
 
-void VideoPositionMarkerProvider::SetPosition(int frame_number) {
-	marker->SetPosition(c->videoController->TimeAtFrame(frame_number));
+void VideoPositionMarkerProvider::SetPositions(int frame_number) {
+	auto vc = c->videoController.get();
+
+	range1->SetPosition(vc->TimeAtFrame(frame_number - 1), vc->TimeAtFrame(frame_number));
+	range2->SetPosition(vc->TimeAtFrame(frame_number), vc->TimeAtFrame(frame_number + 1));
+	marker->SetPosition(vc->TimeAtFrame(frame_number));
+	snap1->SetPosition(vc->TimeAtFrame(frame_number, agi::vfr::START));
+	snap2->SetPosition(vc->TimeAtFrame(frame_number, agi::vfr::END));
 }
 
 void VideoPositionMarkerProvider::Update(int frame_number) {
-	SetPosition(frame_number);
+	SetPositions(frame_number);
 	AnnounceMarkerMoved();
 }
 
 void VideoPositionMarkerProvider::OptChanged(agi::OptionValue const& opt) {
 	if (opt.GetBool()) {
 		video_seek_slot.Unblock();
+		range1 = std::make_unique<VideoPositionRange>(true);
+		range2 = std::make_unique<VideoPositionRange>(false);
 		marker = std::make_unique<VideoPositionMarker>();
-		SetPosition(c->videoController->GetFrameN());
+		snap1 = std::make_unique<VideoPositionSnapPoint>();
+		snap2 = std::make_unique<VideoPositionSnapPoint>();
+		SetPositions(c->videoController->GetFrameN());
 	}
 	else {
 		video_seek_slot.Block();
+		range1.reset();
+		range2.reset();
 		marker.reset();
+		snap1.reset();
+		snap2.reset();
 	}
 }
 
-void VideoPositionMarkerProvider::GetMarkers(const TimeRange &range, AudioMarkerVector &out) const {
+void VideoPositionMarkerProvider::GetMarkers(const TimeRange &timerange, AudioMarkerVector &out) const {
 	if (!c->project->VideoProvider())
 		return;
 
-	if (marker && range.contains(*marker))
+	for (auto range : {range1.get(), range2.get()})
+		if (range && timerange.overlaps({range->GetPosition(), range->GetPosition() + range->GetWidth() - 1}))
+			out.push_back(range);
+
+	if (marker && timerange.contains(marker->GetPosition()))
 		out.push_back(marker.get());
+
+}
+
+void VideoPositionMarkerProvider::GetSnapMarkers(const TimeRange &timerange, AudioMarkerVector &out) const {
+	if (!c->project->VideoProvider())
+		return;
+
+	for (auto snap : {snap1.get(), snap2.get()})
+		if (snap && timerange.contains(snap->GetPosition()))
+			out.push_back(snap);
 }
 
 SecondsMarkerProvider::SecondsMarkerProvider()

--- a/src/audio_marker.cpp
+++ b/src/audio_marker.cpp
@@ -87,9 +87,7 @@ class VideoPositionMarker final : public AudioMarker {
 	int position = -1;
 
 public:
-	void SetPosition(int new_pos, const VideoController *vc) {
-		position = vc->TimeAtFrame(new_pos);
-	}
+	void SetPosition(int new_pos) { position = new_pos; }
 
 	int GetPosition() const override { return position; }
 	FeetStyle GetFeet() const override { return Feet_None; }
@@ -108,7 +106,7 @@ VideoPositionMarkerProvider::VideoPositionMarkerProvider(agi::Context *c)
 VideoPositionMarkerProvider::~VideoPositionMarkerProvider() { }
 
 void VideoPositionMarkerProvider::Update(int frame_number) {
-	marker->SetPosition(frame_number, vc);
+	marker->SetPosition(vc->TimeAtFrame(frame_number));
 	AnnounceMarkerMoved();
 }
 
@@ -116,7 +114,7 @@ void VideoPositionMarkerProvider::OptChanged(agi::OptionValue const& opt) {
 	if (opt.GetBool()) {
 		video_seek_slot.Unblock();
 		marker = std::make_unique<VideoPositionMarker>();
-		marker->SetPosition(vc->GetFrameN(), vc);
+		marker->SetPosition(vc->GetFrameN());
 	}
 	else {
 		video_seek_slot.Block();

--- a/src/audio_marker.cpp
+++ b/src/audio_marker.cpp
@@ -87,7 +87,9 @@ class VideoPositionMarker final : public AudioMarker {
 	int position = -1;
 
 public:
-	void SetPosition(int new_pos) { position = new_pos; }
+	void SetPosition(int new_pos, const VideoController *vc) {
+		position = vc->TimeAtFrame(new_pos);
+	}
 
 	int GetPosition() const override { return position; }
 	FeetStyle GetFeet() const override { return Feet_None; }
@@ -106,7 +108,7 @@ VideoPositionMarkerProvider::VideoPositionMarkerProvider(agi::Context *c)
 VideoPositionMarkerProvider::~VideoPositionMarkerProvider() { }
 
 void VideoPositionMarkerProvider::Update(int frame_number) {
-	marker->SetPosition(vc->TimeAtFrame(frame_number));
+	marker->SetPosition(frame_number, vc);
 	AnnounceMarkerMoved();
 }
 
@@ -114,7 +116,7 @@ void VideoPositionMarkerProvider::OptChanged(agi::OptionValue const& opt) {
 	if (opt.GetBool()) {
 		video_seek_slot.Unblock();
 		marker = std::make_unique<VideoPositionMarker>();
-		marker->SetPosition(vc->GetFrameN());
+		marker->SetPosition(vc->GetFrameN(), vc);
 	}
 	else {
 		video_seek_slot.Block();

--- a/src/audio_marker.cpp
+++ b/src/audio_marker.cpp
@@ -105,8 +105,12 @@ VideoPositionMarkerProvider::VideoPositionMarkerProvider(agi::Context *c)
 
 VideoPositionMarkerProvider::~VideoPositionMarkerProvider() { }
 
-void VideoPositionMarkerProvider::Update(int frame_number) {
+void VideoPositionMarkerProvider::SetPosition(int frame_number) {
 	marker->SetPosition(vc->TimeAtFrame(frame_number));
+}
+
+void VideoPositionMarkerProvider::Update(int frame_number) {
+	SetPosition(frame_number);
 	AnnounceMarkerMoved();
 }
 
@@ -114,7 +118,7 @@ void VideoPositionMarkerProvider::OptChanged(agi::OptionValue const& opt) {
 	if (opt.GetBool()) {
 		video_seek_slot.Unblock();
 		marker = std::make_unique<VideoPositionMarker>();
-		marker->SetPosition(vc->GetFrameN());
+		SetPosition(vc->GetFrameN());
 	}
 	else {
 		video_seek_slot.Block();

--- a/src/audio_marker.cpp
+++ b/src/audio_marker.cpp
@@ -85,16 +85,13 @@ void AudioMarkerProviderKeyframes::GetMarkers(TimeRange const& range, AudioMarke
 class VideoPositionMarker final : public AudioMarker {
 	Pen style{"Colour/Audio Display/Play Cursor"};
 	int position = -1;
-	int snap_position = -1;
 
 public:
 	void SetPosition(int new_pos, const VideoController *vc) {
 		position = vc->TimeAtFrame(new_pos);
-		snap_position = vc->TimeAtFrame(new_pos, agi::vfr::START);
 	}
 
 	int GetPosition() const override { return position; }
-	int GetSnapPosition() const override { return snap_position; }
 	FeetStyle GetFeet() const override { return Feet_None; }
 	wxPen GetStyle() const override { return style; }
 	operator int() const { return position; }

--- a/src/audio_marker.cpp
+++ b/src/audio_marker.cpp
@@ -85,13 +85,16 @@ void AudioMarkerProviderKeyframes::GetMarkers(TimeRange const& range, AudioMarke
 class VideoPositionMarker final : public AudioMarker {
 	Pen style{"Colour/Audio Display/Play Cursor"};
 	int position = -1;
+	int snap_position = -1;
 
 public:
 	void SetPosition(int new_pos, const VideoController *vc) {
 		position = vc->TimeAtFrame(new_pos);
+		snap_position = vc->TimeAtFrame(new_pos, agi::vfr::START);
 	}
 
 	int GetPosition() const override { return position; }
+	int GetSnapPosition() const override { return snap_position; }
 	FeetStyle GetFeet() const override { return Feet_None; }
 	wxPen GetStyle() const override { return style; }
 	operator int() const { return position; }

--- a/src/audio_marker.h
+++ b/src/audio_marker.h
@@ -28,6 +28,8 @@ class AudioMarkerKeyframe;
 class Pen;
 class Project;
 class VideoPositionMarker;
+class VideoPositionRange;
+class VideoPositionSnapPoint;
 class wxPen;
 
 namespace agi {
@@ -53,6 +55,10 @@ public:
 	/// @return The marker's position in milliseconds
 	virtual int GetPosition() const = 0;
 
+	/// @brief Get the marker's width
+	/// @return The marker's width if the marker should be a rectangle, or 0 if the marker should be drawn as a line (with the thickness specified by the style)
+	virtual int GetWidth() const { return 0; }
+
 	/// @brief Get the marker's drawing style
 	/// @return A pen object describing the marker's drawing style
 	virtual wxPen GetStyle() const = 0;
@@ -72,8 +78,11 @@ protected:
 
 	~AudioMarkerProvider() = default;
 public:
-	/// @brief Return markers in a time range
+	/// @brief Return markers in a time range to render in audio display
 	virtual void GetMarkers(const TimeRange &range, AudioMarkerVector &out) const = 0;
+
+	/// @brief Return markers in a time range to snap timed lines to
+	virtual void GetSnapMarkers(const TimeRange &range, AudioMarkerVector &out) const { GetMarkers(range, out); };
 
 	DEFINE_SIGNAL_ADDERS(AnnounceMarkerMoved, AddMarkerMovedListener)
 };
@@ -141,12 +150,16 @@ public:
 class VideoPositionMarkerProvider final : public AudioMarkerProvider {
 	agi::Context *c;
 
+	std::unique_ptr<VideoPositionRange> range1;
+	std::unique_ptr<VideoPositionRange> range2;
 	std::unique_ptr<VideoPositionMarker> marker;
+	std::unique_ptr<VideoPositionSnapPoint> snap1;
+	std::unique_ptr<VideoPositionSnapPoint> snap2;
 
 	agi::signal::Connection video_seek_slot;
 	agi::signal::Connection enable_opt_changed_slot;
 
-	void SetPosition(int frame_number);
+	void SetPositions(int frame_number);
 	void Update(int frame_number);
 	void OptChanged(agi::OptionValue const& opt);
 
@@ -155,6 +168,7 @@ public:
 	~VideoPositionMarkerProvider();
 
 	void GetMarkers(const TimeRange &range, AudioMarkerVector &out) const override;
+	void GetSnapMarkers(const TimeRange &range, AudioMarkerVector &out) const override;
 };
 
 /// Marker provider for lines every second

--- a/src/audio_marker.h
+++ b/src/audio_marker.h
@@ -51,12 +51,8 @@ public:
 	};
 
 	/// @brief Get the marker's position
-	/// @return The marker's visual position in milliseconds
+	/// @return The marker's position in milliseconds
 	virtual int GetPosition() const = 0;
-
-	/// @brief Get the marker's snap position
-	/// @return The millisecond to which times should be snapped when snapping to this marker
-	virtual int GetSnapPosition() const { return GetPosition(); };
 
 	/// @brief Get the marker's drawing style
 	/// @return A pen object describing the marker's drawing style

--- a/src/audio_marker.h
+++ b/src/audio_marker.h
@@ -51,8 +51,12 @@ public:
 	};
 
 	/// @brief Get the marker's position
-	/// @return The marker's position in milliseconds
+	/// @return The marker's visual position in milliseconds
 	virtual int GetPosition() const = 0;
+
+	/// @brief Get the marker's snap position
+	/// @return The millisecond to which times should be snapped when snapping to this marker
+	virtual int GetSnapPosition() const { return GetPosition(); };
 
 	/// @brief Get the marker's drawing style
 	/// @return A pen object describing the marker's drawing style

--- a/src/audio_marker.h
+++ b/src/audio_marker.h
@@ -27,7 +27,6 @@
 class AudioMarkerKeyframe;
 class Pen;
 class Project;
-class VideoController;
 class VideoPositionMarker;
 class wxPen;
 
@@ -140,7 +139,7 @@ public:
 
 /// Marker provider for the current video playback position
 class VideoPositionMarkerProvider final : public AudioMarkerProvider {
-	VideoController *vc;
+	agi::Context *c;
 
 	std::unique_ptr<VideoPositionMarker> marker;
 

--- a/src/audio_marker.h
+++ b/src/audio_marker.h
@@ -147,6 +147,7 @@ class VideoPositionMarkerProvider final : public AudioMarkerProvider {
 	agi::signal::Connection video_seek_slot;
 	agi::signal::Connection enable_opt_changed_slot;
 
+	void SetPosition(int frame_number);
 	void Update(int frame_number);
 	void OptChanged(agi::OptionValue const& opt);
 

--- a/src/audio_timing_dialogue.cpp
+++ b/src/audio_timing_dialogue.cpp
@@ -881,11 +881,14 @@ int AudioTimingControllerDialogue::SnapMarkers(int snap_range, std::vector<Audio
 	}
 
 	int snap_distance = INT_MAX;
-	auto check = [&](int marker, int pos)
+	int snap_move = 0;
+	auto check = [&](int markerpos, int snappos, int pos)
 	{
-		auto dist = marker - pos;
-		if (tabs(dist) < tabs(snap_distance))
+		auto dist = markerpos - pos;
+		if (tabs(dist) < tabs(snap_distance)) {
 			snap_distance = dist;
+			snap_move = snappos - pos;
+		}
 	};
 
 	int prev = -1;
@@ -902,14 +905,14 @@ int AudioTimingControllerDialogue::SnapMarkers(int snap_range, std::vector<Audio
 
 		for (const auto marker : snap_markers)
 		{
-			check(marker->GetPosition(), pos);
-			if (snap_distance == 0) return 0;
+			check(marker->GetPosition(), marker->GetSnapPosition(), pos);
+			if (snap_distance == 0 && snap_move == 0) return 0;
 		}
 
 		for (auto it = boost::lower_bound(inactive_markers, range.begin()); it != end(inactive_markers); ++it)
 		{
-			check(*it, pos);
-			if (snap_distance == 0) return 0;
+			check(*it, *it, pos);
+			if (snap_distance == 0 && snap_move == 0) return 0;
 			if (*it > pos) break;
 		}
 	}
@@ -918,8 +921,8 @@ int AudioTimingControllerDialogue::SnapMarkers(int snap_range, std::vector<Audio
 		return 0;
 
 	for (auto m : active)
-		static_cast<DialogueTimingMarker *>(m)->SetPosition(m->GetPosition() + snap_distance);
-	return snap_distance;
+		static_cast<DialogueTimingMarker *>(m)->SetPosition(m->GetPosition() + snap_move);
+	return snap_move;
 }
 
 } // namespace {

--- a/src/audio_timing_dialogue.cpp
+++ b/src/audio_timing_dialogue.cpp
@@ -881,14 +881,11 @@ int AudioTimingControllerDialogue::SnapMarkers(int snap_range, std::vector<Audio
 	}
 
 	int snap_distance = INT_MAX;
-	int snap_move = 0;
-	auto check = [&](int markerpos, int snappos, int pos)
+	auto check = [&](int marker, int pos)
 	{
-		auto dist = markerpos - pos;
-		if (tabs(dist) < tabs(snap_distance)) {
+		auto dist = marker - pos;
+		if (tabs(dist) < tabs(snap_distance))
 			snap_distance = dist;
-			snap_move = snappos - pos;
-		}
 	};
 
 	int prev = -1;
@@ -905,14 +902,14 @@ int AudioTimingControllerDialogue::SnapMarkers(int snap_range, std::vector<Audio
 
 		for (const auto marker : snap_markers)
 		{
-			check(marker->GetPosition(), marker->GetSnapPosition(), pos);
-			if (snap_distance == 0 && snap_move == 0) return 0;
+			check(marker->GetPosition(), pos);
+			if (snap_distance == 0) return 0;
 		}
 
 		for (auto it = boost::lower_bound(inactive_markers, range.begin()); it != end(inactive_markers); ++it)
 		{
-			check(*it, *it, pos);
-			if (snap_distance == 0 && snap_move == 0) return 0;
+			check(*it, pos);
+			if (snap_distance == 0) return 0;
 			if (*it > pos) break;
 		}
 	}
@@ -921,8 +918,8 @@ int AudioTimingControllerDialogue::SnapMarkers(int snap_range, std::vector<Audio
 		return 0;
 
 	for (auto m : active)
-		static_cast<DialogueTimingMarker *>(m)->SetPosition(m->GetPosition() + snap_move);
-	return snap_move;
+		static_cast<DialogueTimingMarker *>(m)->SetPosition(m->GetPosition() + snap_distance);
+	return snap_distance;
 }
 
 } // namespace {

--- a/src/audio_timing_dialogue.cpp
+++ b/src/audio_timing_dialogue.cpp
@@ -445,8 +445,8 @@ void AudioTimingControllerDialogue::GetMarkers(const TimeRange &range, AudioMark
 		boost::upper_bound(markers, range.end(), marker_ptr_cmp()),
 		back_inserter(out_markers));
 
-	keyframes_provider.GetMarkers(range, out_markers);
 	video_position_provider.GetMarkers(range, out_markers);
+	keyframes_provider.GetMarkers(range, out_markers);
 }
 
 void AudioTimingControllerDialogue::OnSelectedSetChanged()
@@ -897,8 +897,8 @@ int AudioTimingControllerDialogue::SnapMarkers(int snap_range, std::vector<Audio
 
 		snap_markers.clear();
 		TimeRange range(pos - snap_range, pos + snap_range);
-		keyframes_provider.GetMarkers(range, snap_markers);
-		video_position_provider.GetMarkers(range, snap_markers);
+		keyframes_provider.GetSnapMarkers(range, snap_markers);
+		video_position_provider.GetSnapMarkers(range, snap_markers);
 
 		for (const auto marker : snap_markers)
 		{

--- a/src/libresrc/default_config.json
+++ b/src/libresrc/default_config.json
@@ -106,6 +106,8 @@
 			"Line boundary End" : "rgb(0, 0, 216)",
 			"Line boundary Start" : "rgb(216, 0, 0)",
 			"Play Cursor" : "rgb(255,255,255)",
+			"Current Frame Range" : "rgba(255,255,255,160)",
+			"Previous Frame Range" : "rgba(255,255,255,200)",
 			"Seconds Line" : "rgb(0,100,255)",
 			"Spectrum" : "Icy Blue",
 			"Syllable Boundaries" : "rgb(255,255,0)",

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -253,6 +253,8 @@ void Interface_Colours(wxTreebook *book, Preferences *parent) {
 
 	auto audio = p->PageSizer(_("Audio Display"));
 	p->OptionAdd(audio, _("Play cursor"), "Colour/Audio Display/Play Cursor");
+	p->OptionAdd(audio, _("Current frame range"), "Colour/Audio Display/Current Frame Range", {.alpha = true});
+	p->OptionAdd(audio, _("Previous frame range"), "Colour/Audio Display/Previous Frame Range", {.alpha = true});
 	p->OptionAdd(audio, _("Line boundary start"), "Colour/Audio Display/Line boundary Start");
 	p->OptionAdd(audio, _("Line boundary end"), "Colour/Audio Display/Line boundary End");
 	p->OptionAdd(audio, _("Line boundary inactive line"), "Colour/Audio Display/Line Boundary Inactive Line");

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -73,10 +73,10 @@ void General(wxTreebook *book, Preferences *parent) {
 	wxString autoload_modes[] = { _("Never"), _("Always"), _("Ask") };
 	wxArrayString autoload_modes_arr(3, autoload_modes);
 	p->OptionChoice(general, _("Automatically load linked files"), autoload_modes_arr, "App/Auto/Load Linked Files");
-	p->OptionAdd(general, _("Undo Levels"), "Limits/Undo Levels", 2, 10000);
+	p->OptionAdd(general, _("Undo Levels"), "Limits/Undo Levels", {.min = 2, .max = 10000});
 
 	auto recent = p->PageSizer(_("Recently Used Lists"));
-	p->OptionAdd(recent, _("Files"), "Limits/MRU", 0, 16);
+	p->OptionAdd(recent, _("Files"), "Limits/MRU", {.min = 0, .max = 16});
 	p->OptionAdd(recent, _("Find/Replace"), "Limits/Find Replace");
 
 	p->SetSizerAndFit(p->sizer);
@@ -136,13 +136,13 @@ void Audio(wxTreebook *book, Preferences *parent) {
 	p->OptionAdd(general, _("Auto-focus on mouse over"), "Audio/Auto/Focus");
 	p->OptionAdd(general, _("Play audio when stepping in video"), "Audio/Plays When Stepping Video");
 	p->OptionAdd(general, _("Left-click-drag moves end marker"), "Audio/Drag Timing");
-	p->OptionAdd(general, _("Default timing length (ms)"), "Timing/Default Duration", 0, 36000);
-	p->OptionAdd(general, _("Default lead-in length (ms)"), "Audio/Lead/IN", 0, 36000);
-	p->OptionAdd(general, _("Default lead-out length (ms)"), "Audio/Lead/OUT", 0, 36000);
+	p->OptionAdd(general, _("Default timing length (ms)"), "Timing/Default Duration", {.min = 0, .max = 36000});
+	p->OptionAdd(general, _("Default lead-in length (ms)"), "Audio/Lead/IN", {.min = 0, .max = 36000});
+	p->OptionAdd(general, _("Default lead-out length (ms)"), "Audio/Lead/OUT", {.min = 0, .max = 36000});
 
-	p->OptionAdd(general, _("Marker drag-start sensitivity (px)"), "Audio/Start Drag Sensitivity", 1, 15);
-	p->OptionAdd(general, _("Line boundary thickness (px)"), "Audio/Line Boundaries Thickness", 1, 5);
-	p->OptionAdd(general, _("Maximum snap distance (px)"), "Audio/Snap/Distance", 0, 25);
+	p->OptionAdd(general, _("Marker drag-start sensitivity (px)"), "Audio/Start Drag Sensitivity", {.min = 1, .max = 15});
+	p->OptionAdd(general, _("Line boundary thickness (px)"), "Audio/Line Boundaries Thickness", {.min = 1, .max = 5});
+	p->OptionAdd(general, _("Maximum snap distance (px)"), "Audio/Snap/Distance", {.min = 0, .max = 25});
 
 	const wxString dtl_arr[] = { _("Don't show"), _("Show previous"), _("Show previous and next"), _("Show all") };
 	wxArrayString choice_dtl(4, dtl_arr);
@@ -223,9 +223,9 @@ void Interface(wxTreebook *book, Preferences *parent) {
 	p->OptionFont(edit_box, "Subtitle/Edit Box/");
 
 	auto character_count = p->PageSizer(_("Character Counter"));
-	p->OptionAdd(character_count, _("Maximum characters per line"), "Subtitle/Character Limit", 0, 1000);
-	p->OptionAdd(character_count, _("Characters Per Second Warning Threshold"), "Subtitle/Character Counter/CPS Warning Threshold", 0, 1000);
-	p->OptionAdd(character_count, _("Characters Per Second Error Threshold"), "Subtitle/Character Counter/CPS Error Threshold", 0, 1000);
+	p->OptionAdd(character_count, _("Maximum characters per line"), "Subtitle/Character Limit", {.min = 0, .max = 1000});
+	p->OptionAdd(character_count, _("Characters Per Second Warning Threshold"), "Subtitle/Character Counter/CPS Warning Threshold", {.min = 0, .max = 1000});
+	p->OptionAdd(character_count, _("Characters Per Second Error Threshold"), "Subtitle/Character Counter/CPS Error Threshold", {.min = 0, .max = 1000});
 	p->OptionAdd(character_count, _("Ignore whitespace"), "Subtitle/Character Counter/Ignore Whitespace");
 	p->OptionAdd(character_count, _("Ignore punctuation"), "Subtitle/Character Counter/Ignore Punctuation");
 
@@ -310,7 +310,7 @@ void Interface_Colours(wxTreebook *book, Preferences *parent) {
 
 	// Separate sizer to prevent the colors in the visual tools section from getting resized
 	auto visual_tools_alpha = p->PageSizer(_("Visual Typesetting Tools Alpha"));
-	p->OptionAdd(visual_tools_alpha, _("Shaded Area"), "Colour/Visual Tools/Shaded Area Alpha", 0, 1, 0.1);
+	p->OptionAdd(visual_tools_alpha, _("Shaded Area"), "Colour/Visual Tools/Shaded Area Alpha", {.min = 0, .max = 1, .inc = 0.1});
 
 	p->sizer = main_sizer;
 
@@ -325,7 +325,7 @@ void Backup(wxTreebook *book, Preferences *parent) {
 	wxControl *cb = p->OptionAdd(save, _("Enable"), "App/Auto/Save");
 	p->CellSkip(save);
 	p->EnableIfChecked(cb,
-		p->OptionAdd(save, _("Interval in seconds"), "App/Auto/Save Every Seconds", 1));
+		p->OptionAdd(save, _("Interval in seconds"), "App/Auto/Save Every Seconds", {.min = 1}));
 	p->OptionBrowse(save, _("Path"), "Path/Auto/Save", cb, true);
 	p->OptionAdd(save, _("Autosave after every change"), "App/Auto/Save on Every Change");
 
@@ -403,7 +403,7 @@ void Advanced_Audio(wxTreebook *book, Preferences *parent) {
 	wxArrayString sc_choice(5, sc_arr);
 	p->OptionChoice(spectrum, _("Frequency mapping"), sc_choice, "Audio/Renderer/Spectrum/FreqCurve");
 
-	p->OptionAdd(spectrum, _("Cache memory max (MB)"), "Audio/Renderer/Spectrum/Memory Max", 2, 1024);
+	p->OptionAdd(spectrum, _("Cache memory max (MB)"), "Audio/Renderer/Spectrum/Memory Max", {.min = 2, .max = 1024});
 
 #ifdef WITH_AVISYNTH
 	auto avisynth = p->PageSizer("Avisynth");
@@ -435,8 +435,8 @@ void Advanced_Audio(wxTreebook *book, Preferences *parent) {
 
 #ifdef WITH_DIRECTSOUND
 	auto dsound = p->PageSizer("DirectSound");
-	p->OptionAdd(dsound, _("Buffer latency"), "Player/Audio/DirectSound/Buffer Latency", 1, 1000);
-	p->OptionAdd(dsound, _("Buffer length"), "Player/Audio/DirectSound/Buffer Length", 1, 100);
+	p->OptionAdd(dsound, _("Buffer latency"), "Player/Audio/DirectSound/Buffer Latency", {.min = 1, .max = 1000});
+	p->OptionAdd(dsound, _("Buffer length"), "Player/Audio/DirectSound/Buffer Length", {.min = 1, .max = 100});
 #endif
 
 	p->SetSizerAndFit(p->sizer);
@@ -468,7 +468,7 @@ void Advanced_Video(wxTreebook *book, Preferences *parent) {
 	wxArrayString log_levels_choice(8, log_levels);
 	p->OptionChoice(ffms, _("Debug log verbosity"), log_levels_choice, "Provider/FFmpegSource/Log Level", true);
 
-	p->OptionAdd(ffms, _("Decoding threads"), "Provider/Video/FFmpegSource/Decoding Threads", -1);
+	p->OptionAdd(ffms, _("Decoding threads"), "Provider/Video/FFmpegSource/Decoding Threads", {.min = -1});
 	p->OptionAdd(ffms, _("Enable unsafe seeking"), "Provider/Video/FFmpegSource/Unsafe Seeking");
 #endif
 

--- a/src/preferences_base.cpp
+++ b/src/preferences_base.cpp
@@ -126,7 +126,7 @@ void OptionPage::CellSkip(PageSection section) {
 	section.sizer->AddStretchSpacer();
 }
 
-wxControl *OptionPage::OptionAdd(PageSection section, const wxString &name, const char *opt_name, double min, double max, double inc) {
+wxControl *OptionPage::OptionAdd(PageSection section, const wxString &name, const char *opt_name, OptionAddArgs kwargs) {
 	parent->AddChangeableOption(opt_name);
 	const auto opt = OPT_GET(opt_name);
 
@@ -140,14 +140,14 @@ wxControl *OptionPage::OptionAdd(PageSection section, const wxString &name, cons
 		}
 
 		case agi::OptionType::Int: {
-			auto sc = new wxSpinCtrl(section.box, -1, std::to_wstring((int)opt->GetInt()), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, min, max, opt->GetInt());
+			auto sc = new wxSpinCtrl(section.box, -1, std::to_wstring((int)opt->GetInt()), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, kwargs.min, kwargs.max, opt->GetInt());
 			sc->Bind(wxEVT_SPINCTRL, IntUpdater(opt_name, parent));
 			Add(section, name, sc);
 			return sc;
 		}
 
 		case agi::OptionType::Double: {
-			auto scd = new wxSpinCtrlDouble(section.box, -1, std::to_wstring(opt->GetDouble()), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, min, max, opt->GetDouble(), inc);
+			auto scd = new wxSpinCtrlDouble(section.box, -1, std::to_wstring(opt->GetDouble()), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, kwargs.min, kwargs.max, opt->GetDouble(), kwargs.inc);
 			scd->Bind(wxEVT_SPINCTRLDOUBLE, DoubleUpdater(opt_name, parent));
 			Add(section, name, scd);
 			return scd;

--- a/src/preferences_base.cpp
+++ b/src/preferences_base.cpp
@@ -161,7 +161,7 @@ wxControl *OptionPage::OptionAdd(PageSection section, const wxString &name, cons
 		}
 
 		case agi::OptionType::Color: {
-			auto cb = new ColourButton(section.box, wxSize(40,10), false, opt->GetColor());
+			auto cb = new ColourButton(section.box, wxSize(40,10), kwargs.alpha, opt->GetColor());
 			cb->Bind(EVT_COLOR, ColourUpdater(opt_name, parent));
 			Add(section, name, cb);
 			return cb;

--- a/src/preferences_base.h
+++ b/src/preferences_base.h
@@ -37,6 +37,7 @@ struct OptionAddArgs {
 	double min = 0;
 	double max = INT_MAX;
 	double inc = 1;
+	bool alpha = false;
 };
 
 class OptionPage : public wxScrolled<wxPanel> {

--- a/src/preferences_base.h
+++ b/src/preferences_base.h
@@ -33,6 +33,12 @@ struct PageSection {
 	wxWindow *box;
 };
 
+struct OptionAddArgs {
+	double min = 0;
+	double max = INT_MAX;
+	double inc = 1;
+};
+
 class OptionPage : public wxScrolled<wxPanel> {
 	template<class T>
 	void Add(PageSection section, wxString const& label, T *control);
@@ -48,7 +54,8 @@ public:
 	PageSection PageSizer(wxString name);
 
 	void CellSkip(PageSection section);
-	wxControl *OptionAdd(PageSection section, const wxString &name, const char *opt_name, double min=0, double max=INT_MAX, double inc=1);
+
+	wxControl *OptionAdd(PageSection section, const wxString &name, const char *opt_name, OptionAddArgs kwargs = {});
 	void OptionChoice(PageSection section, const wxString &name, const wxArrayString &choices, const char *opt_name, bool translate = false);
 	void OptionBrowse(PageSection section, const wxString &name, const char *opt_name, wxControl *enabler = nullptr, bool do_enable = false);
 	void OptionFont(PageSection section, std::string opt_prefix);

--- a/tests/tests/color.cpp
+++ b/tests/tests/color.cpp
@@ -56,11 +56,13 @@ TEST(lagi_color, rgb) {
 	EXPECT_EQ(agi::Color(255, 255, 255), agi::Color("rgb(255,255,255)"));
 	EXPECT_EQ(agi::Color(255, 0, 127), agi::Color("rgb(255, 0, 127)"));
 	EXPECT_EQ(agi::Color(16, 32, 48), agi::Color("rgb(  16  , 32  , 48  )"));
+	EXPECT_EQ(agi::Color(16, 32, 48, 64), agi::Color("rgba(  16  , 32  , 48  , 64  )"));
 
 	EXPECT_EQ("rgb(0, 0, 0)", agi::Color(0, 0, 0).GetRgbFormatted());
 	EXPECT_EQ("rgb(255, 255, 255)", agi::Color(255, 255, 255).GetRgbFormatted());
 	EXPECT_EQ("rgb(255, 0, 127)", agi::Color(255, 0, 127).GetRgbFormatted());
 	EXPECT_EQ("rgb(16, 32, 48)", agi::Color(16, 32, 48).GetRgbFormatted());
+	EXPECT_EQ("rgba(16, 32, 48, 64)", agi::Color(16, 32, 48, 64).GetRgbFormatted());
 }
 
 TEST(lagi_color, ass_ovr) {


### PR DESCRIPTION
Lots of text incoming, since timestamp wrangling is hell and I want to write down my reasoning before I inevitably forget it again in two weeks.

Before commit 5d4973a5f64c54a6a3a84278f385d2d474cfa5ab, snapping an audio line's end time to the "current video position" indicator line would reliably make the line end on the frame before the current video frame (i.e. make the current video frame be the first frame where the selected line is *not* visible any more).

Commit 5d4973a5f64c54a6a3a84278f385d2d474cfa5ab broke this, making the behavior of snapping audio times to the "current video position" inconsistent.

The commit in question is definitely not fully correct, ultimately just because the entire concept of implicitly converting millisecond timestamps to centisecond timestamps is flawed in and of itself, and bound to always fail in sufficiently crazy edge cases. Fixing the timestamp conversion properly would entail either working with centisecond timestamps from the beginning, or somehow making the process of converting timestamps aware of the context the timestamps are from (e.g. "coming from some frame timestamp").

However, this specific issue was only *exposed* by this commit, and not solely caused by it. Its root cause was just that the "current video position" marker on the audio display would mark the *exact* time of the current video frame, rather than the ideal start/end time for a line to start/end at that video frame. This is why only snapping to the "current video position" broke while snapping to keyframes worked fine. It's quite possible that snapping to the "current video frame" marker was just never thought of as a use case.

So, for now, TypesettingTools/Aegisub#421 can just be fixed by positioning the "current video position" marker in the middle of the frame rather than at the frame's exact start, and
5d4973a5f64c54a6a3a84278f385d2d474cfa5ab can be untangled at some later time.

Fixes TypesettingTools/Aegisub#421.

---

Still need to decide how to handle the fact that keyframe markers and current frame markers may now overlap.