### PR TITLE
macOS: declare video and audio document types

### DIFF
--- a/packages/osx_bundle/Contents/Info.plist
+++ b/packages/osx_bundle/Contents/Info.plist
@@ -141,6 +141,71 @@
             <key>LSHandlerRank</key>
             <string>None</string>
 		</dict>
+
+        <!-- video files loadable by Project::LoadList -->
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>asf</string>
+				<string>avi</string>
+				<string>avs</string>
+				<string>d2v</string>
+				<string>h264</string>
+				<string>hevc</string>
+				<string>m2ts</string>
+				<string>m4v</string>
+				<string>mkv</string>
+				<string>mov</string>
+				<string>mp4</string>
+				<string>mpeg</string>
+				<string>mpg</string>
+				<string>ogm</string>
+				<string>rm</string>
+				<string>rmvb</string>
+				<string>ts</string>
+				<string>webm</string>
+				<string>wmv</string>
+				<string>y4m</string>
+				<string>yuv</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>Video file</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSTypeIsPackage</key>
+			<false/>
+            <key>LSHandlerRank</key>
+            <string>None</string>
+		</dict>
+
+        <!-- audio files loadable by Project::LoadList -->
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>aac</string>
+				<string>ac3</string>
+				<string>ape</string>
+				<string>dts</string>
+				<string>eac3</string>
+				<string>flac</string>
+				<string>m4a</string>
+				<string>mka</string>
+				<string>mp3</string>
+				<string>ogg</string>
+				<string>opus</string>
+				<string>w64</string>
+				<string>wav</string>
+				<string>wma</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>Audio file</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSTypeIsPackage</key>
+			<false/>
+            <key>LSHandlerRank</key>
+            <string>None</string>
+		</dict>
 	</array>
 
 </dict>


### PR DESCRIPTION
## Problem

On macOS, dragging a video file onto the Aegisub Dock icon is rejected — the icon never highlights and the drop bounces back. In Finder's **Open With** dialog, Aegisub is greyed out for video and audio files; selecting it requires switching the filter to *All Applications*, and macOS then records it as a per-file binding rather than learning the association, so it has to be repeated for every single file.

## Cause

This is purely a missing declaration — the application code already handles these files.

`Project::LoadList()` dispatches by extension into video, audio and subtitle loading, and `AegisubApp::MacOpenFiles()` routes the macOS `odoc` Apple Event straight into it:

```cpp
void AegisubApp::MacOpenFiles(wxArrayString const& filenames) { OpenFiles(filenames); }

void AegisubApp::OpenFiles(wxArrayStringsAdapter filenames) {
	...
	frames[0]->context->project->LoadList(files);
}
```

So any media path that reaches the app loads correctly — this is the same path used by drag-and-drop onto the Aegisub *window*, which works today. But `packages/osx_bundle/Contents/Info.plist` declares only `.ass`, `.ssa`, `.srt` and `.txt`, and LaunchServices decides drop acceptance from `CFBundleDocumentTypes`. Media files are therefore blocked before they ever reach `LoadList()`.

## Change

Declare the video and audio extension lists from `Project::LoadList()`, so the bundle advertises what the application can already load. Subtitle types are untouched.

## Why `LSHandlerRank` `None`

`None` means "never propose this app as a handler for the type" while still allowing the type to be dropped — existing default players (IINA, QuickTime, VLC) are entirely unaffected, and Aegisub does not appear as a suggested handler for anyone's video library. The `.txt` entry in this file already uses `None` for the same reason.

I verified that `None` is sufficient rather than assuming it, using `LSCanURLAcceptURL` (the acceptance check behind Dock drop highlighting), with minimal test bundles on macOS 15.6:

| declared type | accepts `.mkv` |
| --- | --- |
| `LSHandlerRank` `None` | ✅ true |
| `LSHandlerRank` `Alternate` | ✅ true |
| no media type declared (control) | ❌ false |

Against real bundles:

| bundle | `.mkv` | `.mp4` | `.wav` | `.flac` | `.ass` |
| --- | --- | --- | --- | --- | --- |
| current release build | ❌ | ❌ | ❌ | ❌ | ✅ |
| this patch | ✅ | ✅ | ✅ | ✅ | ✅ |

Subtitle handling is unchanged, and no default handler for any media type is altered.

## Notes

- `.sub` and `.ttxt` are also accepted by `LoadList()` but are deliberately left undeclared here — `.sub` in particular is ambiguous (VobSub vs. MicroDVD) and not reliably loadable, so declaring it would advertise more than Aegisub can deliver. Happy to add them if preferred.
- No code changes; single file, declaration only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
