### PR TITLE
MatroskaParser: fix hardcoded 32-track ceiling and its silent failure

### DIFF
--- a/src/MatroskaParser.c
+++ b/src/MatroskaParser.c
@@ -145,6 +145,10 @@ struct Queue {
 };
 
 #define	MPF_ERROR 0x10000
+// Sticky: set when a file exceeds MAX_TRACKS. Unlike MPF_ERROR, this
+// survives parseSegment/parsePointers's tolerant local setjmp/longjmp
+// recovery, so parseFile can still report it after the fact.
+#define	MPF_TRACKLIMIT 0x20000
 #define	IBSZ	  1024
 
 #define	RBRESYNC  1
@@ -1278,8 +1282,10 @@ static void parseTrackEntry(MatroskaFile *mf,uint64_t toplen) {
   size_t	    cplen = 0, cslen = 0, cpadd = 0;
   unsigned	    CompScope, num_comp = 0;
 
-  if (mf->nTracks >= MAX_TRACKS)
+  if (mf->nTracks >= MAX_TRACKS) {
+    mf->flags |= MPF_TRACKLIMIT;
     errorjmp(mf,"Too many tracks.");
+  }
 
   // clear track info
   memset(&t,0,sizeof(t));
@@ -2733,6 +2739,14 @@ segment:
   } else
     mf->pSegmentTop = mf->pSegment + len;
   parseSegment(mf,len);
+
+  // parseSegment/parsePointers may have silently swallowed a "too many
+  // tracks" error while tolerating other recoverable errors around it;
+  // MPF_TRACKLIMIT survives that so we can still report it here, at a
+  // point with no local setjmp scope of our own, so this always reaches
+  // mkv_OpenEx's outer setjmp.
+  if (mf->flags & MPF_TRACKLIMIT)
+    errorjmp(mf,"File contains more than %u tracks.",(unsigned)MAX_TRACKS);
 
   // check if we got all data
   if (!mf->seen.SegmentInfo)

--- a/src/MatroskaParser.c
+++ b/src/MatroskaParser.c
@@ -203,7 +203,7 @@ struct MatroskaFile {
   struct QueueEntry **QBlocks;
   struct Queue	    *Queues;
   uint64_t	    readPosition;
-  unsigned int	    trackMask;
+  long		    selectedTrack; // -1 = no filter (keep all tracks), else the one kept track index
   uint64_t	    pSegmentTop;  // offset of next byte after the segment
   uint64_t	    tcCluster;    // current cluster timecode
 
@@ -2163,7 +2163,7 @@ blockex:
 
       for (tracknum=0;tracknum<mf->nTracks;++tracknum)
 	if (mf->Tracks[tracknum]->Number == trackid) {
-	  if (mf->trackMask & (1<<tracknum)) // ignore this block
+	  if (mf->selectedTrack >= 0 && mf->selectedTrack != (long)tracknum) // ignore this block
 	    break;
 	  goto found;
 	}
@@ -2657,7 +2657,7 @@ ok:
     mf->readPosition = mf->Cues[mf->nCues - 1].Position + mf->pSegment;
     mf->tcCluster = mf->Cues[mf->nCues - 1].Time / mf->Seg.TimecodeScale;
   }
-  mf->trackMask = ~(1 << vtrack);
+  mf->selectedTrack = vtrack;
 
   do
     while (mf->Queues[vtrack].head)
@@ -2670,7 +2670,7 @@ ok:
     }
   while (fillQueues(mf,NULL) != EOF);
 
-  mf->trackMask = 0;
+  mf->selectedTrack = -1;
 
   EmptyQueues(mf);
 
@@ -2803,6 +2803,7 @@ MatroskaFile  *mkv_OpenEx(InputStream *io,
 
   mf->cache = io;
   mf->flags = flags;
+  mf->selectedTrack = -1;
   io->progress(io,0,0);
 
   if (setjmp(mf->jb)==0) {
@@ -2949,7 +2950,7 @@ void  mkv_Seek(MatroskaFile *mf,uint64_t timecode,unsigned flags) {
       if (setjmp(mf->jb)!=0)
 	return;
 
-      mkv_SetTrackMask(mf,mf->trackMask);
+      mkv_SetTrackMask(mf,mf->selectedTrack);
 
       if (flags & (MKVF_SEEK_TO_PREV_KEYFRAME | MKVF_SEEK_TO_PREV_KEYFRAME_STRICT)) {
 	// we do this in two stages
@@ -3007,7 +3008,7 @@ void  mkv_Seek(MatroskaFile *mf,uint64_t timecode,unsigned flags) {
 found:
   
 	  for (n=0;n<mf->nTracks;++n)
-	    if (!(mf->trackMask & (1<<n)) && m_kftime[n]==MAXU64 &&
+	    if ((mf->selectedTrack < 0 || mf->selectedTrack == (long)n) && m_kftime[n]==MAXU64 &&
 		m_seendf[n] && j>0)
 	    {
 	      // we need to restart the search from prev cue
@@ -3127,21 +3128,21 @@ int	      mkv_TruncFloat(MKFLOAT f) {
 
 #define	FTRACK	0xffffffff
 
-void	      mkv_SetTrackMask(MatroskaFile *mf,unsigned int mask) {
+void	      mkv_SetTrackMask(MatroskaFile *mf,long selectedTrack) {
   unsigned int	  i;
 
   if (mf->flags & MPF_ERROR)
     return;
 
-  mf->trackMask = mask;
+  mf->selectedTrack = selectedTrack;
 
   for (i=0;i<mf->nTracks;++i)
-    if (mask & (1<<i))
+    if (selectedTrack >= 0 && selectedTrack != (long)i)
       ClearQueue(mf,&mf->Queues[i]);
 }
 
 int	      mkv_ReadFrame(MatroskaFile *mf,
-			    unsigned int mask,unsigned int *track,
+			    long selectedTrack,unsigned int *track,
 			    uint64_t *StartTime,uint64_t *EndTime,
 			    uint64_t *FilePos,unsigned int *FrameSize,
 			    unsigned int *FrameFlags)
@@ -3154,7 +3155,7 @@ int	      mkv_ReadFrame(MatroskaFile *mf,
     return -1;
 
   for (i=0;i<mf->nTracks;++i)
-    skip[i] = (i<32 && (mask & (1u<<i))) ? 1 : 0;
+    skip[i] = (selectedTrack >= 0 && selectedTrack != (long)i) ? 1 : 0;
 
   do {
     // extract required frame, use block with the lowest timecode

--- a/src/MatroskaParser.c
+++ b/src/MatroskaParser.c
@@ -2477,7 +2477,7 @@ ex:
 
 // this is almost the same as readMoreBlocks, except it ensures
 // there are no partial frames queued, however empty queues are ok
-static int  fillQueues(MatroskaFile *mf,unsigned int mask) {
+static int  fillQueues(MatroskaFile *mf,const unsigned char *skip) {
   unsigned    i,j;
   int	      ret = 0;
 
@@ -2485,7 +2485,7 @@ static int  fillQueues(MatroskaFile *mf,unsigned int mask) {
     j = 0;
 
     for (i=0;i<mf->nTracks;++i)
-      if (mf->Queues[i].head && !(mask & (1<<i)))
+      if (mf->Queues[i].head && (!skip || !skip[i]))
 	++j;
 
     if (j>0) // have at least some frames
@@ -2494,7 +2494,7 @@ static int  fillQueues(MatroskaFile *mf,unsigned int mask) {
     if ((ret = readMoreBlocks(mf)) < 0) {
       j = 0;
       for (i=0;i<mf->nTracks;++i)
-	if (mf->Queues[i].head && !(mask & (1<<i)))
+	if (mf->Queues[i].head && (!skip || !skip[i]))
 	  ++j;
       if (j) // we adjusted some blocks
 	return 0;
@@ -2668,7 +2668,7 @@ ok:
 	nd = tc;
       QFree(mf,QGet(&mf->Queues[vtrack]));
     }
-  while (fillQueues(mf,0) != EOF);
+  while (fillQueues(mf,NULL) != EOF);
 
   mf->trackMask = 0;
 
@@ -2914,9 +2914,10 @@ uint64_t     mkv_GetSegmentTop(MatroskaFile *mf) {
 
 void  mkv_Seek(MatroskaFile *mf,uint64_t timecode,unsigned flags) {
   int		i,j,m,ret;
-  unsigned	n,z,mask;
+  unsigned	n,z;
   uint64_t	*m_kftime = alloca(mf->nTracks * sizeof(*m_kftime));
   unsigned char	*m_seendf = alloca(mf->nTracks * sizeof(*m_seendf));
+  unsigned char	*m_done = alloca(mf->nTracks);
 
   if (mf->flags & MKVF_AVOID_SEEKS)
     return;
@@ -2968,7 +2969,7 @@ void  mkv_Seek(MatroskaFile *mf,uint64_t timecode,unsigned flags) {
 	  mf->tcCluster = mf->Cues[j].Time;
 
 	  for (;;) {
-	    if ((ret = fillQueues(mf,0)) < 0 || ret == RBRESYNC)
+	    if ((ret = fillQueues(mf,NULL)) < 0 || ret == RBRESYNC)
 	      return;
 
 	    // drain queues until we get to the required timecode
@@ -3027,8 +3028,9 @@ again:;
       mf->readPosition = mf->Cues[j].Position + mf->pSegment;
       mf->tcCluster = mf->Cues[j].Time;
 
-      for (mask=0;;) {
-	if ((ret = fillQueues(mf,mask)) < 0 || ret == RBRESYNC)
+      memset(m_done,0,mf->nTracks);
+      for (;;) {
+	if ((ret = fillQueues(mf,m_done)) < 0 || ret == RBRESYNC)
 	  return;
 
 	// drain queues until we get to the required timecode
@@ -3041,7 +3043,7 @@ again:;
 	for (n=z=0;n<mf->nTracks;++n)
 	  if (m_kftime[n]==MAXU64 || (mf->Queues[n].head && mf->Queues[n].head->Start>=m_kftime[n])) {
 	    ++z;
-	    mask |= 1<<n;
+	    m_done[n] = 1;
 	  }
 
 	if (z==mf->nTracks)
@@ -3069,7 +3071,7 @@ void  mkv_SkipToKeyframe(MatroskaFile *mf) {
   do {
     wait = 0;
 
-    if (fillQueues(mf,0)<0)
+    if (fillQueues(mf,NULL)<0)
       return;
 
     for (n=0;n<mf->nTracks;++n)
@@ -3088,7 +3090,7 @@ void  mkv_SkipToKeyframe(MatroskaFile *mf) {
   do {
     wait = 0;
 
-    if (fillQueues(mf,0)<0)
+    if (fillQueues(mf,NULL)<0)
       return;
 
     for (n=0;n<mf->nTracks;++n)
@@ -3146,21 +3148,25 @@ int	      mkv_ReadFrame(MatroskaFile *mf,
 {
   unsigned int	    i,j;
   struct QueueEntry *qe;
+  unsigned char	    *skip = alloca(mf->nTracks);
 
   if (setjmp(mf->jb)!=0)
     return -1;
 
+  for (i=0;i<mf->nTracks;++i)
+    skip[i] = (i<32 && (mask & (1u<<i))) ? 1 : 0;
+
   do {
     // extract required frame, use block with the lowest timecode
     for (j=FTRACK,i=0;i<mf->nTracks;++i)
-      if (!(mask & (1<<i)) && mf->Queues[i].head) {
+      if (!skip[i] && mf->Queues[i].head) {
 	j = i;
 	++i;
 	break;
       }
 
     for (;i<mf->nTracks;++i)
-      if (!(mask & (1<<i)) && mf->Queues[i].head &&
+      if (!skip[i] && mf->Queues[i].head &&
 	  mf->Queues[j].head->Start > mf->Queues[i].head->Start)
 	j = i;
 
@@ -3182,7 +3188,7 @@ int	      mkv_ReadFrame(MatroskaFile *mf,
     if (mf->flags & MPF_ERROR)
       return -1;
 
-  } while (fillQueues(mf,mask)>=0);
+  } while (fillQueues(mf,skip)>=0);
 
   return EOF;
 }

--- a/src/MatroskaParser.c
+++ b/src/MatroskaParser.c
@@ -2915,8 +2915,8 @@ uint64_t     mkv_GetSegmentTop(MatroskaFile *mf) {
 void  mkv_Seek(MatroskaFile *mf,uint64_t timecode,unsigned flags) {
   int		i,j,m,ret;
   unsigned	n,z,mask;
-  uint64_t	m_kftime[MAX_TRACKS];
-  unsigned char	m_seendf[MAX_TRACKS];
+  uint64_t	*m_kftime = alloca(mf->nTracks * sizeof(*m_kftime));
+  unsigned char	*m_seendf = alloca(mf->nTracks * sizeof(*m_seendf));
 
   if (mf->flags & MKVF_AVOID_SEEKS)
     return;

--- a/src/MatroskaParser.c
+++ b/src/MatroskaParser.c
@@ -74,7 +74,10 @@
 
 #define	MAX_STRING_LEN	      1023
 #define	QSEGSIZE	      512
-#define	MAX_TRACKS	      32
+// Sanity ceiling only - Tracks[] grows dynamically via AGET/ArrayAlloc,
+// and nothing else sizes an array off this anymore. Just bounds memory
+// a corrupt/malicious file can force us to commit to.
+#define	MAX_TRACKS	      65536
 #define	MAX_READAHEAD	      (256*1024)
 
 #define	MAXCLUSTER	      (64*1048576)

--- a/src/MatroskaParser.h
+++ b/src/MatroskaParser.h
@@ -330,20 +330,18 @@ X int	      mkv_TruncFloat(MKFLOAT f);
 #define	FRAME_STREAM_MASK     0xff000000
 #define	FRAME_STREAM_SHIFT    24
 
-/* This sets the masking flags for the parser,
- *  masked tracks [with 1s in their bit positions]
- *  will be ignored when reading file data.
+/* Selects the single track to read; pass -1 to keep all tracks.
  * This call discards all parsed and queued frames
  */
-X void	      mkv_SetTrackMask(/* in */ MatroskaFile *mf,/* in */ unsigned int mask);
+X void	      mkv_SetTrackMask(/* in */ MatroskaFile *mf,/* in */ long selectedTrack);
 
 /* Read one frame from the queue.
- * mask specifies what tracks to ignore.
+ * selectedTrack limits reading to one track; pass -1 for no filter.
  * Returns -1 if there are no more frames in the specified
  * set of tracks, 0 on success
  */
 X int	      mkv_ReadFrame(/* in */  MatroskaFile *mf,
-			    /* in */  unsigned int mask,
+			    /* in */  long selectedTrack,
 			    /* out */ unsigned int *track,
 			    /* out */ uint64_t *StartTime /* in ns */,
 			    /* out */ uint64_t *EndTime /* in ns */,

--- a/src/mkv_wrap.cpp
+++ b/src/mkv_wrap.cpp
@@ -131,7 +131,7 @@ static bool read_subtitles(agi::ProgressSink *ps, MatroskaFile *file, MkvStdIO *
 
 	SrtTagParser srtParser;
 
-	while (mkv_ReadFrame(file, 0, &rt, &startTime, &endTime, &filePos, &frameSize, &frameFlags) == 0) {
+	while (mkv_ReadFrame(file, -1, &rt, &startTime, &endTime, &filePos, &frameSize, &frameFlags) == 0) {
 		if (ps->IsCancelled()) return true;
 		if (frameSize == 0) continue;
 
@@ -251,7 +251,7 @@ void MatroskaWrapper::GetSubtitles(agi::fs::path const& filename, AssFile *targe
 	}
 
 	// Picked track
-	mkv_SetTrackMask(file, ~(1 << trackToRead));
+	mkv_SetTrackMask(file, trackToRead);
 	auto trackInfo = mkv_GetTrackInfo(file, trackToRead);
 	std::string CodecID(trackInfo->CodecID);
 	bool srt = CodecID == "S_TEXT/UTF8";


### PR DESCRIPTION
## Summary

Fixes #532. The 32-track limit turned out to be deeper than "widen the bitmask":

- `MAX_TRACKS` (32) in `MatroskaParser.c` guards **registration** of tracks in `parseTrackEntry` — tracks past #32 are never read into `mf->Tracks` at all, so downstream code (including any bitmask) never even sees them. `mf->Tracks` already grows dynamically (`AGET`/`ArrayAlloc`, same pattern as `QBlocks`/`Cues`/`Attachments`), so `MAX_TRACKS` was never a structural requirement — it's now just a sanity ceiling (65536) against corrupt/malicious files, not a "hopefully big enough" guess.
- `trackMask` (and the two other bitmask-shaped internals it touches: `fillQueues`'s mask param and `mkv_Seek`'s own local per-track completion bitmask) is never used in this codebase to express an arbitrary multi-track combination — only "no filter" or "keep exactly one track". Replaced with a plain track index (`selectedTrack`, -1 = no filter), which removes the bit-width ceiling entirely instead of just moving it, and incidentally fixes `mkv_wrap.cpp`'s own latent UB (`1 << trackToRead` for `trackToRead >= 32`).
- The "Too many tracks." error already existed but was silently swallowed by a local `setjmp` recovery scope when tracks are parsed inline (the common path) — `mkv_OpenEx` would return success with a truncated track list and no indication anything was wrong. Added a sticky flag that survives that recovery so the error reaches the caller regardless of which internal path parsed the tracks.

Split into 5 commits (see individual messages for the reasoning behind each): 3 behavior-preserving refactors that make everything downstream tolerate an arbitrary track count, then the actual ceiling raise, then the error-surfacing fix — in that order so every commit compiles and none of them regress behavior on its own.

## Test plan

- [x] Read the code path in `MatroskaParser.c`/`mkv_wrap.cpp` end to end (see individual commit messages for the reasoning behind each of the 5 commits).
- [x] Built locally (meson/ninja) after every commit — each compiles clean on its own.
- [x] Manual GUI test: built this branch, opened Subtitle > Open Subtitles... on a synthetic 40-subtitle-track `.mkv` (generated with `ffmpeg`, same input stream mapped 40 times). The "Multiple subtitle tracks" dialog lists all 40 tracks (0-39); selecting track 39 (beyond the old 32-track limit) loads correctly with no corruption.
- [x] Manual GUI test with the real-world file attached to #661 (`40sub's.mkv`, a duplicate of this issue) — opens correctly with no errors.
- [x] Standalone harness linking `MatroskaParser.c` directly (bypassing the GUI), driven exactly like `mkv_wrap.cpp` does, against the same synthetic file: confirmed pre-fix (`master`) truncates to 32 tracks with no error, post-fix reads all 40 with the correct track selected and zero cross-track corruption; a normal 2-track file still works identically (no regression).