### PR TITLE
Make lfs.dir error out when the directory can't be opened

### DIFF
--- a/automation/tests/modules/lfs.moon
+++ b/automation/tests/modules/lfs.moon
@@ -85,3 +85,16 @@ describe 'lfs', ->
       os.remove name .. '/a'
       os.remove name .. '/b'
       lfs.rmdir name
+
+    it 'should error for a nonexistent path like vanilla lfs', ->
+      ok, err = pcall -> lfs.dir temp_name!
+      assert.is.false ok
+      assert.is.truthy err\find 'cannot open', 1, true
+
+    it 'should error when given a file rather than a directory', ->
+      name = temp_name!
+      lfs.touch name
+      ok, err = pcall -> lfs.dir name
+      assert.is.false ok
+      assert.is.truthy err\find 'cannot open', 1, true
+      os.remove name

--- a/libaegisub/lua/modules/lfs.cpp
+++ b/libaegisub/lua/modules/lfs.cpp
@@ -18,6 +18,8 @@
 #include "libaegisub/lua/ffi.h"
 
 #include <chrono>
+#include <stdexcept>
+#include <system_error>
 
 using namespace agi::fs;
 using namespace agi::lua;
@@ -94,6 +96,13 @@ void dir_free(DirectoryIterator *it, char **) {
 
 DirectoryIterator *dir_new(const char *path, char **err) {
 	return wrap(err, [=]{
+		// DirectoryIterator deliberately swallows open failures, so probe the
+		// path ourselves first: lfs.dir must raise when the directory can't
+		// be opened
+		std::error_code ec;
+		sfs::directory_iterator(agi::fs::path(path), ec);
+		if (ec)
+			throw std::runtime_error("cannot open " + std::string(path) + ": " + ec.message());
 		return new DirectoryIterator(path, "");
 	});
 }


### PR DESCRIPTION
Vanilla luafilesystem raises `cannot open <path>: <reason>` immediately when `lfs.dir` is called on a directory that can't be opened, but both platform implementations of `DirectoryIterator` swallow the failure and produce a silent empty iteration. Since `require 'lfs'` in automation scripts transparently resolves to `aegisub.lfs`, scripts using `pcall lfs.dir` to detect missing or unreadable directories take the wrong branch under Aegisub.

The check lives in `dir_new` rather than `DirectoryIterator` itself, since the rest of the app plausibly relies on silently scanning possibly-missing directories. The probed path is wrapped in `agi::fs::path` so UTF-8 paths survive on Windows (same treatment as #666), and the error message format matches vanilla lfs. This also makes the error path in `lfs.moon`'s `dir` reachable — previously dead code on every platform, which is how the swapped `error()` arguments fixed in #657 went unnoticed for so long.