### PR TITLE
Fix UB on `Comment:`/`Dialogue:` lines in ASS files

### DIFF
--- a/src/ass_dialogue.cpp
+++ b/src/ass_dialogue.cpp
@@ -87,11 +87,13 @@ void AssDialogue::Parse(std::string const& raw) {
 	std::string_view str = raw;
 	if (raw.starts_with("Dialogue:")) {
 		Comment = false;
-		str.remove_prefix(10);
+		// Strip one more byte (if it exists).
+		str.remove_prefix(std::min<size_t>(raw.size(), 10));
 	}
 	else if (raw.starts_with("Comment:")) {
 		Comment = true;
-		str.remove_prefix(9);
+		// Strip one more byte (if it exists).
+		str.remove_prefix(std::min<size_t>(raw.size(), 9));
 	}
 	else
 		throw SubtitleFormatParseError("Failed parsing line: " + raw);


### PR DESCRIPTION
Found using an LLM when looking for security vulnerabilities. Not really relevant for security.

I opted for the minimum changes that (likely) don't change existing behavior — if you prefer, we could also check whether the next character is whitespace or not.