### PR TITLE
Cross-build Intel macOS jobs on Apple Silicon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,12 +91,6 @@ jobs:
               -Ddav1d:enable_tools=false
               -Dzlib:tests=disabled
               --force-fallback-for=boost,wxWidgets,libass,zlib,freetype2,fribidi,harfbuzz,ffms2,libavformat,libavcodec,libswscale,libavutil,libswresample,dav1d,hunspell,uchardet,icu-uc,icu-i18n,libcurl
-          - name: macOS x86_64 Debug
-            os: macos-15
-            buildtype: debugoptimized
-            cross_args: --cross-file tools/macos-x86_64.ini
-            args: *macos_source_args
-            extra_args: -Dbuild_osx_bundle=false
           - name: macOS arm64 Debug
             os: macos-15
             buildtype: debugoptimized
@@ -156,14 +150,14 @@ jobs:
           popd
 
       - name: Install dependencies (macOS Debug)
-        if: startsWith(matrix.config.os, 'macos-') && matrix.config.buildtype == 'debugoptimized' && !matrix.config.cross_args
+        if: startsWith(matrix.config.os, 'macos-') && matrix.config.buildtype == 'debugoptimized'
         run: |
           brew install ninja pkg-config libass boost zlib ffms2 fftw hunspell uchardet icu4c wxwidgets
 
           echo "PKG_CONFIG_PATH=$(brew --prefix icu4c)/lib/pkgconfig:$(brew --prefix zlib)/lib/pkgconfig" >> "${GITHUB_ENV}"
 
       - name: Install build tools (macOS source dependencies)
-        if: startsWith(matrix.config.os, 'macos-') && (matrix.config.buildtype == 'release' || matrix.config.cross_args)
+        if: startsWith(matrix.config.os, 'macos-') && matrix.config.buildtype == 'release'
         run: |
           brew install ninja nasm
 
@@ -204,10 +198,10 @@ jobs:
       - name: Configure
         run: |
           ${{ matrix.config.devenv }}
-          meson setup build ${{ matrix.config.cross_args }} ${{ matrix.config.args }} ${{ matrix.config.extra_args }} -Dbuildtype=${{ matrix.config.buildtype }} ${{ github.ref_type == 'tag' && '-Dofficial_release=true' || '' }}
+          meson setup build ${{ matrix.config.cross_args }} ${{ matrix.config.args }} -Dbuildtype=${{ matrix.config.buildtype }} ${{ github.ref_type == 'tag' && '-Dofficial_release=true' || '' }}
 
       - name: Build FFTW (MacOS)
-        if: startsWith(matrix.config.os, 'macos-') && (matrix.config.buildtype == 'release' || matrix.config.cross_args)
+        if: startsWith(matrix.config.os, 'macos-') && matrix.config.buildtype == 'release'
         run: |
           tools/macos-build-fftw.sh build
           meson setup --reconfigure --clearcache build \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           }
           - name: macOS x86_64 Release
             os: macos-15
-            cross_args: --cross-file tools/macos-x86_64.ini
+            cross_args: --cross-file tools/macos-release.ini --cross-file tools/macos-x86_64.ini
             buildtype: release
             args: &macos_source_args >-
               -Ddefault_library=static
@@ -102,6 +102,7 @@ jobs:
               -Dopenal=enabled
           - name: macOS arm64 Release
             os: macos-15
+            native_args: --native-file tools/macos-release.ini
             buildtype: release
             args: *macos_source_args
 
@@ -198,7 +199,7 @@ jobs:
       - name: Configure
         run: |
           ${{ matrix.config.devenv }}
-          meson setup build ${{ matrix.config.cross_args }} ${{ matrix.config.args }} -Dbuildtype=${{ matrix.config.buildtype }} ${{ github.ref_type == 'tag' && '-Dofficial_release=true' || '' }}
+          meson setup build ${{ matrix.config.native_args }} ${{ matrix.config.cross_args }} ${{ matrix.config.args }} -Dbuildtype=${{ matrix.config.buildtype }} ${{ github.ref_type == 'tag' && '-Dofficial_release=true' || '' }}
 
       - name: Build FFTW (MacOS)
         if: startsWith(matrix.config.os, 'macos-') && matrix.config.buildtype == 'release'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,19 +59,11 @@ jobs:
             buildtype: release,
             args: -Db_pch=false
           }
-          - name: macOS x86_64 Debug
-            os: macos-15-intel
-            buildtype: debugoptimized
-            args: &macos_debug_args >-
-              -Dmacos_deployment_target=15.0
-              -Dbuild_osx_bundle=false
-              -Dfftw3=enabled
-              -Dlibpulse=disabled
-              -Dopenal=enabled
           - name: macOS x86_64 Release
-            os: macos-15-intel
+            os: macos-15
+            cross_args: --cross-file tools/macos-x86_64.ini
             buildtype: release
-            args: &macos_release_args >-
+            args: &macos_source_args >-
               -Ddefault_library=static
               -Dbuild_osx_bundle=true
               -Dfftw3=disabled
@@ -99,14 +91,25 @@ jobs:
               -Ddav1d:enable_tools=false
               -Dzlib:tests=disabled
               --force-fallback-for=boost,wxWidgets,libass,zlib,freetype2,fribidi,harfbuzz,ffms2,libavformat,libavcodec,libswscale,libavutil,libswresample,dav1d,hunspell,uchardet,icu-uc,icu-i18n,libcurl
+          - name: macOS x86_64 Debug
+            os: macos-15
+            buildtype: debugoptimized
+            cross_args: --cross-file tools/macos-x86_64.ini
+            args: *macos_source_args
+            extra_args: -Dbuild_osx_bundle=false
           - name: macOS arm64 Debug
             os: macos-15
             buildtype: debugoptimized
-            args: *macos_debug_args
+            args: >-
+              -Dmacos_deployment_target=15.0
+              -Dbuild_osx_bundle=false
+              -Dfftw3=enabled
+              -Dlibpulse=disabled
+              -Dopenal=enabled
           - name: macOS arm64 Release
             os: macos-15
             buildtype: release
-            args: *macos_release_args
+            args: *macos_source_args
 
     steps:
       - uses: actions/checkout@v6
@@ -153,23 +156,40 @@ jobs:
           popd
 
       - name: Install dependencies (macOS Debug)
-        if: startsWith(matrix.config.os, 'macos-') && matrix.config.buildtype == 'debugoptimized'
+        if: startsWith(matrix.config.os, 'macos-') && matrix.config.buildtype == 'debugoptimized' && !matrix.config.cross_args
         run: |
           brew install ninja pkg-config libass boost zlib ffms2 fftw hunspell uchardet icu4c wxwidgets
 
           echo "PKG_CONFIG_PATH=$(brew --prefix icu4c)/lib/pkgconfig:$(brew --prefix zlib)/lib/pkgconfig" >> "${GITHUB_ENV}"
 
-      - name: Install dependencies (macOS Release)
-        if: startsWith(matrix.config.os, 'macos-') && matrix.config.buildtype == 'release'
+      - name: Install build tools (macOS source dependencies)
+        if: startsWith(matrix.config.os, 'macos-') && (matrix.config.buildtype == 'release' || matrix.config.cross_args)
         run: |
           brew install ninja nasm
 
+      - name: Check Rosetta (macOS cross builds)
+        if: matrix.config.cross_args
+        run: |
+          if ! /usr/bin/arch -x86_64 /usr/bin/true; then
+            sudo softwareupdate --install-rosetta --agree-to-license
+          fi
+          /usr/bin/arch -x86_64 /usr/bin/true
+
       - name: Install test dependencies (macOS)
         if: startsWith(matrix.config.os, 'macos-')
+        env:
+          CROSS_ARGS: ${{ matrix.config.cross_args }}
         run: |
           # LuaJIT is Lua 5.1 to luarocks.
           brew install luajit luarocks
-          luarocks --lua-dir="$(brew --prefix luajit)" --lua-version=5.1 install busted
+          if test -n "${CROSS_ARGS}"; then
+            # Busted's native modules are loaded by the Intel test executable.
+            luarocks --lua-dir="$(brew --prefix luajit)" --lua-version=5.1 install busted \
+              CC='/usr/bin/clang -arch x86_64' \
+              LD='/usr/bin/clang -arch x86_64'
+          else
+            luarocks --lua-dir="$(brew --prefix luajit)" --lua-version=5.1 install busted
+          fi
 
       - name: Install dependencies (Linux)
         if: startsWith(matrix.config.os, 'ubuntu-')
@@ -184,10 +204,10 @@ jobs:
       - name: Configure
         run: |
           ${{ matrix.config.devenv }}
-          meson setup build ${{ matrix.config.args }} -Dbuildtype=${{ matrix.config.buildtype }} ${{ github.ref_type == 'tag' && '-Dofficial_release=true' || '' }}
+          meson setup build ${{ matrix.config.cross_args }} ${{ matrix.config.args }} ${{ matrix.config.extra_args }} -Dbuildtype=${{ matrix.config.buildtype }} ${{ github.ref_type == 'tag' && '-Dofficial_release=true' || '' }}
 
       - name: Build FFTW (MacOS)
-        if: startsWith(matrix.config.os, 'macos-') && matrix.config.buildtype == 'release'
+        if: startsWith(matrix.config.os, 'macos-') && (matrix.config.buildtype == 'release' || matrix.config.cross_args)
         run: |
           tools/macos-build-fftw.sh build
           meson setup --reconfigure --clearcache build \
@@ -198,6 +218,14 @@ jobs:
         run: |
           ${{ matrix.config.devenv }}
           meson compile -C build
+
+      - name: Verify Intel cross-build architecture
+        if: matrix.config.cross_args
+        run: |
+          test "$(lipo -archs build/aegisub)" = x86_64
+          test "$(lipo -archs build/tests/gtest-main)" = x86_64
+          test "$(lipo -archs build/tests/luajit-52)" = x86_64
+          test "$(lipo -archs build/automation/tests/aegisub-lua)" = x86_64
 
       # The automation suite is registered at configure time only if the
       # busted probe succeeds, so make sure it can't silently drop out of CI
@@ -210,6 +238,18 @@ jobs:
         run: |
           ${{ matrix.config.devenv }}
           meson test -C build --verbose --suite Aegisub
+
+      - name: Check cross-built tests executed
+        if: matrix.config.cross_args
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          results = [json.loads(line) for line in Path('build/meson-logs/testlog.json').read_text().splitlines()]
+          if not results or any(result['result'] != 'OK' for result in results):
+              raise SystemExit('Cross-built tests must pass under Rosetta, not be skipped')
+          PY
 
       # Windows artifacts
       - name: Generate Windows installer

--- a/docs/developer_docs.md
+++ b/docs/developer_docs.md
@@ -112,22 +112,25 @@ DMG is created.
 ## Intel macOS cross builds
 
 The Intel Release CI lane uses an Apple Silicon runner with
-`--cross-file tools/macos-x86_64.ini`. Compilation uses native Apple Silicon
-tools targeting x86_64; Rosetta runs the resulting Intel test executables.
+`--cross-file tools/macos-release.ini --cross-file tools/macos-x86_64.ini`.
+Compilation uses native Apple Silicon tools targeting x86_64; Rosetta runs
+the resulting Intel test executables.
 This checks the Intel code path, but does not replace testing a release on
 real Intel hardware.
 
 The Intel lane builds its target dependencies from source using the shared
-macOS release dependency options in `.github/workflows/ci.yml`. Homebrew is
-used for build tools, not target libraries: Apple Silicon bottles cannot be
-linked into an Intel executable. The native arm64 Debug lane still uses
+macOS release dependency options in `.github/workflows/ci.yml`. Both Release
+lanes use `tools/macos-release.ini` to restrict pkg-config and CMake dependency
+discovery away from Homebrew; arm64 loads it with `--native-file`. Homebrew is
+still used for build tools. The native arm64 Debug lane still uses
 Homebrew libraries and is tested but not packaged. Intel coverage comes from
 the Release lane, including tests under Rosetta.
 
-For a local cross build, use the same dependency options and cross file as CI.
+For a local cross build, use the same dependency options and cross files as CI.
 After Meson setup, run `tools/macos-build-fftw.sh BUILD_DIR`, then reconfigure
 with `-Dpkg_config_path="$PWD/BUILD_DIR/fftw-prefix/lib/pkgconfig"`
-and `-Dfftw3=enabled`. The bootstrap reads the target architecture from Meson.
+and `-Dfftw3=enabled`. The bootstrap reads the target architecture from Meson
+and only passes Autoconf's `--host` option when it differs from the build CPU.
 Automation tests also need Intel builds of Busted's native Lua modules; the
 workflow shows the LuaRocks compiler overrides. Use a separate LuaRocks tree
 if native arm64 tests need to run on the same machine.

--- a/docs/developer_docs.md
+++ b/docs/developer_docs.md
@@ -109,6 +109,28 @@ the notary service and stapled. This follows Apple's nested-container guidance;
 the app and every nested Mach-O file are still Developer ID-signed before the
 DMG is created.
 
+## Intel macOS cross builds
+
+The Intel CI lanes use Apple Silicon runners with
+`--cross-file tools/macos-x86_64.ini`. Compilation uses native Apple Silicon
+tools targeting x86_64; Rosetta runs the resulting Intel test executables.
+This checks the Intel code path, but does not replace testing a release on
+real Intel hardware.
+
+Both Intel lanes build their target dependencies from source using the shared
+macOS release dependency options in `.github/workflows/ci.yml`. Homebrew is
+used for build tools, not target libraries: Apple Silicon bottles cannot be
+linked into an Intel executable. The native arm64 Debug lane still uses
+Homebrew libraries. Intel Debug builds are tested but not packaged.
+
+For a local cross build, use the same dependency options and cross file as CI.
+After Meson setup, run `tools/macos-build-fftw.sh BUILD_DIR`, then reconfigure
+with `-Dpkg_config_path="$PWD/BUILD_DIR/fftw-prefix/lib/pkgconfig"`
+and `-Dfftw3=enabled`. The bootstrap reads the target architecture from Meson.
+Automation tests also need Intel builds of Busted's native Lua modules; the
+workflow shows the LuaRocks compiler overrides. Use a separate LuaRocks tree
+if native arm64 tests need to run on the same machine.
+
 ## Running Doxygen
 
 You can run Doxygen with the following command:

--- a/docs/developer_docs.md
+++ b/docs/developer_docs.md
@@ -111,17 +111,18 @@ DMG is created.
 
 ## Intel macOS cross builds
 
-The Intel CI lanes use Apple Silicon runners with
+The Intel Release CI lane uses an Apple Silicon runner with
 `--cross-file tools/macos-x86_64.ini`. Compilation uses native Apple Silicon
 tools targeting x86_64; Rosetta runs the resulting Intel test executables.
 This checks the Intel code path, but does not replace testing a release on
 real Intel hardware.
 
-Both Intel lanes build their target dependencies from source using the shared
+The Intel lane builds its target dependencies from source using the shared
 macOS release dependency options in `.github/workflows/ci.yml`. Homebrew is
 used for build tools, not target libraries: Apple Silicon bottles cannot be
 linked into an Intel executable. The native arm64 Debug lane still uses
-Homebrew libraries. Intel Debug builds are tested but not packaged.
+Homebrew libraries and is tested but not packaged. Intel coverage comes from
+the Release lane, including tests under Rosetta.
 
 For a local cross build, use the same dependency options and cross file as CI.
 After Meson setup, run `tools/macos-build-fftw.sh BUILD_DIR`, then reconfigure

--- a/tools/macos-build-fftw.sh
+++ b/tools/macos-build-fftw.sh
@@ -38,7 +38,8 @@ if machine["system"] != "darwin":
     raise SystemExit("FFTW macOS bootstrap requires a Darwin host")
 print({"aarch64": "arm64", "x86_64": "x86_64"}.get(machine["cpu_family"], machine["cpu_family"]))
 ')"
-EXPECTED_STAMP="fftw=${FFTW_VERSION} arch=${ARCH} macos=${DEPLOYMENT_TARGET}"
+BUILD_ARCH="$(uname -m)"
+EXPECTED_STAMP="fftw=${FFTW_VERSION} arch=${ARCH} build=${BUILD_ARCH} macos=${DEPLOYMENT_TARGET}"
 
 if test -f "${FFTW_STAMP}" && test "$(cat "${FFTW_STAMP}")" = "${EXPECTED_STAMP}"; then
     echo "Using existing FFTW build: ${EXPECTED_STAMP}"
@@ -74,11 +75,15 @@ export CC=/usr/bin/clang
 export CFLAGS="-O3 -arch ${ARCH} -mmacosx-version-min=${DEPLOYMENT_TARGET}"
 export LDFLAGS="-arch ${ARCH} -mmacosx-version-min=${DEPLOYMENT_TARGET}"
 
+# Keep runtime probes enabled for native builds.
+set -- "--build=$(./config.guess)"
+if test "${ARCH}" != "${BUILD_ARCH}"; then
+    set -- "$@" "--host=${ARCH}-apple-darwin"
+fi
+
 # Aegisub only uses FFTW's single-threaded, double-precision API.
 # shellcheck disable=SC2086
-./configure \
-    --build="$(./config.guess)" \
-    --host="${ARCH}-apple-darwin" \
+./configure "$@" \
     --prefix="${FFTW_PREFIX}" \
     --disable-shared \
     --enable-static \

--- a/tools/macos-build-fftw.sh
+++ b/tools/macos-build-fftw.sh
@@ -29,7 +29,15 @@ FFTW_SHA256="5630c24cdeb33b131612f7eb4b1a9934234754f9f388ff8617458d0be6f239a1"
 FFTW_URL="https://fftw.org/fftw-${FFTW_VERSION}.tar.gz"
 FFTW_PREFIX="${BUILD_DIR}/fftw-prefix"
 FFTW_STAMP="${FFTW_PREFIX}/.aegisub-build"
-ARCH="$(uname -m)"
+ARCH="$(meson introspect --machines "${BUILD_DIR}" | python3 -c '
+import json
+import sys
+
+machine = json.load(sys.stdin)["host"]
+if machine["system"] != "darwin":
+    raise SystemExit("FFTW macOS bootstrap requires a Darwin host")
+print({"aarch64": "arm64", "x86_64": "x86_64"}.get(machine["cpu_family"], machine["cpu_family"]))
+')"
 EXPECTED_STAMP="fftw=${FFTW_VERSION} arch=${ARCH} macos=${DEPLOYMENT_TARGET}"
 
 if test -f "${FFTW_STAMP}" && test "$(cat "${FFTW_STAMP}")" = "${EXPECTED_STAMP}"; then
@@ -62,12 +70,15 @@ rm -rf "${FFTW_PREFIX}"
 mkdir -p "${FFTW_PREFIX}"
 
 cd "${WORK_DIR}/fftw-${FFTW_VERSION}"
-export CFLAGS="-O3 -mmacosx-version-min=${DEPLOYMENT_TARGET}"
-export LDFLAGS="-mmacosx-version-min=${DEPLOYMENT_TARGET}"
+export CC=/usr/bin/clang
+export CFLAGS="-O3 -arch ${ARCH} -mmacosx-version-min=${DEPLOYMENT_TARGET}"
+export LDFLAGS="-arch ${ARCH} -mmacosx-version-min=${DEPLOYMENT_TARGET}"
 
 # Aegisub only uses FFTW's single-threaded, double-precision API.
 # shellcheck disable=SC2086
 ./configure \
+    --build="$(./config.guess)" \
+    --host="${ARCH}-apple-darwin" \
     --prefix="${FFTW_PREFIX}" \
     --disable-shared \
     --enable-static \
@@ -80,6 +91,10 @@ export LDFLAGS="-mmacosx-version-min=${DEPLOYMENT_TARGET}"
 
 make -s -j"$(sysctl -n hw.logicalcpu)"
 make -s install
+if test "$(lipo -archs "${FFTW_PREFIX}/lib/libfftw3.a")" != "${ARCH}"; then
+    echo "FFTW library architecture does not match Meson's host: ${ARCH}" >&2
+    exit 1
+fi
 printf '%s\n' "${EXPECTED_STAMP}" > "${FFTW_STAMP}"
 
 echo "Built FFTW ${FFTW_VERSION} for macOS ${DEPLOYMENT_TARGET} (${ARCH})"

--- a/tools/macos-release.ini
+++ b/tools/macos-release.ini
@@ -1,0 +1,9 @@
+# Use Homebrew build tools, but exclude its target libraries from discovery.
+[properties]
+pkg_config_libdir = ['/usr/lib/pkgconfig']
+
+[built-in options]
+pkg_config_path = []
+
+[cmake]
+CMAKE_IGNORE_PREFIX_PATH = ['/opt/homebrew', '/usr/local']

--- a/tools/macos-x86_64.ini
+++ b/tools/macos-x86_64.ini
@@ -1,0 +1,29 @@
+# Build Intel binaries with native Apple Silicon tools; run tests via Rosetta.
+[binaries]
+c = ['/usr/bin/clang', '-arch', 'x86_64']
+cpp = ['/usr/bin/clang++', '-arch', 'x86_64']
+objc = ['/usr/bin/clang', '-arch', 'x86_64']
+objcpp = ['/usr/bin/clang++', '-arch', 'x86_64']
+ar = '/usr/bin/ar'
+strip = '/usr/bin/strip'
+pkg-config = 'pkg-config'
+cmake = 'cmake'
+exe_wrapper = ['/usr/bin/arch', '-x86_64']
+
+[host_machine]
+system = 'darwin'
+cpu_family = 'x86_64'
+cpu = 'x86_64'
+endian = 'little'
+
+[properties]
+needs_exe_wrapper = true
+# Never discover Apple Silicon Homebrew libraries as target dependencies.
+pkg_config_libdir = ['/usr/lib/pkgconfig']
+
+[built-in options]
+pkg_config_path = []
+
+[cmake]
+CMAKE_OSX_ARCHITECTURES = 'x86_64'
+CMAKE_IGNORE_PREFIX_PATH = ['/opt/homebrew', '/usr/local']

--- a/tools/macos-x86_64.ini
+++ b/tools/macos-x86_64.ini
@@ -1,4 +1,5 @@
 # Build Intel binaries with native Apple Silicon tools; run tests via Rosetta.
+# Combine with macos-release.ini for target dependency search paths.
 [binaries]
 c = ['/usr/bin/clang', '-arch', 'x86_64']
 cpp = ['/usr/bin/clang++', '-arch', 'x86_64']
@@ -18,12 +19,6 @@ endian = 'little'
 
 [properties]
 needs_exe_wrapper = true
-# Never discover Apple Silicon Homebrew libraries as target dependencies.
-pkg_config_libdir = ['/usr/lib/pkgconfig']
-
-[built-in options]
-pkg_config_path = []
 
 [cmake]
 CMAKE_OSX_ARCHITECTURES = 'x86_64'
-CMAKE_IGNORE_PREFIX_PATH = ['/opt/homebrew', '/usr/local']


### PR DESCRIPTION
## Summary

Draft for consideration after 3.5.0; not intended to block or join that release.

- Move Intel macOS Release to an Apple Silicon runner using an x86_64 Meson cross file, and drop the Intel Debug lane.
- Build Release target dependencies from source and exclude Homebrew target-library discovery. Keep native arm64 Debug on Homebrew without packaging, and retain native arm64 Release.
- Make the FFTW bootstrap use the Meson target architecture, and build native Busted modules for Intel test executables.
- Run Intel tests through Rosetta, verify executable architectures, and fail if tests are skipped.
- Document the cross-build setup and testing limitations.

## Validation

Locally on Apple Silicon:

- Release and debugoptimized builds succeeded with FFTW enabled.
- Both configurations passed all three Aegisub test groups under Rosetta: 367 C++ tests, the Lua compatibility test, and 95 Automation tests.
- The release app passed the macOS 13.0 deployment-target check and ad-hoc signature verification.
- DMG creation and checksum verification passed, with the expected x64 artifact name.
- Workflow structure validation, shell syntax checks, ShellCheck for the FFTW script, and git diff --check passed. Full actionlint reports only pre-existing diagnostics from interpreting Windows PowerShell steps as shell.

All four macOS lanes passed the [initial hosted CI run](https://github.com/TypesettingTools/Aegisub/actions/runs/33942847455), including Intel architecture checks, Rosetta tests, and Release DMG uploads. Intel Release finished in 26m25s. Intel Debug has since been removed; the reduced six-job matrix passes local workflow validation and awaits its updated CI results. Testing on real Intel hardware remains outstanding; Rosetta testing does not replace a real Intel release smoke test.

## Review follow-up

- Keep FFTW runtime probes enabled on native builds by passing `--host` only when the build and target CPUs differ. Include the build CPU in the local stamp to invalidate prior configurations.
- Share pkg-config and CMake dependency-search restrictions through `tools/macos-release.ini`: a native file for arm64 Release and part of the composed Intel cross files. arm64 Debug is unchanged.
- Locally validated a fresh native arm64 Release build, all three Aegisub test groups, bundling, the macOS 13.0 deployment target, and ad-hoc signature verification.
- Validated fresh Intel configuration/reconfiguration, source FFTW selection, both FFTW archive architectures, and a transform smoke test against each library (Intel under Rosetta). Native configure reports cross-compiling=no and working strtod=yes; Intel retains explicit cross-compilation mode.
- Neither Release configuration has Homebrew paths in its dependency compile/link arguments. ShellCheck, workflow structure validation, and git diff --check passed. Full hosted CI for this follow-up is pending.
