### PR TITLE
macOS: fix duplicate Window menu in translated UIs

### DIFF
--- a/src/libresrc/osx/default_menu.json
+++ b/src/libresrc/osx/default_menu.json
@@ -8,7 +8,7 @@
         { "submenu" : "main/video",    "tlcontext": "Menu bar", "text" : "&Video" },
         { "submenu" : "main/audio",    "tlcontext": "Menu bar", "text" : "&Audio" },
         { "special" : "automation",    "tlcontext": "Menu bar", "text" : "A&utomation" },
-        { "submenu" : "main/window",   "tlcontext": "Menu bar", "text" : "Window" },
+        { "submenu" : "main/window",   "tlcontext": "Menu bar", "text" : "Window", "special" : "window" },
         { "submenu" : "main/help",     "tlcontext": "Menu bar", "text" : "&Help", "special" : "help" }
     ],
     "main/file" : [

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -533,7 +533,17 @@ namespace menu {
 			read_entry(item, "text", &disp);
 			read_entry(item, "tlcontext", &context);
 			if (!submenu.empty()) {
-				menu->Append(build_menu(submenu, c, &menu->cm), wxGetTranslation(to_wx(disp), {}, to_wx(context)));
+				wxString tl_disp = wxGetTranslation(to_wx(disp), {}, to_wx(context));
+				menu->Append(build_menu(submenu, c, &menu->cm), tl_disp);
+#ifdef __WXMAC__
+				std::string special;
+				read_entry(item, "special", &special);
+				// wx finds the macOS Window menu by comparing menu titles, so it has to be
+				// given the translated one. Without this it fails to match a translated
+				// title and appends a second, untranslated "Window" menu of its own.
+				if (special == "window")
+					wxApp::s_macWindowMenuTitleName = tl_disp;
+#endif
 			}
 			else {
 				read_entry(item, "special", &submenu);


### PR DESCRIPTION
### Problem

On macOS, any non-English UI shows **two Window menus** in the menu bar — the app's own translated one plus an untranslated "Window" appended after Help. In a Turkish UI that reads `Pencere` … `Yardım` `Window`.

### Cause

`wxMenuBarCocoaImpl::MacCreateOrFindWindowMenu()` (`src/osx/cocoa/menu.mm`) locates the Window menu by comparing each top-level menu title against two strings:

- `wxStripMenuCodes(wxApp::s_macWindowMenuTitleName)`, and
- wx's own translation of `"Window"` in context `"macOS menu name"`.

Aegisub never sets `s_macWindowMenuTitleName`, so it keeps wx's default `"Window"`. wx's contextual translation is also `"Window"` unless a catalog supplies that exact msgctxt/msgid pair. A translated menubar title therefore matches neither, and wx falls through to the branch that allocates a fresh `NSMenu` titled `"Window"` and inserts it after the Help menu.

Aegisub already tells wx the translated **Help** title via `wxApp::s_macHelpMenuTitleName`; there is simply no equivalent for Window.

### Fix

Set `s_macWindowMenuTitleName` from the menubar entry's already-translated title while the menubar is built, and mark the macOS menubar's Window entry with `"special": "window"` so the loop can recognise it. wx then matches Aegisub's existing menu, creates nothing extra, and the title stays translated.

The title is assigned before `MacSetCommonMenuBar()`, so it is in place by the time wx installs the menubar.

### Testing

Reproduced on macOS 26 (arm64) with the UI language set to Turkish: two menus, `Pencere` and `Window`.

The matching behaviour was confirmed by driving wx's *other* match path — adding `msgctxt "macOS menu name" / msgid "Window" / msgstr "Pencere"` to the Turkish catalog makes wx recognise the existing menu, and the duplicate disappears while the title stays `Pencere`. This patch achieves the same match from the application side, so it works for every locale without requiring a catalog entry per language.

### Note, not addressed here

The menubar's `"special": "help"` marker appears to be dead: menubar entries are handled by the loop in `menu::GetMenuBar`, which reads `special` only in the `else` branch (when no `submenu` is present), while `s_macHelpMenuTitleName` is set in `process_menu_item`, which only ever sees entries *inside* a menu. Help detection currently works via wx's `_("&Help")` fallback. Left alone to keep this change focused.
