### PR TITLE
[macOS] Update LSArchitecturePriority in Info.plist

### DIFF
--- a/packages/osx_bundle/Contents/Info.plist
+++ b/packages/osx_bundle/Contents/Info.plist
@@ -35,11 +35,10 @@
     <key>CFBundleLongVersionString</key>
     <string>@PLIST_VERSION@, Copyright 2005-2014, aegisub https://aegisub.org/</string>
 
-    <!-- Values: i386, ppc, x86_65, ppc64 -->
+    <!-- Values: i386, x86_64, arm64, arm64e -->
     <key>LSArchitecturePriority</key>
     <array>
-        <string>x86_64</string>
-        <string>i386</string>
+        <string>arm64</string>
     </array>
 
 	<!-- Target platform -->

--- a/packages/osx_bundle/Contents/Info.plist
+++ b/packages/osx_bundle/Contents/Info.plist
@@ -39,7 +39,7 @@
     <key>LSArchitecturePriority</key>
     <array>
         <string>arm64</string>
-		<string>x86_64</string>
+        <string>x86_64</string>
     </array>
 
 	<!-- Target platform -->

--- a/packages/osx_bundle/Contents/Info.plist
+++ b/packages/osx_bundle/Contents/Info.plist
@@ -39,6 +39,7 @@
     <key>LSArchitecturePriority</key>
     <array>
         <string>arm64</string>
+		<string>x86_64</string>
     </array>
 
 	<!-- Target platform -->


### PR DESCRIPTION
In macOS 27 the system will report any apps that are for x86 and will be opened with Rosetta. 

Even though Aegisub has Arm-native builds in GitHub Actions, they are being reported as x86 applications.

<img width="528" height="268" alt="Screenshot 2026-06-23 at 12 42 34" src="https://github.com/user-attachments/assets/dd1f04f4-9052-481c-88d2-141923baa3d8" /><br>

The reason for this is likely [`LSArchitecturePriority`](https://developer.apple.com/documentation/bundleresources/information-property-list/lsarchitecturepriority) in the `Info.plist`. 

`LSArchitecturePriority` does what it sounds like: it specifies a priority list for which CPU architecture to run first, and will then fall back to the next one. It applies for both binaries as well as scripts, as scripts will be run using an x86 or arm64 terminal in the background. 

The `LSArchitecturePriority` in Aegisub has not been updated since the PPC & x86 universal binary transition, and is telling macOS to load x86_64 first, i386 second and then fall back to whatever it can find (supposedly PPC or in this case arm64). 

```
<!-- Values: i386, ppc, x86_65, ppc64 -->
<key>LSArchitecturePriority</key>
<array>
    <string>x86_64</string>
    <string>i386</string>
</array>
```

This PR changes the priority to `arm64`, and then x86_64 as a fallback. 

Edit: I added x86_64 as a fallback after Arm because the default is 32-bit.

Note: This change is only preferable if the intention is to release a universal binary for future releases. If the intention is to have separate Arm and x86 builds then it would be easier just to remove `LSArchitecturePriority` altogether. 
