### PR TITLE
ci: Remove brew workaround on mac

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,10 +118,7 @@ jobs:
       - name: Install dependencies (MacOS)
         if: startsWith(matrix.config.os, 'macos-')
         run: |
-          export HOMEBREW_NO_INSTALL_CLEANUP=1
-          export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
-          # Skip brew update for now, see https://github.com/actions/setup-python/issues/577
-          # brew update
+          brew update
           brew install ninja
           brew install libass zlib ffms2 fftw hunspell
           brew install pulseaudio  # NO OpenAL in github CI


### PR DESCRIPTION
It's not fully clear if this issue is still present or not, but either way, the current workaround causes warnings due to HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 and the issue threads in question offer more robust workarounds.

Remove this workaround for now and see what happens. If the issue still happens, one of the other workarounds can be applied.

This reverts commit 09e8d0a08732f476ad48034859b0a462becb9b80.