### PR TITLE
fix: delay crash writer initialization

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -156,7 +156,6 @@ bool AegisubApp::OnInit() {
 	});
 
 	config::path = new agi::Path;
-	crash_writer::Initialize(config::path->Decode("?user"));
 
 	agi::log::log = new agi::log::LogSink;
 #ifdef _DEBUG
@@ -175,12 +174,12 @@ bool AegisubApp::OnInit() {
 		// Local config, make ?user mean ?data so all user settings are placed in install dir
 		config::path->SetToken("?user", config::path->Decode("?data"));
 		config::path->SetToken("?local", config::path->Decode("?data"));
-		crash_writer::Initialize(config::path->Decode("?user"));
 	} catch (agi::fs::FileSystemError const&) {
 		// File doesn't exist or we can't read it
 		// Might be worth displaying an error in the second case
 	}
 #endif
+	crash_writer::Initialize(config::path->Decode("?user"));
 
 	StartupLog("Create log writer");
 	auto path_log = config::path->Decode("?user/log/");


### PR DESCRIPTION
Delay crash writer initialization until after Windows portable configuration detection has completed.

On Windows, portable mode is detected by loading `?data/config.json`, then remapping `?user` and `?local` to `?data`. The crash writer was initialized before that remap, which created `%APPDATA%\Aegisub\crashdumps` even for portable installs. If portable config was found, it was then initialized again under the portable directory.

This change initializes the crash writer once, after the portable path decision, so it uses the final `?user` path.

Fix #612 .