### PR TITLE
CI: Silence warning by changing MSVC setup repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,8 @@ jobs:
       - name: Setup MSVC
         if: matrix.config.os == 'windows-latest' && matrix.config.msvc == true
         uses: TheMrMilchmann/setup-msvc-dev@v4
+        with:
+          arch: x64
 
       - name: Install dependencies (Windows)
         if: matrix.config.os == 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Setup MSVC
         if: matrix.config.os == 'windows-latest' && matrix.config.msvc == true
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: TheMrMilchmann/setup-msvc-dev@v4
 
       - name: Install dependencies (Windows)
         if: matrix.config.os == 'windows-latest'


### PR DESCRIPTION
This follows on from #623 aimed at silencing GitHub actions warnings, but I made this PR separate because it has some security implications.

This changes the [`ilammy/msvc-dev-cmd`](https://github.com/ilammy/msvc-dev-cmd) action to the [`TheMrMilchmann/setup-msvc-dev`](https://github.com/TheMrMilchmann/setup-msvc-dev) fork. 

The original `ilammy` action has not been updated in several years, and is using `Node.js 20` which will be disabled soon. A [PR has been opened](https://github.com/ilammy/msvc-dev-cmd/pull/106) that updates it, but the original developer is not responsive. 

The `TheMrMilchmann` fork is actively maintained and should be a drop-in replacement. 

The reason I separated this PR out is that changing the repo used is a security issue, and the new repo should be reviewed by anyone concerned.