### PR TITLE
[macOS] Remove LSArchitecturePriority from Info.plist

### DIFF
--- a/packages/osx_bundle/Contents/Info.plist
+++ b/packages/osx_bundle/Contents/Info.plist
@@ -35,13 +35,6 @@
     <key>CFBundleLongVersionString</key>
     <string>@PLIST_VERSION@, Copyright 2005-2014, aegisub https://aegisub.org/</string>
 
-    <!-- Values: i386, ppc, x86_65, ppc64 -->
-    <key>LSArchitecturePriority</key>
-    <array>
-        <string>x86_64</string>
-        <string>i386</string>
-    </array>
-
 	<!-- Target platform -->
 	<key>CFBundleSupportedPlatforms</key>
 	<array>


### PR DESCRIPTION
 [`LSArchitecturePriority`](https://developer.apple.com/documentation/bundleresources/information-property-list/lsarchitecturepriority) is only used for Universal binaries. 

Since Aegisub is currently not being built as a universal binary, it is not necessary. 

This should fix an issue where the Arm builds are being identified as x86 on macOS 27.

Edit: Supersedes #618 