### PR TITLE
Update Inno Setup Chinese language paths

### DIFF
--- a/packages/win_installer/fragment_setupbase.iss
+++ b/packages/win_installer/fragment_setupbase.iss
@@ -60,6 +60,8 @@ Name: "pt_PT"; MessagesFile: "compiler:Languages\Portuguese.isl"
 Name: "ru"; MessagesFile: "compiler:Languages\Russian.isl"
 Name: "tr"; MessagesFile: "compiler:Languages\Turkish.isl"
 Name: "uk_UA"; MessagesFile: "compiler:Languages\Ukrainian.isl"
+Name: "zh_CN"; MessagesFile: "compiler:Languages\ChineseSimplified.isl"
+Name: "zh_TW"; MessagesFile: "compiler:Languages\ChineseTraditional.isl"
 #ifdef UNOFFICIAL_LANGUAGES
 ; These languages are not shipped with InnoSetup by default and would need to be fetched from https://jrsoftware.org/files/istrans/
 Name: "el"; MessagesFile: {#DEPS_DIR}\innosetup-langs\Greek.isl
@@ -68,8 +70,6 @@ Name: "gl"; MessagesFile: {#DEPS_DIR}\innosetup-langs\Galician.isl
 Name: "id"; MessagesFile: {#DEPS_DIR}\innosetup-langs\Indonesian.isl
 Name: "sr_RS"; MessagesFile: {#DEPS_DIR}\innosetup-langs\SerbianCyrillic.isl
 Name: "sr_RS_latin"; MessagesFile: {#DEPS_DIR}\innosetup-langs\SerbianLatin.isl
-Name: "zh_CN"; MessagesFile: {#DEPS_DIR}\innosetup-langs\ChineseSimplified.isl
-Name: "zh_TW"; MessagesFile: {#DEPS_DIR}\innosetup-langs\ChineseTraditional.isl
 #endif
 
 [Files]

--- a/packages/win_installer/fragment_strings.iss
+++ b/packages/win_installer/fragment_strings.iss
@@ -1,46 +1,50 @@
-﻿[CustomMessages]
+[CustomMessages]
 InstallRuntime=Installing runtime libraries...
 pt_PT.InstallRuntime=A instalar livrarias de runtime...
 uk_UA.InstallRuntime=Встановлюю бібліотеки реального часу...
+tr.InstallRuntime=Çalışma zamanı kütüphaneleri yükleniyor...
+zh_CN.InstallRuntime=正在安装运行库……
+zh_TW.InstallRuntime=正在安裝運行庫……
 #ifdef UNOFFICIAL_LANGUAGES
 el.InstallRuntime=Εγκατάσταση βιβλιοθηκών...
 eu.InstallRuntime=Runtime liburutegiak ezartzen...
 id.InstallRuntime=Memasang runtime libraries...
-zh_CN.InstallRuntime=正在安装运行库……
-zh_TW.InstallRuntime=正在安裝運行庫……
 #endif
 
 StartMenuIcon=Create a start menu icon
 pt_PT.StartMenuIcon=Criar ícone no menu iniciar
 uk_UA.StartMenuIcon=Створити піктограму в меню Запустити
+tr.StartMenuIcon=Başlat menüsü kısayolu oluştur
+zh_CN.StartMenuIcon=创建开始菜单图标
+zh_TW.StartMenuIcon=創建開始功能表圖示
 #ifdef UNOFFICIAL_LANGUAGES
 el.StartMenuIcon=Δημιουργία εικονιδίου στο μενού έναρξης
 eu.StartMenuIcon=Sortu hasiera menuko ikur bat
 id.StartMenuIcon=Buat ikon di menu awal
-zh_CN.StartMenuIcon=创建开始菜单图标
-zh_TW.StartMenuIcon=創建開始功能表圖示
 #endif
 
 CheckForUpdates=Automatically check for new versions of Aegisub
 pt_PT.CheckForUpdates=Verifica automaticamente a existência de novas versões do Aegisub
 uk_UA.CheckForUpdates=Автоматично перевіряти Aegisub на нові версії
+tr.CheckForUpdates=Aegisub'ın yeni sürümlerini otomatik denetle
+zh_CN.CheckForUpdates=自动检查Aegisub的新版本
+zh_TW.CheckForUpdates=自動檢查Aegisub的新版本
 #ifdef UNOFFICIAL_LANGUAGES
 el.CheckForUpdates=Αυτόματος έλεγχος για καινούριες εκδόσεις του Aegisub
 eu.CheckForUpdates=Berezgaitasunez egiaztatu Aegisub-ren bertsio berririk dagoen
 id.CheckForUpdates=Otomatis cek versi terbaru Aegisub
-zh_CN.CheckForUpdates=自动检查Aegisub的新版本
-zh_TW.CheckForUpdates=自動檢查Aegisub的新版本
 #endif
 
 UpdatesGroup=Update Checker:
 pt_PT.UpdatesGroup=Verificar Actualizações:
 uk_UA.UpdatesGroup=Модуль Перевірки на Оновлення:
+tr.UpdatesGroup=Güncelleme Denetleyicisi:
+zh_CN.UpdatesGroup=自动更新：
+zh_TW.UpdatesGroup=自動更新：
 #ifdef UNOFFICIAL_LANGUAGES
 el.UpdatesGroup=Έλεγχος Ενημερώσεων:
 eu.UpdatesGroup=Eguneraketa Egiaztatzailea:
 id.UpdatesGroup=Pemeriksa Pembaharuan
-zh_CN.UpdatesGroup=自动更新：
-zh_TW.UpdatesGroup=自動更新：
 #endif
 
 ; Replacement for License page, no need to bother the user with legal mumbo-jumbo
@@ -48,10 +52,11 @@ zh_TW.UpdatesGroup=自動更新：
 WelcomeLabel2=This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code.
 pt_PT.WelcomeLabel2=Irá ser instalado no seu computador a versão {#BUILD_GIT_VERSION_STRING} do Aegisub.%n%nO Aegisub está protegido sob a Licença Pública Geral GNU (GPL version 2). O que significa que poderá fazer uso da aplicação para qualquer propósito, sem que seja cobrado, mas não serão dadas quaisquer tipos de garantias.%n%nVeja a página do Aegisub para mais informações sobre como obter o código-fonte.
 uk_UA.WelcomeLabel2=Зараз буде встанвлено Aegisub {#BUILD_GIT_VERSION_STRING} на ваш комп'ютер.%n%nAegisub захищено універсальною громадською ліцензією GNU, версія 2. Це означає, що ви можете використосувати цю програму для будь яких цілей безкоштовно, але, в будь-якому випадку, ми не даємо жодних гарантій.%n%nДивіться сайт Aegisub для інформації щодо отримання вихідного коду.
+tr.WelcomeLabel2=Bu program, bilgisayarınıza Aegisub {#BUILD_GIT_VERSION_STRING} sürümünü kuracaktır.%n%nAegisub, GNU Genel Kamu Lisansı sürüm 2 altındadır. Bu, uygulamayı herhangi bir amaçla ücretsiz olarak kullanabileceğiniz, ancak hiçbir garanti verilmediği anlamına gelir.%n%nKaynak kodunu edinme hakkında bilgi için Aegisub web sitesine bakabilirsiniz.
+zh_CN.WelcomeLabel2=将会在您的电脑上安装Aegisub {#BUILD_GIT_VERSION_STRING} 。%n%n Aegisub适用于GNU通用公共许可证第二版(GPLv2)，这意味着您可以将该应用程序用于任何目的而不需要支付费用，但同时也不会得到任何形式的担保。%n%n您可以到Aegisub官网获取源代码信息。
+zh_TW.WelcomeLabel2=將會在您的電腦上安裝Aegisub {#BUILD_GIT_VERSION_STRING} 。%n%n Aegisub適用於GNU通用公共許可證第二版(GPLv2)，這意味著您可以將該應用程式用於任何目的而不需要支付費用，但同時也不會得到任何形式的擔保。%n%n您可以到Aegisub官網獲取原始程式碼資訊。
 #ifdef UNOFFICIAL_LANGUAGES
 el.WelcomeLabel2=Αυτό θα εγκαταστήσει το Aegisub {#BUILD_GIT_VERSION_STRING} στον υπολογιστή σας.%n%nΤο Aegisub καλύπτεται από τον άδεια GNU General Public License version 2. Αυτό σημαίνει ότι μπορείτε να χρησιμοποιήσετε την εφαρμογή για κάθε σκοπό χωρίς χρέωση, αλλά δεν υπάρχουν εγγυήσεις καμίας φύσης.%n%nΔείτε την ιστοσελίδα του Aegisub για πληροφορίες σχετικά με την απόκτηση του πηγαίου κώδικα.
 eu.WelcomeLabel2=Honek Aegisub {#BUILD_GIT_VERSION_STRING} ezarriko du zure ordenagailuan.%n%nAegisub GNU Baimen Publiko Orokorra 2. bertsioa Baimenak estalia dago. Honek esanahi du aplikazio hau edozein asmotarako erabili dezakezula ordaindu behar izan gabe, baina ez da inolako berme motarik ematen.%n%nIkusi Aegisub webgunea iturburu kodea lortzeko argibideetarako.
 id.WelcomeLabel2=Ini akan memasang Aegisub {#BUILD_GIT_VERSION_STRING} di komputer Anda.%n%nAegisub dilindungi oleh Lisensi Publik Umum GNU versi 2. Artinya Anda bisa menggunakan aplikasi ini untuk tujuan apa pun tanpad dipungut biaya, tapi tidak ada jaminan yang bisa diberikan.%n%nLihat laman situs Aegisub untuk memperoleh informasi sumber kode.
-zh_CN.WelcomeLabel2=将会在您的电脑上安装Aegisub {#BUILD_GIT_VERSION_STRING} 。%n%n Aegisub适用于GNU通用公共许可证第二版(GPLv2)，这意味着您可以将该应用程序用于任何目的而不需要支付费用，但同时也不会得到任何形式的担保。%n%n您可以到Aegisub官网获取源代码信息。
-zh_TW.WelcomeLabel2=將會在您的電腦上安裝Aegisub {#BUILD_GIT_VERSION_STRING} 。%n%n Aegisub適用於GNU通用公共許可證第二版(GPLv2)，這意味著您可以將該應用程式用於任何目的而不需要支付費用，但同時也不會得到任何形式的擔保。%n%n您可以到Aegisub官網獲取原始程式碼資訊。
 #endif

--- a/tools/win-installer-setup.ps1
+++ b/tools/win-installer-setup.ps1
@@ -97,8 +97,6 @@ if (!(Test-Path innosetup-langs)) {
 	Invoke-WebRequest https://raw.github.com/jrsoftware/issrc/is-6_7_3/Files/Languages/Unofficial/Indonesian.isl -OutFile innosetup-langs/Indonesian.isl -UseBasicParsing
 	Invoke-WebRequest https://raw.github.com/jrsoftware/issrc/is-6_7_3/Files/Languages/Unofficial/SerbianCyrillic.isl -OutFile innosetup-langs/SerbianCyrillic.isl -UseBasicParsing
 	Invoke-WebRequest https://raw.github.com/jrsoftware/issrc/is-6_7_3/Files/Languages/Unofficial/SerbianLatin.isl -OutFile innosetup-langs/SerbianLatin.isl -UseBasicParsing
-	Invoke-WebRequest https://raw.github.com/jrsoftware/issrc/is-6_7_3/Files/Languages/Unofficial/ChineseSimplified.isl -OutFile innosetup-langs/ChineseSimplified.isl -UseBasicParsing
-	Invoke-WebRequest https://raw.github.com/jrsoftware/issrc/is-6_7_3/Files/Languages/Unofficial/ChineseTraditional.isl -OutFile innosetup-langs/ChineseTraditional.isl -UseBasicParsing
 }
 
 # Aegisub localization


### PR DESCRIPTION
The Windows installer build was failing with a `Couldn't open include file` error for `ChineseSimplified.isl`. This happened because upstream Inno Setup recently moved the Simplified and Traditional Chinese translations from the `Unofficial` directory to the official languages list. 

This PR updates the build scripts to reflect these upstream changes. 

**Status: Draft / Waiting for Upstream Release**
This PR is currently opened as a draft because it does not fully resolve the `meson-internal__win-installer` build failure on its own yet. The CI environment pulls the current stable release of Inno Setup, which does not yet include these newly moved files in its official directory. 

I am keeping this PR as a draft for now. I will update its status to "ready for review" once a new stable Inno Setup version containing these official languages is released and available in the CI.