### PR TITLE
ci: Retry entire osx-build-dmg task up to 10 times

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,18 @@ jobs:
         if: startsWith(matrix.config.os, 'macos-')
         run: |
           meson compile osx-bundle -C build
-          meson compile osx-build-dmg -C build
+
+          # Run osx-build-dmg but retry up to 10 times if it fails since hdiutil can be unreliable
+          # See: https://github.com/actions/runner-images/issues/7522
+          max_tries=10
+          i=0
+          until meson compile osx-build-dmg -C build ; do
+            if [ $i -eq $max_tries ]; then
+              echo "Error: osx-build-dmg failed after ${max_tries} tries."
+              exit 1
+            fi
+            i=$((i+1))
+          done
 
       - name: Upload artifacts - macOS dmg
         uses: actions/upload-artifact@v6

--- a/tools/osx-dmg.sh
+++ b/tools/osx-dmg.sh
@@ -50,15 +50,7 @@ cp -v "${SRC_DIR}/packages/osx_bundle/Contents/Resources/Aegisub.icns" "${DMG_TM
 
 echo
 echo "---- Creating image ----"
-max_tries=10
-i=0
-until /usr/bin/hdiutil create -srcfolder "${DMG_TMP_DIR}" -volname "${PKG_NAME}" -fs HFS+ -fsargs "-c c=64,a=16,e=16" -format UDRW "${DMG_RW_PATH}"; do
-  if [ $i -eq $max_tries ]; then
-    echo "Error: hdiutil failed after ${max_tries} tries."
-    exit 1
-  fi
-  i=$((i+1))
-done
+/usr/bin/hdiutil create -srcfolder "${DMG_TMP_DIR}" -volname "${PKG_NAME}" -fs HFS+ -fsargs "-c c=64,a=16,e=16" -format UDRW "${DMG_RW_PATH}"
 
 echo
 echo "---- Mounting image ----"


### PR DESCRIPTION
Commit 1b2dd29e8298270a96659082f3afffd06e9f9517 made the `hdiutil create` command be retried up to 10 times to fix it occasionally failing on the CI, but missed other hdiutil calls that also frequently fail.

This commit reverts 1b2dd29e8298270a96659082f3afffd06e9f9517 and instead retries the entire osx-build-dmg step in the CI up to 10 times. This also has the advantage of keeping this workaround contained in ci.yml.