### PR TITLE
Keep the Select Lines dialog open when no lines match

### DIFF
--- a/src/dialog_selection.cpp
+++ b/src/dialog_selection.cpp
@@ -246,7 +246,7 @@ void DialogSelection::Process(wxCommandEvent& event) {
 		new_active = *new_sel.begin();
 	con->selectionController->SetSelectionAndActive(std::move(new_sel), new_active);
 
-	if (event.GetId() == wxID_OK) Close();
+	if (count && event.GetId() == wxID_OK) Close();
 }
 
 void DialogSelection::OnDialogueCheckbox(wxCheckBox *chk) {


### PR DESCRIPTION
## Summary
- `DialogSelection::Process` closed the dialog unconditionally on OK, even when the search/action changed nothing (`count == 0`) — right after showing a message box saying so. That forced the user to reopen the dialog and redo the search from scratch after any typo or unchecked option.
- Only close the dialog when the selection actually changed; otherwise leave it open so the user can adjust the criteria in place.

Fixes #349

## Test plan
- [x] Read the code path in `src/dialog_selection.cpp` to confirm `count` is 0 exactly when the message box reports no lines were set/added/removed, for every `Action` branch (SET/ADD/SUB/INTERSECT).
- [ ] Manual: Subtitle > Select Lines..., search for text that matches nothing, press OK — dialog should stay open instead of closing.