### PR TITLE
Update Windows installer license year to 2026

### DIFF
--- a/packages/win_installer/license.txt
+++ b/packages/win_installer/license.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2005-2020, the Aegisub Team.
+Copyright (c) 2005-2026, the Aegisub Team.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
This PR simply updates the copyright year in the Windows installer license text (`Aegisub/packages/win_installer/license.txt`) from 2020 to 2026 to reflect the current year.