### PR TITLE
ci: Manually set up VS developer shell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
           - name: Windows MSVC Release
             os: windows-latest
             msvc: true
+            devenv: |
+              Import-Module "$env:VS\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+              Enter-VsDevShell -VsInstallPath $env:VS -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64"
             buildtype: release
             args: >-
               -Ddefault_library=static
@@ -91,9 +94,15 @@ jobs:
           python -m pip install --upgrade pip setuptools
           pip install meson
 
-      - name: Setup MSVC
-        if: matrix.config.os == 'windows-latest' && matrix.config.msvc == true
-        uses: ilammy/msvc-dev-cmd@v1
+        # Taken from https://github.com/libass/libass/blob/0.17.5/.github/workflows/meson.yml#L118-L125
+      - name: Find Visual Studio
+        if: matrix.config.msvc
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          if (-not $vsPath) { throw "Could not find a Visual Studio installation" }
+          "VS=$vsPath"
+          "VS=$vsPath" >> $env:GITHUB_ENV
 
       - name: Install dependencies (Windows)
         if: matrix.config.os == 'windows-latest'
@@ -133,25 +142,34 @@ jobs:
           sudo apt-get install ninja-build build-essential libx11-dev libfreetype6-dev pkg-config libfontconfig1-dev libass-dev libasound2-dev libffms2-dev intltool libboost-all-dev libhunspell-dev libcurl4-openssl-dev libuchardet-dev libgtest-dev libgmock-dev libwxgtk3.2-dev libportal-gtk3-dev
 
       - name: Configure
-        run: meson setup build ${{ matrix.config.args }} -Dbuildtype=${{ matrix.config.buildtype }} ${{ github.ref_type == 'tag' && '-Dofficial_release=true' || '' }}
+        run: |
+          ${{ matrix.config.devenv }}
+          meson setup build ${{ matrix.config.args }} -Dbuildtype=${{ matrix.config.buildtype }} ${{ github.ref_type == 'tag' && '-Dofficial_release=true' || '' }}
 
       - name: Build
-        run: meson compile -C build
+        run: |
+          ${{ matrix.config.devenv }}
+          meson compile -C build
 
       - name: Run test
-        run: meson test -C build --verbose "gtest main"
+        run: |
+          ${{ matrix.config.devenv }}
+          meson test -C build --verbose "gtest main"
 
       # Windows artifacts
       - name: Generate Windows installer
         if: matrix.config.os == 'windows-latest'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run:
+        run: |
+          ${{ matrix.config.devenv }}
           meson compile win-installer -C build
 
       - name: Generate Windows portable installer
         if: matrix.config.os == 'windows-latest'
-        run: cd build && ninja win-portable
+        run: |
+          ${{ matrix.config.devenv }}
+          cd build && ninja win-portable
 
       - name: Upload artifacts - win_installer
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
The ilammy/msvc-dev-cmd action has been unmaintained for a couple of years now, and GitHub has been showing warnings due to it using a deprecated Node version.

Some forks exist, but in light of GHA supply chain attacks having become an almost weekly occurrence, it's probably safer to just set up the VS developer shell manually, which only takes a couple of lines of magic code.

This is mostly copied from libass's workflow:
https://github.com/libass/libass/blob/0.17.5/.github/workflows/meson.yml