### PR TITLE
Update project properties when saving files

### DIFF
--- a/src/project.cpp
+++ b/src/project.cpp
@@ -162,6 +162,11 @@ void Project::LoadSubtitles(agi::fs::path path, std::string encoding, bool load_
 		LoadUnloadFiles(properties);
 }
 
+void Project::SetSubtitlesFilename(agi::fs::path path) {
+	context->path->SetToken("?script", path.parent_path());
+	UpdateRelativePaths();
+}
+
 void Project::CloseSubtitles() {
 	context->subsController->Close();
 	context->path->SetToken("?script", "");

--- a/src/project.h
+++ b/src/project.h
@@ -69,6 +69,7 @@ public:
 	~Project();
 
 	void LoadSubtitles(agi::fs::path path, std::string encoding="", bool load_linked=true);
+	void SetSubtitlesFilename(agi::fs::path path);
 	void CloseSubtitles();
 	bool CanLoadSubtitlesFromVideo() const { return video_has_subtitles; }
 

--- a/src/subs_controller.cpp
+++ b/src/subs_controller.cpp
@@ -209,7 +209,7 @@ void SubsController::Save(agi::fs::path const& filename, const char *encoding) {
 		// Have to set this now for the sake of things that want to save paths
 		// relative to the script in the header
 		this->filename = filename;
-		context->path->SetToken("?script", filename.parent_path());
+		context->project->SetSubtitlesFilename(filename);
 
 		context->ass->CleanExtradata();
 		writer->WriteFile(context->ass.get(), filename, 0, encoding);


### PR DESCRIPTION
Otherwise, if the file is saved in a different directory than before (say, using "Save as" or when loading subtitles from a video file and then saving them in a different directory than the video file), the relative paths aren't updated to reflect the new directory.

The deeper issue here is that the project.cpp / subs_controller.cpp / ass_file.cpp split is very messy, with various state being split or duplicated across the three and sometimes going out of sync, but this fix should cover most cases.