### PR TITLE
CI: Silence Homebrew trust warnings by untapping aws

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,8 @@ jobs:
         run: |
           export HOMEBREW_NO_INSTALL_CLEANUP=1
           export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
+          # Untap aws to silence Homebrew trust warnings
+          brew untap aws/tap
           # Skip brew update for now, see https://github.com/actions/setup-python/issues/577
           # brew update
           brew install ninja


### PR DESCRIPTION
This silences 8 warnings generated by homebrew. 

Aws is pre-installed in the Github runner, and should not be required for building Aegisub.